### PR TITLE
Add learning path to deploy Redis on Arm

### DIFF
--- a/content/learning-paths/server-and-cloud/redis/_index.md
+++ b/content/learning-paths/server-and-cloud/redis/_index.md
@@ -1,9 +1,9 @@
 ---
-title: Deploying Redis on Arm
+title: Deploy Redis on Arm
 
 minutes_to_complete: 60   
 
-who_is_this_for: This is an advanced topic for anyone who wants to deploy Redis.
+who_is_this_for: This is an advanced topic for developers who want to deploy Redis on Arm based virtual machines.
 
 learning_objectives: 
     - Understand Redis deployment configurations
@@ -16,12 +16,12 @@ learning_objectives:
 prerequisites:
     - An Amazon Web Services (AWS) [account](https://aws.amazon.com/)
     - An Azure portal [account](https://azure.microsoft.com/en-in/get-started/azure-portal)
-    - A Google Cloud [account](https://console.cloud.google.com/?hl=en-au)
-    - A machine with [Terraform](/install-tools/terraform/), [AWS CLI](/install-tools/aws-cli), [Google Cloud CLI](/install-tools/gcloud), [Azure CLI](/install-tools/azure-cli), [AWS IAM authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html), and [Ansible](/install-tools/ansible/) installed
+    - A Google Cloud [account](https://console.cloud.google.com/)
+    - A machine with [Terraform](/install-guides/terraform/), [AWS CLI](/install-guides/aws-cli), [Google Cloud CLI](/install-guides/gcloud), [Azure CLI](/install-guides/azure-cli), [AWS IAM authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html), and [Ansible](/install-guides/ansible/) installed
 
 author_primary: Jason Andrews
 ### Tags
-skilllevels: Introductory
+skilllevels: Advanced
 subjects: Databases
 armips:
     - Neoverse

--- a/content/learning-paths/server-and-cloud/redis/_index.md
+++ b/content/learning-paths/server-and-cloud/redis/_index.md
@@ -1,0 +1,40 @@
+---
+title: Deploying Redis on Arm
+
+minutes_to_complete: 60   
+
+who_is_this_for: This is an advanced topic for anyone who wants to deploy Redis.
+
+learning_objectives: 
+    - Understand Redis deployment configurations
+    - Install Redis on a single AWS Arm based instance
+    - Install Redis on a single Azure Arm based instance
+    - Install Redis on a single GCP Arm based instance
+    - Install Redis with a docker container on a single node
+    - Install Redis in a multi-node configuration (sharding)
+
+prerequisites:
+    - An Amazon Web Services (AWS) [account](https://aws.amazon.com/)
+    - An Azure portal [account](https://azure.microsoft.com/en-in/get-started/azure-portal)
+    - A Google Cloud [account](https://console.cloud.google.com/?hl=en-au)
+    - A machine with [Terraform](/install-tools/terraform/), [AWS CLI](/install-tools/aws-cli), [Google Cloud CLI](/install-tools/gcloud), [Azure CLI](/install-tools/azure-cli), [AWS IAM authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html), and [Ansible](/install-tools/ansible/) installed
+
+author_primary: Jason Andrews
+### Tags
+skilllevels: Introductory
+subjects: Databases
+armips:
+    - Neoverse
+operatingsystems:
+    - Linux
+tools_software_languages:
+    - Terraform
+    - Ansible
+
+### FIXED, DO NOT MODIFY
+# ================================================================================
+weight: 1                       # _index.md always has weight of 1 to order correctly
+layout: "learningpathall"       # All files under learning paths have this same wrapper
+learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
+---
+

--- a/content/learning-paths/server-and-cloud/redis/_next-steps.md
+++ b/content/learning-paths/server-and-cloud/redis/_next-steps.md
@@ -4,10 +4,10 @@
 # ================================================================================
 
 next_step_guidance: >
-    We recommend you continue learning about Redis.
+    If you are interested in running other databases on Arm, like MongoDB continue on to the recommended learning path.
 # 1-3 sentence recommendation outlining how the reader can generally keep learning about these topics, and a specific explanation of why the next step is being recommended.
 
-recommended_path: "/learning-paths/server-and-cloud/redis/"
+recommended_path: "/learning-paths/server-and-cloud/mongodb/"
 # Link to the next learning path being recommended(For example this could be /learning-paths/server-and-cloud/mongodb).
 
 

--- a/content/learning-paths/server-and-cloud/redis/_next-steps.md
+++ b/content/learning-paths/server-and-cloud/redis/_next-steps.md
@@ -1,0 +1,33 @@
+---
+# ================================================================================
+#       Edit
+# ================================================================================
+
+next_step_guidance: >
+    We recommend you continue learning about Redis.
+# 1-3 sentence recommendation outlining how the reader can generally keep learning about these topics, and a specific explanation of why the next step is being recommended.
+
+recommended_path: "/learning-paths/server-and-cloud/redis/"
+# Link to the next learning path being recommended(For example this could be /learning-paths/server-and-cloud/mongodb).
+
+
+# further_reading links to references related to this path. Can be:
+    # Manuals for a tool / software mentioned   (type: documentation)
+    # Blog about related topics                 (type: blog)
+    # General online references                 (type: website) 
+
+further_reading:
+    - resource:
+        title: Redis documentation
+        link: https://redis.io/docs/
+        type: documentation
+
+
+# ================================================================================
+#       FIXED, DO NOT MODIFY
+# ================================================================================
+weight: 21                  # set to always be larger than the content in this path, and one more than 'review'
+title: "Next Steps"         # Always the same
+layout: "learningpathall"   # All files under learning paths have this same wrapper
+---
+

--- a/content/learning-paths/server-and-cloud/redis/_review.md
+++ b/content/learning-paths/server-and-cloud/redis/_review.md
@@ -1,0 +1,61 @@
+---
+# ================================================================================
+#       Edit
+# ================================================================================
+
+# Always 3 questions. Should try to test the reader's knowledge, and reinforce the key points you want them to remember.
+    # question:         A one sentence question
+    # answers:          The correct answers (from 2-4 answer options only). Should be surrounded by quotes.
+    # correct_answer:   An integer indicating what answer is correct (index starts from 0)
+    # explanation:      A short (1-3 sentence) explanation of why the correct answer is correct. Can add aditional context if desired
+
+
+review:
+    - questions:
+        question: >
+            Redis runs at port 6000 by default.
+        answers:
+            - "True"
+            - "False"
+        correct_answer: 2                     
+        explanation: >        
+            Redis runs at port 6379 by default.
+
+    - questions:
+        question: >
+            Redis is written in Java.
+        answers:
+            - "True"
+            - "False"
+        correct_answer: 2                     
+        explanation: >
+            Redis is written in ANSI C.
+               
+    - questions:
+        question: >
+            There are 6000 hash slots in Redis Cluster.
+        answers:
+            - "True"
+            - "False"
+        correct_answer: 2                     
+        explanation: >
+            There are 16384 hash slots in Redis Cluster.
+            
+    - questions:
+        question: >
+            Redis Cluster requires minimum 6 primary nodes to work properly. 
+        answers:
+            - "True"
+            - "False"
+        correct_answer: 2                     
+        explanation: >
+            Redis Cluster requires minimum 3 primary nodes to work properly.
+
+# ================================================================================
+#       FIXED, DO NOT MODIFY
+# ================================================================================
+title: "Review"                 # Always the same title
+weight: 20                      # Set to always be larger than the content in this path
+layout: "learningpathall"       # All files under learning paths have this same wrapper
+---
+

--- a/content/learning-paths/server-and-cloud/redis/aws_deployment.md
+++ b/content/learning-paths/server-and-cloud/redis/aws_deployment.md
@@ -12,7 +12,7 @@ layout: "learningpathall"
 
 You can deploy Redis on AWS Graviton processors using Terraform and Ansible. 
 
-In this topic, you will deploy Redis on a single AWS EC2 instance, and in the next topic you will deploy Redis on a single Azure instance. 
+In this section, you will deploy Redis on a single AWS EC2 instance.
 
 If you are new to Terraform, you should look at [Automate AWS EC2 instance creation using Terraform](/learning-paths/server-and-cloud/aws/terraform/) before starting this Learning Path.
 
@@ -48,9 +48,7 @@ You should now have your AWS access keys and your SSH keys in the current direct
 
 ## Create an AWS EC2 instance using Terraform
 
-Using a text editor, save the code below in a file called `main.tf`.
-
-Scroll down to see the information you need to change in `main.tf`.
+Using a text editor, save the code below in a file called `main.tf`:
 
 ```console
 provider "aws" {
@@ -140,7 +138,7 @@ terraform init
     
 The output should be similar to:
 
-```console
+```output
 Initializing the backend...
 
 Initializing provider plugins...
@@ -189,7 +187,7 @@ Answer `yes` to the prompt to confirm you want to create AWS resources.
 
 The public IP address will be different, but the output should be similar to:
 
-```console
+```output
 Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
 
 Outputs:
@@ -245,7 +243,7 @@ Using a text editor, save the code below to in a file called `playbook.yaml`. Th
       shell: redis-cli -p 6379 CONFIG SET requirepass "{password}"
       become_user: ubuntu
 ```
-Replace `{password}` with your value.
+Replace `{password}` in this file with your value.
 
 ### Ansible Commands
 
@@ -261,7 +259,7 @@ Deployment may take a few minutes.
 
 The output should be similar to:
 
-```console
+```output
 PLAY [all] *****************************************************************************************************************************************************
 
 TASK [Gathering Facts] *****************************************************************************************************************************************
@@ -305,11 +303,11 @@ apt install redis-tools
 redis-cli -h <public-IP-address> -p 6379
 ```
 The output will be:
-```console
+```output
 ubuntu@ip-172-31-38-39:~$ redis-cli -h 172.31.30.40 -p 6379
 172.31.30.40:6379> 
 ```
-3. Authorize Redis with the password set by us in playbook.yaml file.
+3. Authorize Redis with the password set by us in `playbook.yaml` file.
 ```console
 172.31.30.40:6379> ping
 (error) NOAUTH Authentication required.

--- a/content/learning-paths/server-and-cloud/redis/aws_deployment.md
+++ b/content/learning-paths/server-and-cloud/redis/aws_deployment.md
@@ -1,0 +1,340 @@
+---
+# User change
+title: "Install Redis on a single AWS Arm based instance"
+
+weight: 3 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Install Redis on a single AWS Arm based instance 
+
+You can deploy Redis on AWS Graviton processors using Terraform and Ansible. 
+
+In this topic, you will deploy Redis on a single AWS EC2 instance, and in the next topic you will deploy Redis on a single Azure instance. 
+
+If you are new to Terraform, you should look at [Automate AWS EC2 instance creation using Terraform](/learning-paths/server-and-cloud/aws/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need an [AWS account](https://portal.aws.amazon.com/billing/signup?nc2=h_ct&src=default&redirect_url=https%3A%2F%2Faws.amazon.com%2Fregistration-confirmation#/start) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin you will also need:
+- An AWS access key ID and secret access key
+- An SSH key pair
+
+The instructions to create the keys are below.
+
+### Generate AWS access keys 
+
+Terraform requires AWS authentication to create AWS resources. You can generate access keys (access key ID and secret access key) to perform authentication. Terraform uses the access keys to make calls to AWS using the AWS CLI. 
+
+To generate an access key and secret access key, follow the [steps from the Terraform Learning Path](/learning-paths/server-and-cloud/aws/terraform#generate-access-keys-access-key-id-and-secret-access-key).
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for AWS EC2 access. 
+
+```console
+ssh-keygen -f aws_key -t rsa -b 2048 -P ""
+```
+
+You should now have your AWS access keys and your SSH keys in the current directory.
+
+## Create an AWS EC2 instance using Terraform
+
+Using a text editor, save the code below in a file called `main.tf`.
+
+Scroll down to see the information you need to change in `main.tf`.
+
+```console
+provider "aws" {
+  region = "us-east-2"
+  access_key  = "AXXXXXXXXXXXXXXXXXXX"
+  secret_key   = "AAXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}
+resource "aws_instance" "redis-deployment" {
+  ami = "ami-0ca2eafa23bc3dd01"
+  instance_type = "t4g.small"
+  key_name= "aws_key"
+  vpc_security_group_ids = [aws_security_group.main.id]
+}
+
+resource "aws_security_group" "main" {
+  name        = "main"
+  description = "Allow TLS inbound traffic"
+
+  ingress {
+    description      = "Open redis connection port"
+    from_port        = 6379
+    to_port          = 6379
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+  ingress {
+    description      = "Allow ssh to instance"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+}
+
+output "Master_public_IP" {
+  value = [aws_instance.redis-deployment.public_ip]
+}
+
+resource "local_file" "inventory" {
+    depends_on=[aws_instance.redis-deployment]
+    filename = "(your_current_directory)/hosts"
+    content = <<EOF
+[all]
+ansible-target1 ansible_connection=ssh ansible_host=${aws_instance.redis-deployment.public_dns} ansible_user=ubuntu
+                EOF
+}
+
+resource "aws_key_pair" "deployer" {
+        key_name   = "aws_key"
+        public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCUZXm6T6JTQBuxw7aFaH6gmxDnjSOnHbrI59nf+YCHPqIHMlGaxWw0/xlaJiJynjOt67Zjeu1wNPifh2tzdN3UUD7eUFSGcLQaCFBDorDzfZpz4wLDguRuOngnXw+2Z3Iihy2rCH+5CIP2nCBZ+LuZuZ0oUd9rbGy6pb2gLmF89GYzs2RGG+bFaRR/3n3zR5ehgCYzJjFGzI8HrvyBlFFDgLqvI2KwcHwU2iHjjhAt54XzJ1oqevRGBiET/8RVsLNu+6UCHW6HE9r+T5yQZH50nYkSl/QKlxBj0tGHXAahhOBpk0ukwUlfbGcK6SVXmqtZaOuMNlNvssbocdg1KwOH ubuntu@ip-172-31-XXXX-XXXX"
+}
+```
+Make the changes listed below in `main.tf` to match your account settings.
+
+1. In the `provider` section, update all 3 values to use your preferred AWS region and your AWS access key ID and secret access key.
+
+2. (optional) In the `aws_instance` section, change the ami value to your preferred Linux distribution. The AMI ID for Ubuntu 22.04 on Arm is `ami-0ca2eafa23bc3dd01`. No change is needed if you want to use Ubuntu AMI. 
+
+{{% notice Note %}}
+The instance type is t4g.small. This an an Arm-based instance and requires an Arm Linux distribution.
+{{% /notice %}}
+
+3. In the `aws_key_pair` section, change the `public_key` value to match your SSH key. Copy and paste the contents of your `aws_key.pub` file to the `public_key` string. Make sure the string is a single line in the text file.
+
+4. In the `local_file` section, change the `filename` to be the path to your current directory.
+
+The hosts file is automatically generated and does not need to be changed, change the path to the location of the hosts file.
+
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for AWS.
+
+```console
+terraform init
+```
+    
+The output should be similar to:
+
+```console
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding latest version of hashicorp/local...
+- Finding latest version of hashicorp/aws...
+- Installing hashicorp/local v2.4.0...
+- Installed hashicorp/local v2.4.0 (signed by HashiCorp)
+- Installing hashicorp/aws v4.58.0...
+- Installed hashicorp/aws v4.58.0 (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```console
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all AWS resources. 
+
+```console
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create AWS resources. 
+
+The public IP address will be different, but the output should be similar to:
+
+```console
+Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+Master_public_IP = [
+  "3.135.226.118",
+]
+```
+
+## Configure Redis through Ansible
+Install the Redis and the required dependencies. 
+
+Using a text editor, save the code below to in a file called `playbook.yaml`. This is the YAML file for the Ansible playbook. 
+
+```console
+---
+- hosts: all
+  become: true
+  become_user: root
+  remote_user: ubuntu
+
+  tasks:
+    - name: Update the Machine and install dependencies
+      shell: |
+             apt-get update -y
+             curl -fsSL "https://packages.redis.io/gpg" | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+             echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" |  tee /etc/apt/sources.list.d/redis.list
+             apt install -y redis-tools redis
+    - name: Create directories
+      file:
+        path: "/home/ubuntu/redis"
+        state: directory
+      become_user: ubuntu
+    - name: Create configuration files
+      copy:
+        dest: "/home/ubuntu/redis/redis.conf"
+        content: |
+          bind 0.0.0.0
+          port 6379
+          protected-mode yes
+          cluster-enabled no
+          daemonize yes
+          appendonly no
+      become_user: ubuntu
+    - name: Stop redis-server
+      shell: service redis-server stop
+    - name: Start redis server with configuration files
+      shell: redis-server redis.conf
+      args:
+        chdir: "/home/ubuntu/redis"
+      become_user: ubuntu
+    - name: Set Authentication password
+      shell: redis-cli -p 6379 CONFIG SET requirepass "{password}"
+      become_user: ubuntu
+```
+Replace `{password}` with your value.
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the  `ansible-playbook` command.
+
+```console
+ansible-playbook playbook.yaml -i hosts --key-file aws_key
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```console
+PLAY [all] *****************************************************************************************************************************************************
+
+TASK [Gathering Facts] *****************************************************************************************************************************************
+The authenticity of host 'ec2-3-135-226-118.us-east-2.compute.amazonaws.com (172.31.30.40)' can't be established.
+ED25519 key fingerprint is SHA256:uWZgVeACoIxRDQ9TrqbpnjUz14x57jTca6iASH3gU7M.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+ok: [ansible-target1]
+
+TASK [Update the Machine and install dependencies] *************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Create directories] **************************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Create configuration files] ******************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Stop redis-server] ***************************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Start redis server with configuration files] *************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Set Authentication password] *****************************************************************************************************************************
+changed: [ansible-target1]
+
+PLAY RECAP *****************************************************************************************************************************************************
+ansible-target1            : ok=7    changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+## Connecting to the Redis server from local machine
+
+Execute the steps below to connect to the remote Redis server from your local machine.
+1. We need to install redis-tools to interact with redis-server.
+```console
+apt install redis-tools
+```
+2. Connect to redis-server through redis-cli.
+```console
+redis-cli -h <public-IP-address> -p 6379
+```
+The output will be:
+```console
+ubuntu@ip-172-31-38-39:~$ redis-cli -h 172.31.30.40 -p 6379
+172.31.30.40:6379> 
+```
+3. Authorize Redis with the password set by us in playbook.yaml file.
+```console
+172.31.30.40:6379> ping
+(error) NOAUTH Authentication required.
+172.31.30.40:6379> AUTH 123456789
+OK
+172.31.30.40:6379> ping
+PONG
+```
+4. Try out commands in the redis-cli.
+```console
+172.31.30.40:6379> set name test
+OK
+172.31.30.40:6379> get name
+"test"
+172.31.30.40:6379>
+```
+You have successfully installed Redis on an AWS EC2 instance running Graviton processors.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```
+
+Continue the Learning Path to deploy Redis on a single Azure instance.
+

--- a/content/learning-paths/server-and-cloud/redis/azure_deployment.md
+++ b/content/learning-paths/server-and-cloud/redis/azure_deployment.md
@@ -1,0 +1,431 @@
+---
+# User change
+title: "Install Redis on a single Azure Arm based instance"
+
+weight: 4 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Install Redis on a single Azure Arm based instance 
+
+You can deploy Redis on Azure using Terraform and Ansible. 
+
+In this topic, you will deploy Redis on a single Azure instance, and in the next topic you will deploy Redis on a single Google Cloud instance. 
+
+If you are new to Terraform, you should look at [Automate Azure instance creation using Terraform](/learning-paths/server-and-cloud/azure/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need an [an Azure portal account](https://azure.microsoft.com/en-in/get-started/azure-portal) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin you will also need:
+- Login to Azure CLI
+- An SSH key pair
+
+The instructions to login to Azure CLI and to create the keys are below.
+
+### Azure authentication
+
+The installation of Terraform on your Desktop/Laptop needs to communicate with Azure. Thus, Terraform needs to be authenticated.
+
+For authentication, follow the [steps from the Terraform Learning Path](/learning-paths/server-and-cloud/azure/terraform#azure-authentication).
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for Azure access. 
+
+```console
+ssh-keygen -f azure_key -t rsa -b 2048 -P ""
+```
+
+You should now have your SSH keys in the current directory.
+
+## Create an Azure instance using Terraform
+For Azure Arm based instance deployment, the Terraform configuration is broken into four files: `providers.tf`, `variables.tf`, `main.tf`, and `outputs.tf`.
+
+Add the following code in `providers.tf` file to configure Terraform to communicate with Azure.
+
+```console
+terraform {
+  required_version = ">=0.12"
+
+  required_providers {
+    azurerm = {
+      source= "hashicorp/azurerm"
+      version = "~>2.0"
+    }
+    random = {
+      source= "hashicorp/random"
+      version = "~>3.0"
+    }
+    tls = {
+    source = "hashicorp/tls"
+    version = "~>4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+``` 
+
+Create a `variables.tf` file for describing the variables referenced in the other files with their type and a default value.
+
+```console
+variable "resource_group_location" {
+  default = "eastus2"
+  description = "Location of the resource group."
+}
+
+variable "resource_group_name_prefix" {
+  default = "rg"
+  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+}
+```
+
+Add the resources required to create a virtual machine in `main.tf`.
+
+Scroll down to see the information you need to change in `main.tf`.
+
+```console
+resource "random_pet" "rg_name" {
+  prefix = var.resource_group_name_prefix
+}
+
+resource "azurerm_resource_group" "rg" {
+  location = var.resource_group_location
+  name = random_pet.rg_name.id
+}
+
+# Create virtual network
+resource "azurerm_virtual_network" "my_terraform_network" {
+  name = "myVnet"
+  address_space = ["10.0.0.0/16"]
+  location = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+# Create subnet
+resource "azurerm_subnet" "my_terraform_subnet" {
+  name = "mySubnet"
+  resource_group_name = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.my_terraform_network.name
+  address_prefixes = ["10.0.1.0/24"]
+}
+
+# Create Public IPs
+resource "azurerm_public_ip" "my_terraform_public_ip" {
+  name = "myPublicIP"
+  location = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method = "Dynamic"
+}
+
+# Create Network Security Group and rule
+resource "azurerm_network_security_group" "my_terraform_nsg" {
+  name= "myNetworkSecurityGroup"
+  location= azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  security_rule {
+    name= "SSH"
+    priority= 1001
+    direction= "Inbound"
+    access = "Allow"
+    protocol= "Tcp"
+    source_port_range= "*"
+    destination_port_range = "22"
+    source_address_prefix= "*"
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name= "Redis-port"
+    priority= 1002
+    direction= "Inbound"
+    access = "Allow"
+    protocol= "Tcp"
+    source_port_range= "*"
+    destination_port_range = "6379"
+    source_address_prefix= "*"
+    destination_address_prefix = "*"
+  }
+}
+
+# Create network interface
+resource "azurerm_network_interface" "my_terraform_nic" {
+  name= "myNIC"
+  location= azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  ip_configuration {
+    name= "my_nic_configuration"
+    subnet_id = azurerm_subnet.my_terraform_subnet.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id= azurerm_public_ip.my_terraform_public_ip.id
+  }
+}
+
+# Connect the security group to the network interface
+resource "azurerm_network_interface_security_group_association" "example" {
+  network_interface_id= azurerm_network_interface.my_terraform_nic.id
+  network_security_group_id = azurerm_network_security_group.my_terraform_nsg.id
+}
+
+# Generate random text for a unique storage account name
+resource "random_id" "random_id" {
+  keepers = {
+    # Generate a new ID only when a new resource group is defined
+    resource_group = azurerm_resource_group.rg.name
+  }
+
+  byte_length = 8
+}
+
+# Create storage account for boot diagnostics
+resource "azurerm_storage_account" "my_storage_account" {
+  name = "diag${random_id.random_id.hex}"
+  location = azurerm_resource_group.rg.location
+  resource_group_name= azurerm_resource_group.rg.name
+  account_tier = "Standard"
+  account_replication_type = "LRS"
+}
+
+# Create virtual machine
+resource "azurerm_linux_virtual_machine" "my_terraform_vm" {
+  name= "myVM"
+  location= azurerm_resource_group.rg.location
+  resource_group_name= azurerm_resource_group.rg.name
+  network_interface_ids = [azurerm_network_interface.my_terraform_nic.id]
+  size= "Standard_D2ps_v5"
+
+  os_disk {
+    name = "myOsDisk"
+    caching= "ReadWrite"
+    storage_account_type = "Premium_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer = "0001-com-ubuntu-server-focal"
+    sku= "20_04-lts-arm64"
+    version= "20.04.202209200"
+  }
+
+  computer_name= "myvm"
+  admin_username= "ubuntu"
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username= "ubuntu"
+    public_key = file("/home/ubuntu/.ssh/azure_key.pub")
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.my_storage_account.primary_blob_endpoint
+  }
+}
+
+resource "local_file" "inventory" {
+    depends_on=[azurerm_linux_virtual_machine.my_terraform_vm]
+    filename = "(your_current_directory)/hosts"
+    content = <<EOF
+[all]
+ansible-target1 ansible_connection=ssh ansible_host=${azurerm_linux_virtual_machine.my_terraform_vm.public_ip_address} ansible_user=ubuntu
+                EOF
+}
+```
+Make the changes listed below in `main.tf` to match your account settings.
+
+1. In the `admin_ssh_key` section, change the `public_key` value to match your SSH key.
+
+2. In the `local_file` section, change the `filename` to be the path to your current directory.
+
+The hosts file is automatically generated and does not need to be changed, change the path to the location of the hosts file.
+
+
+Add the below code in `outputs.tf` to get Resource group name and Public IP.
+
+```console
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "public_ip_address" {
+  value = azurerm_linux_virtual_machine.my_terraform_vm.public_ip_address
+}
+```
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for Azure.
+
+```console
+terraform init
+```
+    
+The output should be similar to:
+
+```console
+Initializing the backend...
+
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/tls from the dependency lock file
+- Reusing previous version of hashicorp/azurerm from the dependency lock file
+- Reusing previous version of hashicorp/random from the dependency lock file
+- Using previously-installed hashicorp/local v2.4.0
+- Using previously-installed hashicorp/tls v4.0.4
+- Using previously-installed hashicorp/azurerm v2.99.0
+- Using previously-installed hashicorp/random v3.4.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```console
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all Azure resources. 
+
+```console
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create Azure resources. 
+
+The public IP address will be different, but the output should be similar to:
+
+```console
+Apply complete! Resources: 12 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+public_ip_address = "20.110.186.231"
+resource_group_name = "rg-tight-dove"
+```
+
+## Configure Redis through Ansible
+
+Install the Redis and the required dependencies.
+
+You can use the same `playbook.yaml` file used in the topic, [Install Redis on a single AWS Arm based instance](/learning-paths/server-and-cloud/redis/aws_deployment#configure-redis-through-ansible).
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the  `ansible-playbook` command.
+
+```console
+ansible-playbook playbook.yaml -i hosts --key-file azure_key
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```console
+PLAY [all] *****************************************************************************************************************************************************
+
+TASK [Gathering Facts] *****************************************************************************************************************************************
+The authenticity of host '20.110.186.231 (20.110.186.231)' can't be established.
+ED25519 key fingerprint is SHA256:LHk4u86Sw5Uw7WPPvKaz7qp2mKyxn+X7Gxz1DogTL+4.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+ok: [ansible-target1]
+
+TASK [Update the Machine and install dependencies] *************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Create directories] **************************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Create configuration files] ******************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Stop redis-server] ***************************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Start redis server with configuration files] *************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Set Authentication password] *****************************************************************************************************************************
+changed: [ansible-target1]
+
+PLAY RECAP *****************************************************************************************************************************************************
+ansible-target1            : ok=7    changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+
+```
+
+## Connecting to the Redis server from local machine
+
+Execute the steps below to connect to the remote Redis server from your local machine.
+1. We need to install redis-tools to interact with redis-server.
+```console
+apt install redis-tools
+```
+2. Connect to redis-server through redis-cli.
+```console
+redis-cli -h <public-IP-address> -p 6379
+```
+The output will be:
+```console
+ubuntu@ip-172-31-38-39:~$ redis-cli -h 20.110.186.231 -p 6379
+20.110.186.231:6379> 
+```
+3. Authorize Redis with the password set by us in playbook.yaml file.
+```console
+20.110.186.231:6379> ping
+(error) NOAUTH Authentication required.
+20.110.186.231:6379> AUTH 123456789
+OK
+20.110.186.231:6379> ping
+PONG
+```
+4. Try out commands in the redis-cli.
+```console
+20.110.186.231:6379> set name test
+OK
+20.110.186.231:6379> get name
+"test"
+20.110.186.231:6379>
+```
+You have successfully installed Redis on an Azure instance.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```
+
+Continue the Learning Path to deploy Redis on a single Google Cloud instance.
+

--- a/content/learning-paths/server-and-cloud/redis/azure_deployment.md
+++ b/content/learning-paths/server-and-cloud/redis/azure_deployment.md
@@ -12,7 +12,7 @@ layout: "learningpathall"
 
 You can deploy Redis on Azure using Terraform and Ansible. 
 
-In this topic, you will deploy Redis on a single Azure instance, and in the next topic you will deploy Redis on a single Google Cloud instance. 
+In this section, you will deploy Redis on a single Azure instance. 
 
 If you are new to Terraform, you should look at [Automate Azure instance creation using Terraform](/learning-paths/server-and-cloud/azure/terraform/) before starting this Learning Path.
 
@@ -276,7 +276,7 @@ terraform init
     
 The output should be similar to:
 
-```console
+```output
 Initializing the backend...
 
 Initializing provider plugins...
@@ -322,7 +322,7 @@ Answer `yes` to the prompt to confirm you want to create Azure resources.
 
 The public IP address will be different, but the output should be similar to:
 
-```console
+```output
 Apply complete! Resources: 12 added, 0 changed, 0 destroyed.
 
 Outputs:
@@ -351,7 +351,7 @@ Deployment may take a few minutes.
 
 The output should be similar to:
 
-```console
+```output
 PLAY [all] *****************************************************************************************************************************************************
 
 TASK [Gathering Facts] *****************************************************************************************************************************************
@@ -396,7 +396,7 @@ apt install redis-tools
 redis-cli -h <public-IP-address> -p 6379
 ```
 The output will be:
-```console
+```output
 ubuntu@ip-172-31-38-39:~$ redis-cli -h 20.110.186.231 -p 6379
 20.110.186.231:6379> 
 ```

--- a/content/learning-paths/server-and-cloud/redis/configurations.md
+++ b/content/learning-paths/server-and-cloud/redis/configurations.md
@@ -1,0 +1,66 @@
+---
+# User change
+title: "About Redis deployment configurations"
+
+weight: 2 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  About Redis deployment configurations
+
+###  Introduction to Redis
+Redis, which stands for Remote Dictionary Server, is an open source, in-memory, key-value data store. Redis has a variety of data types, including bitmaps, hyperloglogs, geographic indexes, streams, lists, sets, and sorted sets with range queries.
+
+### Configuring Redis Server
+We can configure the Redis server using the [redis.conf](https://redis.io/docs/management/config-file/) file. Alternatively, we can configure Redis servers by [passing arguments via the command line](https://redis.io/docs/management/config/#passing-arguments-via-the-command-line) when fewer configuration variables need to be set.
+
+### Single node configuration
+After installing Redis, by default it runs on localhost (`127.0.0.1`) at port **6379**. Hence, port **6379** becomes unavailable for binding with the public IP of the remote server. Thus, we set the bind configuration option in the **redis.conf** file to `0.0.0.0`.
+
+For a single-node Redis server, we need to set the following in the **redis.conf** file:
+```console
+bind 0.0.0.0
+port 6379
+protected-mode yes
+cluster-enabled no
+daemonize yes
+appendonly no
+```
+
+To connect to the remote Redis server, we need to use Redis Client (`redis-cli`) with:
+- **-h** option providing hostname
+- **-p** option providing the port number  
+
+### Multi-node configuration
+A Redis multi-node cluster requires 3 primary and 3 replica nodes in a minimal configuration to work properly.  
+
+We can use 6 different ports of the same host as follows:
+```console
+redis-cli --cluster create HOST:port1 HOST:port2 HOST:port3 HOST:port4 HOST:port5 HOST:port6
+```
+
+Alternatively, we can create 6 different hosts with Redis server running on same port as follows:
+```console
+redis-cli --cluster create HOST1:port HOST2:port HOST3:port HOST4:port HOST5:port HOST6:port
+```
+Here, we are using the second approach, in which we need to create 6 different hosts with Redis server running on **6379** port.
+
+Here is the minimal template of **redis.conf** file.
+```console
+bind 0.0.0.0
+protected-mode no
+port 6379
+cluster-enabled yes
+cluster-config-file nodes.conf
+cluster-node-timeout 5000
+daemonize yes
+appendonly yes
+```
+
+To connect to the remote Redis multi-node cluster, we need to use Redis Client (`redis-cli`) with:
+- **-c** option to enable cluster mode
+- **-h** option providing hostname
+- **-p** option providing the port number.
+

--- a/content/learning-paths/server-and-cloud/redis/docker_deployment.md
+++ b/content/learning-paths/server-and-cloud/redis/docker_deployment.md
@@ -1,0 +1,230 @@
+---
+# User change
+title: "Install Redis on a Docker container"
+
+weight: 6 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Install Redis on a Docker container 
+
+You can deploy Redis on a Docker container using Terraform and Ansible. 
+
+In this topic, you will deploy Redis on a Docker container, and in the next topic you will deploy Redis in a multi-node configuration. 
+
+## Before you begin
+
+You should have the prerequisite tools installed from the topic, [Install Redis on a single AWS Arm based instance](/learning-paths/server-and-cloud/redis/aws_deployment#create-an-aws-ec2-instance-using-terraform).
+
+Use the same AWS access key ID and secret access key and the same SSH key pair.
+
+## Create an AWS EC2 instance using Terraform
+
+You can use the same `main.tf` file used in the topic, [Install Redis on a single AWS Arm based instance](/learning-paths/server-and-cloud/redis/aws_deployment).
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for AWS.
+
+```console
+terraform init
+```
+    
+The output should be similar to:
+
+```console
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding latest version of hashicorp/local...
+- Finding latest version of hashicorp/aws...
+- Installing hashicorp/local v2.4.0...
+- Installed hashicorp/local v2.4.0 (signed by HashiCorp)
+- Installing hashicorp/aws v4.58.0...
+- Installed hashicorp/aws v4.58.0 (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```console
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all AWS resources. 
+
+```console
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create AWS resources. 
+
+The public IP address will be different, but the output should be similar to:
+
+```console
+Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+Master_public_IP = [
+  "3.135.226.118",
+]
+```
+
+## Install Redis on a Docker container through Ansible
+Install the Redis and the required dependencies. 
+
+Using a text editor, save the code below to in a file called `playbook.yaml`. This is the YAML file for the Ansible playbook. 
+```console
+---
+- hosts: all
+  become: true
+  become_user: root
+  remote_user: ubuntu
+
+  tasks:
+    - name: Update the Machine and install docker dependencies
+      shell: |
+        apt update
+        apt install -y ca-certificates curl gnupg lsb-release
+    - name: Create directory
+      file:
+        path: /etc/apt/keyrings
+        state: directory
+    - name: Download docker gpg key and install docker
+      shell: |
+        curl -fsSL 'https://download.docker.com/linux/ubuntu/gpg' | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+        apt update
+        apt install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    - name: Start and enable docker service
+      service:
+        name: docker
+        state: started
+        enabled: yes
+    - name: Start redis container
+      shell: docker run --name redis-container -p 6000:6379 -d redis
+    - name: Set Authentication password
+      shell: docker exec -it redis-container redis-cli CONFIG SET requirepass "{password}"
+```
+Replace `{password}` with your value.
+
+To access the Redis server running inside the Docker container on port `6379`, we need to expose it to any available port on the machine using `-p {port_no_of_machine}:6379` argument. We need to replace `{port_no_of_machine}` with its respective value. In our example, we have used port number `6000`.
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the  `ansible-playbook` command.
+
+```console
+ansible-playbook playbook.yaml -i hosts --key-file aws_key
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```console
+PLAY [all] *****************************************************************************************************************************************************
+
+TASK [Gathering Facts] *****************************************************************************************************************************************
+The authenticity of host 'ec2-3-135-226-118.us-east-2.compute.amazonaws.com (172.31.30.40)' can't be established.
+ED25519 key fingerprint is SHA256:uWZgVeACoIxRDQ9TrqbpnjUz14x57jTca6iASH3gU7M.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+ok: [ansible-target1]
+
+TASK [Update the Machine and install docker dependencies] *************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Create directory] ***********************************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Download docker gpg key and install docker] *********************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Start and enable docker service] ********************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Start redis container] ******************************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Set Authentication password] ************************************************************************************************************************************
+changed: [ansible-target1]
+
+PLAY RECAP ************************************************************************************************************************************************************
+ansible-target1            : ok=7    changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+## Connecting to the Redis server from local machine
+
+Execute the steps below to connect to the remote Redis server from your local machine.
+1. We need to install redis-tools to interact with redis-server.
+```console
+apt install redis-tools
+```
+2. Connect to redis-server through redis-cli.
+```console
+redis-cli -h <public-IP-address> -p 6379
+```
+The output will be:
+```console
+ubuntu@ip-172-31-38-39:~$ redis-cli -h 172.31.30.40 -p 6379
+172.31.30.40:6379> 
+```
+3. Authorize Redis with the password set by us in playbook.yaml file.
+```console
+172.31.30.40:6379> ping
+(error) NOAUTH Authentication required.
+172.31.30.40:6379> AUTH 123456789
+OK
+172.31.30.40:6379> ping
+PONG
+```
+4. Try out commands in the redis-cli.
+```console
+172.31.30.40:6379> set name test
+OK
+172.31.30.40:6379> get name
+"test"
+172.31.30.40:6379>
+```
+You have successfully installed Redis on a Docker container.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```
+
+Continue the Learning Path to deploy Redis in a multi-node configuration.
+

--- a/content/learning-paths/server-and-cloud/redis/docker_deployment.md
+++ b/content/learning-paths/server-and-cloud/redis/docker_deployment.md
@@ -8,11 +8,11 @@ weight: 6 # 1 is first, 2 is second, etc.
 layout: "learningpathall"
 ---
 
-##  Install Redis on a Docker container 
+##  Install Redis with a Docker container 
 
-You can deploy Redis on a Docker container using Terraform and Ansible. 
+You can deploy Redis with a Docker container using Terraform and Ansible. 
 
-In this topic, you will deploy Redis on a Docker container, and in the next topic you will deploy Redis in a multi-node configuration. 
+In this topic, you will deploy Redis with a Docker container.
 
 ## Before you begin
 
@@ -38,7 +38,7 @@ terraform init
     
 The output should be similar to:
 
-```console
+```output
 Initializing the backend...
 
 Initializing provider plugins...
@@ -87,7 +87,7 @@ Answer `yes` to the prompt to confirm you want to create AWS resources.
 
 The public IP address will be different, but the output should be similar to:
 
-```console
+```output
 Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
 
 Outputs:
@@ -97,7 +97,7 @@ Master_public_IP = [
 ]
 ```
 
-## Install Redis on a Docker container through Ansible
+## Install Redis with a Docker container through Ansible
 Install the Redis and the required dependencies. 
 
 Using a text editor, save the code below to in a file called `playbook.yaml`. This is the YAML file for the Ansible playbook. 
@@ -151,7 +151,7 @@ Deployment may take a few minutes.
 
 The output should be similar to:
 
-```console
+```output
 PLAY [all] *****************************************************************************************************************************************************
 
 TASK [Gathering Facts] *****************************************************************************************************************************************
@@ -195,7 +195,7 @@ apt install redis-tools
 redis-cli -h <public-IP-address> -p 6379
 ```
 The output will be:
-```console
+```output
 ubuntu@ip-172-31-38-39:~$ redis-cli -h 172.31.30.40 -p 6379
 172.31.30.40:6379> 
 ```

--- a/content/learning-paths/server-and-cloud/redis/gcp_deployment.md
+++ b/content/learning-paths/server-and-cloud/redis/gcp_deployment.md
@@ -1,0 +1,286 @@
+---
+# User change
+title: "Install Redis on a single GCP Arm based instance"
+
+weight: 5 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Install Redis on a single GCP Arm based instance 
+
+You can deploy Redis on Google Cloud using Terraform and Ansible. 
+
+In this topic, you will deploy Redis on a single Google Cloud instance, and in the next topic you will deploy Redis on a Docker container. 
+
+If you are new to Terraform, you should look at [Automate GCP instance creation using Terraform](/learning-paths/server-and-cloud/gcp/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need an [Google Cloud account](https://console.cloud.google.com/?hl=en-au) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin you will also need:
+- Login to Google Cloud CLI 
+- An SSH key pair
+
+The instructions to login to Google Cloud CLI and to create the keys are below.
+
+### Acquire user credentials
+
+To obtain user access credentials, follow the [steps from the Terraform Learning Path](/learning-paths/server-and-cloud/gcp/terraform#acquire-user-credentials).
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for Google Cloud access. 
+
+```console
+ssh-keygen -f gcp_key -t rsa -b 2048 -P ""
+```
+
+You should now have your SSH keys in the current directory.
+
+## Create a GCP instance using Terraform
+
+Using a text editor, save the code below in a file called `main.tf`.
+
+Scroll down to see the information you need to change in `main.tf`.
+```
+provider "google" {
+  project = "{project_id}"
+  region = "us-central1"
+  zone = "us-central1-a"
+}
+
+resource "google_compute_project_metadata_item" "ssh-keys" {
+  key   = "gcp_key"
+  value = "ubuntu:${file("{public_key_location}")}"
+}
+
+resource "google_compute_firewall" "rules" {
+  project     = "{project_id}"
+  name        = "my-firewall-rule"
+  network     = "default"
+  description = "Open Redis connection port"
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol  = "tcp"
+    ports     = ["6379"]
+  }
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = "vm_name"
+  machine_type = "t2a-standard-1"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts-arm64"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+}
+output "Master_public_IP" {
+  value = [google_compute_instance.vm_instance.network_interface.0.access_config.0.nat_ip]
+}
+
+resource "local_file" "inventory" {
+    depends_on=[google_compute_instance.vm_instance]
+    filename = "(your_current_directory)/hosts"
+    content = <<EOF
+[all]
+ansible-target1 ansible_connection=ssh ansible_host=${google_compute_instance.vm_instance.network_interface.0.access_config.0.nat_ip} ansible_user=ubuntu
+                EOF
+}
+```
+Make the changes listed below in `main.tf` to match your account settings.
+
+1. In the `provider` and `google_compute_firewall` sections, update the `project_id` with your value.
+
+2. In the `google_compute_project_metadata_item` section, change the `public_key_location` value to match your SSH key.
+
+3. In the `local_file` section, change the `filename` to be the path to your current directory.
+
+The hosts file is automatically generated and does not need to be changed, change the path to the location of the hosts file.
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for Google Cloud.
+
+```console
+terraform init
+```
+    
+The output should be similar to:
+
+```console
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding latest version of hashicorp/google...
+- Finding latest version of hashicorp/local...
+- Installing hashicorp/google v4.57.0...
+- Installed hashicorp/google v4.57.0 (signed by HashiCorp)
+- Installing hashicorp/local v2.4.0...
+- Installed hashicorp/local v2.4.0 (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```console
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all GCP resources. 
+
+```console
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create GCP resources. 
+
+The public IP address will be different, but the output should be similar to:
+
+```console
+Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+Master_public_IP = [
+  "34.68.176.131",
+]
+```
+
+## Configure Redis through Ansible
+Install the Redis and the required dependencies. 
+
+You can use the same `playbook.yaml` file used in the topic, [Install Redis on a single AWS Arm based instance](/learning-paths/server-and-cloud/redis/aws_deployment#configure-redis-through-ansible).
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the  `ansible-playbook` command.
+
+```console
+ansible-playbook playbook.yaml -i hosts --key-file gcp_key
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```console
+PLAY [all] *****************************************************************************************************************************************************
+
+TASK [Gathering Facts] *****************************************************************************************************************************************
+The authenticity of host '34.68.176.131 (34.68.176.131)' can't be established.
+ED25519 key fingerprint is SHA256:uWZgVeACoIxRDQ9TrqbpnjUz14x57jTca6iASH3gU7M.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+ok: [ansible-target1]
+
+TASK [Update the Machine and install dependencies] *************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Create directories] **************************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Create configuration files] ******************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Stop redis-server] ***************************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Start redis server with configuration files] *************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Set Authentication password] *****************************************************************************************************************************
+changed: [ansible-target1]
+
+PLAY RECAP *****************************************************************************************************************************************************
+ansible-target1            : ok=7    changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+## Connecting to the Redis server from local machine
+
+Execute the steps below to connect to the remote Redis server from your local machine.
+1. We need to install redis-tools to interact with redis-server.
+```console
+apt install redis-tools
+```
+2. Connect to redis-server through redis-cli.
+```console
+redis-cli -h <public-IP-address> -p 6379
+```
+The output will be:
+```console
+ubuntu@ip-172-31-38-39:~$ redis-cli -h 34.68.176.131 -p 6379
+34.68.176.131:6379> 
+```
+3. Authorize Redis with the password set by us in playbook.yaml file.
+```console
+34.68.176.131:6379> ping
+(error) NOAUTH Authentication required.
+34.68.176.131:6379> AUTH 123456789
+OK
+34.68.176.131:6379> ping
+PONG
+```
+4. Try out commands in the redis-cli.
+```console
+34.68.176.131:6379> set name test
+OK
+34.68.176.131:6379> get name
+"test"
+34.68.176.131:6379>
+```
+You have successfully installed Redis on a Google Cloud instance.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```
+
+Continue the Learning Path to deploy Redis on a Docker container.
+

--- a/content/learning-paths/server-and-cloud/redis/gcp_deployment.md
+++ b/content/learning-paths/server-and-cloud/redis/gcp_deployment.md
@@ -12,7 +12,7 @@ layout: "learningpathall"
 
 You can deploy Redis on Google Cloud using Terraform and Ansible. 
 
-In this topic, you will deploy Redis on a single Google Cloud instance, and in the next topic you will deploy Redis on a Docker container. 
+In this section, you will deploy Redis on a single Google Cloud instance.
 
 If you are new to Terraform, you should look at [Automate GCP instance creation using Terraform](/learning-paths/server-and-cloud/gcp/terraform/) before starting this Learning Path.
 
@@ -128,7 +128,7 @@ terraform init
     
 The output should be similar to:
 
-```console
+```output
 Initializing the backend...
 
 Initializing provider plugins...
@@ -178,7 +178,7 @@ Answer `yes` to the prompt to confirm you want to create GCP resources.
 
 The public IP address will be different, but the output should be similar to:
 
-```console
+```output
 Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
 
 Outputs:
@@ -207,7 +207,7 @@ Deployment may take a few minutes.
 
 The output should be similar to:
 
-```console
+```output
 PLAY [all] *****************************************************************************************************************************************************
 
 TASK [Gathering Facts] *****************************************************************************************************************************************
@@ -251,7 +251,7 @@ apt install redis-tools
 redis-cli -h <public-IP-address> -p 6379
 ```
 The output will be:
-```console
+```output
 ubuntu@ip-172-31-38-39:~$ redis-cli -h 34.68.176.131 -p 6379
 34.68.176.131:6379> 
 ```

--- a/content/learning-paths/server-and-cloud/redis/multi-node_deployment.md
+++ b/content/learning-paths/server-and-cloud/redis/multi-node_deployment.md
@@ -127,7 +127,7 @@ terraform init
     
 The output should be similar to:
 
-```console
+```output
 Initializing the backend...
 
 Initializing provider plugins...
@@ -176,7 +176,7 @@ Answer `yes` to the prompt to confirm you want to create AWS resources.
 
 The output should be similar to:
 
-```console
+```output
 Apply complete! Resources: 9 added, 0 changed, 0 destroyed.
 ```
 
@@ -241,7 +241,7 @@ Deployment may take a few minutes.
 
 The output should be similar to:
 
-```console
+```output
 PLAY [Redis Cluster Install] *************************************************************************************************************************************
 
 TASK [Gathering Facts] *******************************************************************************************************************************************
@@ -336,7 +336,7 @@ Replace `redis-deployment[n].public_ip` with their respective values.
 
 The output should be similar to:
 
-```console
+```output
 >>> Performing hash slots allocation on 6 nodes...
 Master[0] -> Slots 0 - 5460
 Master[1] -> Slots 5461 - 10922
@@ -397,7 +397,7 @@ Replace `{redis-deployment[n].public_ip}` with the IP of any of the instances cr
 
 The output should be similar to:
 
-```console
+```output
 cluster_state:ok
 cluster_slots_assigned:16384
 cluster_slots_ok:16384
@@ -424,7 +424,7 @@ redis-cli -c -h {redis-deployment[n].public_ip} -p 6379 cluster nodes
 ```
 The output should be similar to:
 
-```console
+```output
 a871235e3fc81a8feee28527c3ae1435d4f9a7f0 172.31.26.201:6379@16379 master - 0 1678791540000 2 connected 5461-10922
 d8965922e7ec90de5e8218c136f2b744be4cb258 172.31.19.70:6379@16379 master - 0 1678791539596 3 connected 10923-16383
 cadd3b1b0c3975726fbf9859105df8ef60b837d2 172.31.29.216:6379@16379 slave a871235e3fc81a8feee28527c3ae1435d4f9a7f0 0 1678791539000 6 connected
@@ -445,7 +445,7 @@ apt install redis-tools
 redis-cli -c -h <public-IP-address> -p 6379
 ```
 The output will be:
-```console
+```output
 ubuntu@ip-172-31-38-39:~$ redis-cli -c -h ec2-18-117-150-63.us-east-2.compute.amazonaws.com -p 6379
 ec2-18-117-150-63.us-east-2.compute.amazonaws.com:6379>
 ```

--- a/content/learning-paths/server-and-cloud/redis/multi-node_deployment.md
+++ b/content/learning-paths/server-and-cloud/redis/multi-node_deployment.md
@@ -1,0 +1,481 @@
+---
+# User change
+title: "Install Redis in a multi-node configuration"
+
+weight: 7 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Install Redis in a multi-node configuration 
+
+You can deploy Redis in a multi-node configuration on AWS Graviton processors using Terraform and Ansible. You will create three primary nodes and three replica nodes.
+
+## Before you begin
+
+You should have the prerequisite tools installed from the topic, [Install Redis on a single AWS Arm based instance](/learning-paths/server-and-cloud/redis/aws_deployment).
+
+Use the same AWS access key ID and secret access key and the same SSH key pair.
+
+## Create AWS EC2 instances using Terraform
+
+Using a text editor, save the code below in a file called `main.tf`. You will create a security group that opens inbound port `22`(ssh). Also every Redis Cluster node requires two TCP connections open. The normal Redis TCP port used to serve clients, for example `6379` plus the port obtained by adding 10000 to the data port, so `16379` in the example.
+
+Scroll down to see the information you need to change in `main.tf`.
+
+```console
+provider "aws" {
+  region = "us-east-2"
+  access_key  = "AXXXXXXXXXXXXXXXXXXX"
+  secret_key   = "AXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}
+resource "aws_instance" "redis-deployment" {
+  ami = "ami-0ca2eafa23bc3dd01"
+  count = "6"
+  instance_type = "t4g.small"
+  key_name= "aws_key"
+  vpc_security_group_ids = [aws_security_group.main.id]
+}
+
+resource "aws_security_group" "main" {
+  name        = "main"
+  description = "Allow TLS inbound traffic"
+
+  ingress {
+    description      = "Open redis connection port"
+    from_port        = 6379
+    to_port          = 6379
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+  ingress {
+    description      = "Open port for Cluster bus"
+    from_port        = 16379
+    to_port          = 16379
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+  ingress {
+    description      = "Allow ssh to instance"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+}
+
+resource "local_file" "inventory" {
+    depends_on=[aws_instance.redis-deployment]
+    filename = "(your_current_directory)/hosts"
+    content = <<EOF
+[redis]
+
+${aws_instance.redis-deployment[0].public_dns}
+${aws_instance.redis-deployment[1].public_dns}
+${aws_instance.redis-deployment[2].public_dns}
+${aws_instance.redis-deployment[3].public_dns}
+${aws_instance.redis-deployment[4].public_dns}
+${aws_instance.redis-deployment[5].public_dns}
+
+[all:vars]
+host_key_checking=false
+ansible_connection=ssh
+ansible_user=ubuntu
+                EOF
+}
+
+resource "aws_key_pair" "deployer" {
+        key_name   = "aws_key"
+        public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/GFk2t5I2WOGWIP11kk9+sS2hwb+SuZV8b6KAi8IPR50pDjBXtBBt/8Apl+cyTmUjIlVxnyV6rS4sGVdKLC7SDNU8nl1SfDuh1HJRtlbMu8k+OmA3i9T/rihz2Qs9htkbSkdZ3bADCd5tcregPIht1bdQkjFK5zpbmiNHqIC1KJYIKfiwHMCLt+3ZQWr8iw1G19hHLbfpvDr0H/ewlrpMNG3StJSo6E2Jec6NZ09takFMl0a2r9Cej3bSQz5TuDnxWFDm1xk2svLojROnNeSH2sVx6UoPDpt05eniqgpYdMysYzxeOwS+qMHzR2IV2+0UoDFMxgcSgnhM36qlSk7H ubuntu@ip-172-XX-XX-XX"
+}
+```
+Make the changes listed below in `main.tf` to match your account settings.
+
+1. In the `provider` section, update all 3 values to use your preferred AWS region and your AWS access key ID and secret access key.
+
+2. (optional) In the `aws_instance` section, change the ami value to your preferred Linux distribution. The AMI ID for Ubuntu 22.04 on Arm is `ami-0ca2eafa23bc3dd01`. No change is needed if you want to use Ubuntu AMI. 
+
+{{% notice Note %}}
+The instance type is t4g.small. This an an Arm-based instance and requires an Arm Linux distribution.
+{{% /notice %}}
+
+3. In the `aws_key_pair` section, change the `public_key` value to match your SSH key. Copy and paste the contents of your `aws_key.pub` file to the `public_key` string. Make sure the string is a single line in the text file.
+
+4. In the `local_file` section, change the `filename` to be the path to your current directory.
+
+The hosts file is automatically generated and does not need to be changed, change the path to the location of the hosts file.
+
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for AWS.
+
+```console
+terraform init
+```
+    
+The output should be similar to:
+
+```console
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding latest version of hashicorp/local...
+- Finding latest version of hashicorp/aws...
+- Installing hashicorp/local v2.4.0...
+- Installed hashicorp/local v2.4.0 (signed by HashiCorp)
+- Installing hashicorp/aws v4.58.0...
+- Installed hashicorp/aws v4.58.0 (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```console
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all AWS resources. 
+
+```console
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create AWS resources. 
+
+The output should be similar to:
+
+```console
+Apply complete! Resources: 9 added, 0 changed, 0 destroyed.
+```
+
+## Install Redis in a multi-node configuration through Ansible
+Install the Redis and the required dependencies. 
+
+Using a text editor, save the code below to in a file called `playbook.yaml`. This is the YAML file for the Ansible playbook. The following playbook contains a collection of tasks that install Redis in a multi-node configuration (3 primary and 3 replica nodes). 
+
+```console
+---
+- name: Redis Cluster Install
+  hosts: redis
+  become: true
+  become_user: root
+  remote_user: ubuntu
+  tasks:
+    - name: Update the Machine and install dependencies
+      shell: |
+             apt-get update -y
+             curl -fsSL "https://packages.redis.io/gpg" | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+             echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" |  tee /etc/apt/sources.list.d/redis.list
+             apt install -y redis-tools redis
+    - name: Create directories
+      file:
+        path: "/home/ubuntu/redis"
+        state: directory
+      become_user: ubuntu
+    - name: Create configuration files
+      copy:
+       dest: "/home/ubuntu/redis/redis.conf"
+       content: |
+         bind 0.0.0.0
+         protected-mode no
+         port 6379
+         cluster-enabled yes
+         cluster-config-file nodes.conf
+         cluster-node-timeout 5000
+         daemonize yes
+         appendonly yes
+      become_user: ubuntu
+    - name: Stop redis-server
+      shell: service redis-server stop
+    - name: Start redis server with configuration files
+      shell: redis-server redis.conf
+      args:
+        chdir: "/home/ubuntu/redis"
+      become_user: ubuntu
+```
+**NOTE:-** Since the allocation of primary and replica nodes is random at the time of cluster creation, it is difficult to know which nodes are primary and which nodes are replica. Hence, for the multi-node configuration, we need to turn off **protected-mode**, which is enabled by default, so that we can connect to the primary and replica nodes. Also, the **bind address** is by default set to `127.0.0.1` due to which port 6379 becomes unavailable for binding with the public IP of the remote server. Thus, we set the bind configuration option to `0.0.0.0`.
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the  `ansible-playbook` command.
+
+```console
+ansible-playbook playbook.yaml -i hosts --key-file aws_key
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```console
+PLAY [Redis Cluster Install] *************************************************************************************************************************************
+
+TASK [Gathering Facts] *******************************************************************************************************************************************
+The authenticity of host 'ec2-13-58-162-195.us-east-2.compute.amazonaws.com (172.31.28.72)' can't be established.
+ED25519 key fingerprint is SHA256:tr9tgt90kYwO0TTcqixWAL3FfpfxVHN2pEZlWevxp+g.
+This key is not known by any other names
+The authenticity of host 'ec2-18-217-125-204.us-east-2.compute.amazonaws.com (172.31.23.206)' can't be established.
+ED25519 key fingerprint is SHA256:liR6mlOvk2hfxArrwNkYvrP9a6flWDE63rIYHUMol7s.
+This key is not known by any other names
+The authenticity of host 'ec2-3-142-240-147.us-east-2.compute.amazonaws.com (172.31.21.161)' can't be established.
+ED25519 key fingerprint is SHA256:k0xJlAKunLQhmtQzay0D0i+XO8C9N8y1AxF4qnoKOxI.
+This key is not known by any other names
+The authenticity of host 'ec2-3-17-132-158.us-east-2.compute.amazonaws.com (172.31.30.32)' can't be established.
+ED25519 key fingerprint is SHA256:Bvhc5zvHx4vl4Cnpz1VUgwE0WwSjnj8CSvHStiNwnA0.
+This key is not known by any other names
+The authenticity of host 'ec2-3-23-96-163.us-east-2.compute.amazonaws.com (172.31.27.229)' can't be established.
+ED25519 key fingerprint is SHA256:Z5XybSrhgkScd1P0eeFMVWgFVm8to+771TAaRyvBVlY.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+yes
+yes
+ok: [ec2-13-58-162-195.us-east-2.compute.amazonaws.com]
+The authenticity of host 'ec2-3-17-161-89.us-east-2.compute.amazonaws.com (172.31.23.88)' can't be established.
+ED25519 key fingerprint is SHA256:8dKquVwCvXEjCpJ6oOJ4OScISz4UwYlkFJRWJBt11ZM.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+yes
+ok: [ec2-18-217-125-204.us-east-2.compute.amazonaws.com]
+yes
+ok: [ec2-3-142-240-147.us-east-2.compute.amazonaws.com]
+ok: [ec2-3-17-132-158.us-east-2.compute.amazonaws.com]
+ok: [ec2-3-23-96-163.us-east-2.compute.amazonaws.com]
+ok: [ec2-3-17-161-89.us-east-2.compute.amazonaws.com]
+
+TASK [Update the Machine and install dependencies] ***************************************************************************************************************
+changed: [ec2-3-23-96-163.us-east-2.compute.amazonaws.com]
+changed: [ec2-18-217-125-204.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-17-132-158.us-east-2.compute.amazonaws.com]
+changed: [ec2-13-58-162-195.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-142-240-147.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-17-161-89.us-east-2.compute.amazonaws.com]
+
+TASK [Create directories] ****************************************************************************************************************************************
+changed: [ec2-3-142-240-147.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-23-96-163.us-east-2.compute.amazonaws.com]
+changed: [ec2-18-217-125-204.us-east-2.compute.amazonaws.com]
+changed: [ec2-13-58-162-195.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-17-132-158.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-17-161-89.us-east-2.compute.amazonaws.com]
+
+TASK [Create configuration files] ********************************************************************************************************************************
+changed: [ec2-3-17-132-158.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-142-240-147.us-east-2.compute.amazonaws.com]
+changed: [ec2-13-58-162-195.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-23-96-163.us-east-2.compute.amazonaws.com]
+changed: [ec2-18-217-125-204.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-17-161-89.us-east-2.compute.amazonaws.com]
+
+TASK [Stop redis-server] *****************************************************************************************************************************************
+changed: [ec2-3-17-132-158.us-east-2.compute.amazonaws.com]
+changed: [ec2-13-58-162-195.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-142-240-147.us-east-2.compute.amazonaws.com]
+changed: [ec2-18-217-125-204.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-23-96-163.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-17-161-89.us-east-2.compute.amazonaws.com]
+
+TASK [Start redis server with configuration files] ***************************************************************************************************************
+changed: [ec2-13-58-162-195.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-17-132-158.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-23-96-163.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-142-240-147.us-east-2.compute.amazonaws.com]
+changed: [ec2-18-217-125-204.us-east-2.compute.amazonaws.com]
+changed: [ec2-3-17-161-89.us-east-2.compute.amazonaws.com]
+
+PLAY RECAP *******************************************************************************************************************************************************
+ec2-13-58-162-195.us-east-2.compute.amazonaws.com : ok=6    changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+ec2-18-217-125-204.us-east-2.compute.amazonaws.com : ok=6    changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+ec2-3-142-240-147.us-east-2.compute.amazonaws.com : ok=6    changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+ec2-3-17-132-158.us-east-2.compute.amazonaws.com : ok=6    changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+ec2-3-17-161-89.us-east-2.compute.amazonaws.com : ok=6    changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+ec2-3-23-96-163.us-east-2.compute.amazonaws.com : ok=6    changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+## Create a Redis cluster
+
+After the Redis installation has been completed on all servers, lift the cluster up with the help of the following command.
+
+```console
+redis-cli --cluster create {redis-deployment[0].public_ip}:6379 {redis-deployment[1].public_ip}:6379 {redis-deployment[2].public_ip}:6379 {redis-deployment[3].public_ip}:6379 {redis-deployment[4].public_ip}:6379 {redis-deployment[5].public_ip}:6379 --cluster-replicas 1
+```
+Replace `redis-deployment[n].public_ip` with their respective values.
+
+The output should be similar to:
+
+```console
+>>> Performing hash slots allocation on 6 nodes...
+Master[0] -> Slots 0 - 5460
+Master[1] -> Slots 5461 - 10922
+Master[2] -> Slots 10923 - 16383
+Adding replica ec2-3-142-208-82.us-east-2.compute.amazonaws.com:6379 to ec2-18-117-150-63.us-east-2.compute.amazonaws.com:6379
+Adding replica ec2-52-15-94-91.us-east-2.compute.amazonaws.com:6379 to ec2-18-191-103-96.us-east-2.compute.amazonaws.com:6379
+Adding replica ec2-3-133-91-199.us-east-2.compute.amazonaws.com:6379 to ec2-18-220-255-133.us-east-2.compute.amazonaws.com:6379
+M: e01e0295b9e1e4129f86c33880f8eb5873c77f05 ec2-18-117-150-63.us-east-2.compute.amazonaws.com:6379
+   slots:[0-5460] (5461 slots) master
+M: a871235e3fc81a8feee28527c3ae1435d4f9a7f0 ec2-18-191-103-96.us-east-2.compute.amazonaws.com:6379
+   slots:[5461-10922] (5462 slots) master
+M: d8965922e7ec90de5e8218c136f2b744be4cb258 ec2-18-220-255-133.us-east-2.compute.amazonaws.com:6379
+   slots:[10923-16383] (5461 slots) master
+S: 54214adb94bd90ca4ca69d9ca1cf4469594b7b48 ec2-3-133-91-199.us-east-2.compute.amazonaws.com:6379
+   replicates d8965922e7ec90de5e8218c136f2b744be4cb258
+S: 0e088022aabf1d8eaa65fef9b87dd46a9434caf6 ec2-3-142-208-82.us-east-2.compute.amazonaws.com:6379
+   replicates e01e0295b9e1e4129f86c33880f8eb5873c77f05
+S: cadd3b1b0c3975726fbf9859105df8ef60b837d2 ec2-52-15-94-91.us-east-2.compute.amazonaws.com:6379
+   replicates a871235e3fc81a8feee28527c3ae1435d4f9a7f0
+Can I set the above configuration? (type 'yes' to accept): yes
+>>> Nodes configuration updated
+>>> Assign a different config epoch to each node
+>>> Sending CLUSTER MEET messages to join the cluster
+Waiting for the cluster to join
+...
+>>> Performing Cluster Check (using node ec2-18-117-150-63.us-east-2.compute.amazonaws.com:6379)
+M: e01e0295b9e1e4129f86c33880f8eb5873c77f05 ec2-18-117-150-63.us-east-2.compute.amazonaws.com:6379
+   slots:[0-5460] (5461 slots) master
+   1 additional replica(s)
+M: a871235e3fc81a8feee28527c3ae1435d4f9a7f0 172.31.26.201:6379
+   slots:[5461-10922] (5462 slots) master
+   1 additional replica(s)
+M: d8965922e7ec90de5e8218c136f2b744be4cb258 172.31.19.70:6379
+   slots:[10923-16383] (5461 slots) master
+   1 additional replica(s)
+S: cadd3b1b0c3975726fbf9859105df8ef60b837d2 172.31.29.216:6379
+   slots: (0 slots) slave
+   replicates a871235e3fc81a8feee28527c3ae1435d4f9a7f0
+S: 0e088022aabf1d8eaa65fef9b87dd46a9434caf6 172.31.26.125:6379
+   slots: (0 slots) slave
+   replicates e01e0295b9e1e4129f86c33880f8eb5873c77f05
+S: 54214adb94bd90ca4ca69d9ca1cf4469594b7b48 172.31.22.1:6379
+   slots: (0 slots) slave
+   replicates d8965922e7ec90de5e8218c136f2b744be4cb258
+[OK] All nodes agree about slots configuration.
+>>> Check for open slots...
+>>> Check slots coverage...
+[OK] All 16384 slots covered.
+```
+
+## Status of the Redis Cluster
+
+`cluster info` provides **info** style information about Redis Cluster vital parameters.
+```console
+redis-cli -c -h {redis-deployment[n].public_ip} -p 6379 cluster info
+```
+Replace `{redis-deployment[n].public_ip}` with the IP of any of the instances created.
+
+The output should be similar to:
+
+```console
+cluster_state:ok
+cluster_slots_assigned:16384
+cluster_slots_ok:16384
+cluster_slots_pfail:0
+cluster_slots_fail:0
+cluster_known_nodes:6
+cluster_size:3
+cluster_current_epoch:6
+cluster_my_epoch:1
+cluster_stats_messages_ping_sent:482
+cluster_stats_messages_pong_sent:478
+cluster_stats_messages_sent:960
+cluster_stats_messages_ping_received:473
+cluster_stats_messages_pong_received:482
+cluster_stats_messages_meet_received:5
+cluster_stats_messages_received:960
+```
+
+**cluster_state** is **ok** if the node is able to receive queries.
+
+The `cluster nodes` command can be sent to any node in the cluster and provides the state of the cluster and the information for each node according to the local view the queried node has of the cluster.
+```console
+redis-cli -c -h {redis-deployment[n].public_ip} -p 6379 cluster nodes
+```
+The output should be similar to:
+
+```console
+a871235e3fc81a8feee28527c3ae1435d4f9a7f0 172.31.26.201:6379@16379 master - 0 1678791540000 2 connected 5461-10922
+d8965922e7ec90de5e8218c136f2b744be4cb258 172.31.19.70:6379@16379 master - 0 1678791539596 3 connected 10923-16383
+cadd3b1b0c3975726fbf9859105df8ef60b837d2 172.31.29.216:6379@16379 slave a871235e3fc81a8feee28527c3ae1435d4f9a7f0 0 1678791539000 6 connected
+0e088022aabf1d8eaa65fef9b87dd46a9434caf6 172.31.26.125:6379@16379 slave e01e0295b9e1e4129f86c33880f8eb5873c77f05 0 1678791540800 5 connected
+e01e0295b9e1e4129f86c33880f8eb5873c77f05 172.31.23.74:6379@16379 myself,master - 0 1678791539000 1 connected 0-5460
+54214adb94bd90ca4ca69d9ca1cf4469594b7b48 172.31.22.1:6379@16379 slave d8965922e7ec90de5e8218c136f2b744be4cb258 0 1678791541300 4 connected
+```
+
+## Connecting to Redis cluster from local machine
+
+Execute the steps below to connect to the remote Redis server from your local machine.
+1. We need to install redis-tools to interact with redis-server.
+```console
+apt install redis-tools
+```
+2. Connect to redis-server through redis-cli.
+```console
+redis-cli -c -h <public-IP-address> -p 6379
+```
+The output will be:
+```console
+ubuntu@ip-172-31-38-39:~$ redis-cli -c -h ec2-18-117-150-63.us-east-2.compute.amazonaws.com -p 6379
+ec2-18-117-150-63.us-east-2.compute.amazonaws.com:6379>
+```
+3. Try out commands in the redis-cli.              
+The redis-cli will run in interactive mode. We can connect to any of the nodes, the command will get redirected to primary node.
+```console
+ec2-18-117-150-63.us-east-2.compute.amazonaws.com:6379> ping
+PONG
+ec2-18-117-150-63.us-east-2.compute.amazonaws.com:6379> set name test
+-> Redirected to slot [5798] located at 172.31.26.201:6379
+OK
+172.31.26.201:6379> get name
+"test"
+172.31.26.201:6379> set ans sample
+-> Redirected to slot [2698] located at 172.31.23.74:6379
+OK
+172.31.23.74:6379> get ans
+"sample"
+172.31.23.74:6379> get name
+-> Redirected to slot [5798] located at 172.31.26.201:6379
+"test"
+172.31.26.201:6379>
+```
+You have successfully installed Redis in a multi-node configuration.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```
+


### PR DESCRIPTION
- Add section to deploy Redis on a single AWS Arm based instance.
- Add section to deploy Redis on a single Azure Arm based instance.
- Add section to deploy Redis on a single GCP Arm based instance.
- Add section to deploy Redis with a docker container on a single node.
- Add section to deploy Redis in a multi-node configuration.