### PR TITLE
Add learning path to deploy Memcached as a cache for MySQL

### DIFF
--- a/content/learning-paths/server-and-cloud/memcached/_index.md
+++ b/content/learning-paths/server-and-cloud/memcached/_index.md
@@ -8,13 +8,17 @@ layout: learningpathall
 learning_objectives:
 - Install and run memcached on your Arm-based cloud server
 - Use an open-source benchmark to test memcached performance
+- Deploy memcached as a cache for MySQL
 learning_path_main_page: 'yes'
-minutes_to_complete: 10
+minutes_to_complete: 40
 operatingsystems:
 - Linux
 prerequisites:
-- An Arm based instance from an appropriate cloud service provider.
-skilllevels: Introductory
+- An Amazon Web Services (AWS) [account](https://aws.amazon.com/)
+- An Azure portal [account](https://azure.microsoft.com/en-in/get-started/azure-portal)
+- A Google Cloud [account](https://console.cloud.google.com/)
+- A machine with [Terraform](/install-guides/terraform/), [AWS CLI](/install-guides/aws-cli), [Google Cloud CLI](/install-guides/gcloud), [Azure CLI](/install-guides/azure-cli), [AWS IAM authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html), and [Ansible](/install-guides/ansible/) installed
+skilllevels: Advanced
 subjects: Web
 test_images:
 - ubuntu:latest
@@ -26,7 +30,6 @@ title: Run memcached on Arm servers and measure its performance
 tools_software_languages:
 - Memcached
 weight: 1
-who_is_this_for: This is an introductory topic for software developers who want to
-  use memcached as their in-memory key-value store for mobile, web, gaming or e-Commerce
-  applications.
+who_is_this_for: This is an advanced topic for developers who want to use memcached as their in-memory key-value store.
+
 ---

--- a/content/learning-paths/server-and-cloud/memcached/memcached.md
+++ b/content/learning-paths/server-and-cloud/memcached/memcached.md
@@ -1,6 +1,6 @@
 ---
 layout: learningpathall
-title: Run Memcached on Arm servers
+title: Run and test Memcached on Arm servers
 weight: 2
 ---
 

--- a/content/learning-paths/server-and-cloud/memcached/memcached_mysql_aws.md
+++ b/content/learning-paths/server-and-cloud/memcached/memcached_mysql_aws.md
@@ -1,0 +1,651 @@
+---
+# User change
+title: "Deploy Memcached as a cache for MySQL on an AWS Arm based Instance"
+
+weight: 3 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Deploy Memcached as a cache for MySQL on an AWS Arm based Instance
+
+You can deploy Memcached as a cache for MySQL on an AWS Arm based Instance using Terraform and Ansible. 
+
+In this section, you will deploy Memcached as a cache for MySQL on an AWS Instance. 
+
+If you are new to Terraform, you should look at [Automate AWS EC2 instance creation using Terraform](/learning-paths/server-and-cloud/aws-terraform/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need an [AWS account](https://portal.aws.amazon.com/billing/signup?nc2=h_ct&src=default&redirect_url=https%3A%2F%2Faws.amazon.com%2Fregistration-confirmation#/start) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin, you will also need:
+- An AWS access key ID and secret access key. 
+- An SSH key pair
+
+The instructions to create the keys are below.
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for AWS EC2 access. To generate the key-pair, follow this [
+documentation](/install-guides/ssh#ssh-keys).
+
+{{% notice Note %}}
+If you already have an SSH key-pair present in the `~/.ssh` directory, you can skip this step.
+{{% /notice %}}
+
+
+### Generate AWS access keys 
+
+Terraform requires AWS authentication to create AWS resources. You can generate access keys (access key ID and secret access key) to perform authentication. Terraform uses the access keys to make calls to AWS using the AWS CLI. 
+
+To generate an access key and secret access key, follow the [steps from the Terraform Learning Path](/learning-paths/server-and-cloud/aws-terraform/terraform#generate-access-keys-access-key-id-and-secret-access-key).
+
+## Create an AWS EC2 instance using Terraform
+
+Using a text editor, save the code below in a file called `main.tf`.
+    
+```console
+provider "aws" {
+  region = "us-east-2"
+  access_key  = "AXXXXXXXXXXXXXXXXXXX"
+  secret_key   = "AXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}
+  resource "aws_instance" "MYSQL_TEST" {
+  count         = "2"
+  ami           = "ami-0ca2eafa23bc3dd01"
+  instance_type = "t4g.small"
+  security_groups= [aws_security_group.Terraformsecurity1.name]
+  key_name = "id_rsa"
+  tags = {
+    Name = "MYSQL_TEST"
+  }
+
+resource "aws_default_vpc" "main" {
+  tags = {
+    Name = "main"
+  }
+}
+resource "aws_security_group" "Terraformsecurity1" {
+  name        = "Terraformsecurity1"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = aws_default_vpc.main.id
+
+  ingress {
+    description      = "TLS from VPC"
+    from_port        = 3306
+    to_port          = 3306
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+}
+  ingress {
+    description      = "TLS from VPC"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "Terraformsecurity1"
+  }
+
+ }
+resource "local_file" "inventory" {
+    depends_on=[aws_instance.MYSQL_TEST]
+    filename = "(your_current_directory)/hosts"
+    content = <<EOF
+[mysql1]
+${aws_instance.MYSQL_TEST[0].public_ip}
+[mysql2]
+${aws_instance.MYSQL_TEST[1].public_ip}
+[all:vars]
+ansible_connection=ssh
+ansible_user=ubuntu
+                EOF
+}
+
+resource "aws_key_pair" "deployer" {
+        key_name   = "id_rsa"
+        public_key = file("~/.ssh/id_rsa.pub")
+} 
+    
+```
+Make the changes listed below in `main.tf` to match your account settings.
+
+1. In the `provider` section, update all 3 values to use your preferred AWS region and your AWS access key ID and secret access key.
+
+2. (optional) In the `aws_instance` section, change the ami value to your preferred Linux distribution. The AMI ID for Ubuntu 22.04 on Arm is `ami-0ca2eafa23bc3dd01`. No change is needed if you want to use Ubuntu AMI. 
+
+{{% notice Note %}}
+The instance type is t4g.small. This is an Arm-based instance and requires an Arm Linux distribution.
+{{% /notice %}}
+
+3. In the `local_file` section, change the `filename` to be the path to your current directory.
+
+The hosts file is automatically generated and does not need to be changed, change the path to the location of the hosts file.
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for AWS.
+
+```console
+terraform init
+```
+    
+The output should be similar to:
+
+```output
+Initializing the backend...
+
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/aws from the dependency lock file
+- Using previously-installed hashicorp/local v2.3.0
+- Using previously-installed hashicorp/aws v4.52.0
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```console
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all AWS resources.
+
+```console
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create AWS resources.
+
+The output should be similar to:
+
+```output
+Apply complete! Resources: 6 added, 0 changed, 0 destroyed.
+```
+
+## Configure MySQL through Ansible
+
+Install MySQL and the required dependencies.
+
+Using a text editor, save the code below in a file called `playbook.yaml`. This Playbook installs & enables MySQL in the instances and creates databases inside them.
+
+```console
+---
+- hosts: mysql1, mysql2
+  remote_user: root
+  become: true
+
+  tasks:
+    - name: Update the Machine and Install dependencies
+      shell: |
+             apt-get update -y
+             apt-get -y install mysql-server
+             apt -y install python3-pip
+             pip3 install PyMySQL
+    - name: start and enable mysql service
+      service:
+        name: mysql
+        state: started
+        enabled: yes
+    - name: Change Root Password
+      shell: sudo mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '{{Your_mysql_password}}'"
+    - name: Create database user with password and all database privileges and 'WITH GRANT OPTION'
+      mysql_user:
+         login_user: root
+         login_password: {{Your_mysql_password}}
+         login_host: localhost
+         name: Local_user
+         host: '%'
+         password: {{Give_any_password}}
+         priv: '*.*:ALL,GRANT'
+         state: present
+    - name: Create a new database with name 'arm_test1'
+      when: "'mysql1' in group_names"
+      community.mysql.mysql_db:
+        name: arm_test1
+        login_user: root
+        login_password: {{Your_mysql_password}}
+        login_host: localhost
+        state: present
+        login_unix_socket: /run/mysqld/mysqld.sock
+    - name: Create a new database with name 'arm_test2'
+      when: "'mysql2' in group_names"
+      community.mysql.mysql_db:
+        name: arm_test2
+        login_user: root
+        login_password: {{Your_mysql_password}}
+        login_host: localhost
+        state: present
+        login_unix_socket: /run/mysqld/mysqld.sock
+    - name: MySQL secure installation
+      become: yes
+      expect:
+        command: mysql_secure_installation
+        responses:
+           'Enter current password for root': '{{Your_mysql_password}}'
+           'Set root password': 'n'
+           'Remove anonymous users': 'y'
+           'Disallow root login remotely': 'n'
+           'Remove test database': 'y'
+           'Reload privilege tables now': 'y'
+        timeout: 1
+      register: secure_mysql
+      failed_when: "'... Failed!' in secure_mysql.stdout_lines"
+    - name: Enable remote login by changing bind-address
+      lineinfile:
+         path: /etc/mysql/mysql.conf.d/mysqld.cnf
+         regexp: '^bind-address'
+         line: 'bind-address = 0.0.0.0'
+         backup: yes
+      notify:
+         - Restart mysql
+  handlers:
+    - name: Restart mysql
+      service:
+        name: mysql
+        state: restarted
+```
+
+Replace `{{Your_mysql_password}}` and `{{Give_any_password}}` in this file with your own password.
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the  `ansible-playbook` command:
+
+```console
+ansible-playbook playbook.yaml -i hosts --key-file ~/.ssh/id_rsa
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```output
+ubuntu@ip-172-31-38-39:~/aws-mysql$ ansible-playbook mysqlmodule.yml -i hosts --key-file ~/.ssh/id_rsa
+
+PLAY [mysql1, mysql2] ********************************************************************************************************************************************
+
+TASK [Gathering Facts] *******************************************************************************************************************************************
+The authenticity of host '13.59.220.179 (13.59.220.179)' can't be established.
+ED25519 key fingerprint is SHA256:6NBcdhBr1+nppeL27zwkXOTVnWUZGRQYVUuJOkQvGY4.
+This key is not known by any other names
+The authenticity of host '3.15.227.23 (3.15.227.23)' can't be established.
+ED25519 key fingerprint is SHA256:0tq05+K/EPSM7rDFQBESqO3feDbk+F3XmZgjOpi6+jM.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+yes
+ok: [13.59.220.179]
+ok: [3.15.227.23]
+
+TASK [Update the Machine and Install dependencies] ***************************************************************************************************************
+changed: [13.59.220.179]
+changed: [3.15.227.23]
+
+TASK [start and enable mysql service] ****************************************************************************************************************************
+ok: [13.59.220.179]
+ok: [3.15.227.23]
+
+TASK [Change Root Password] **************************************************************************************************************************************
+changed: [13.59.220.179]
+changed: [3.15.227.23]
+
+TASK [Create database user with password and all database privileges and 'WITH GRANT OPTION'] ********************************************************************
+changed: [13.59.220.179]
+changed: [3.15.227.23]
+
+TASK [Create a new database with name 'arm_test1'] ***************************************************************************************************************
+skipping: [3.15.227.23]
+changed: [13.59.220.179]
+
+TASK [Create a new database with name 'arm_test2'] ***************************************************************************************************************
+skipping: [13.59.220.179]
+changed: [3.15.227.23]
+
+TASK [MySQL secure installation] *********************************************************************************************************************************
+changed: [3.15.227.23]
+changed: [13.59.220.179]
+
+TASK [Enable remote login by changing bind-address] **************************************************************************************************************
+changed: [3.15.227.23]
+changed: [13.59.220.179]
+
+RUNNING HANDLER [Restart mysql] **********************************************************************************************************************************
+changed: [13.59.220.179]
+changed: [3.15.227.23]
+
+PLAY RECAP *******************************************************************************************************************************************************
+13.59.220.179              : ok=9    changed=7    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+3.15.227.23                : ok=9    changed=7    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+```
+
+## Connect to Database from local machine
+
+To connect to the database, you need the `public-ip` of the instance where MySQL is deployed. You also need to use the MySQL Client to interact with the MySQL database.
+
+```console
+apt install mysql-client
+```
+
+```console
+mysql -h {public_ip of instance where Mysql deployed} -P3306 -u {user of database} -p{password of database}
+```
+Replace `{public_ip of instance where Mysql deployed}`, `{user of database}` and `{password of database}` with your values. In this example, `user`= `Local_user`, which is getting created in the `playbook.yaml` file. 
+
+The output will be:
+```output
+ubuntu@ip-172-31-38-39:~/aws-mysql$ mysql -h 13.59.220.179 -P3306 -u Local_user -p
+Enter password:
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 9
+Server version: 8.0.32-0ubuntu0.22.04.2 (Ubuntu)
+
+Copyright (c) 2000, 2023, Oracle and/or its affiliates.
+
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+mysql>
+```
+
+### Access Database and Create Table
+
+1. You can access your database by using the below commands.
+
+```console
+show databases;
+```
+
+```console
+use {your_database};
+```
+
+The output will be:
+
+```output
+mysql> show databases;
++--------------------+
+| Database           |
++--------------------+
+| arm_test1          |
+| information_schema |
+| mysql              |
+| performance_schema |
+| sys                |
++--------------------+
+5 rows in set (0.00 sec)
+mysql> use arm_test1;
+Database changed
+```
+
+2. Use the below commands to create a table and insert values into it.
+
+```console
+create table book(name char(10),id varchar(10));
+```
+```console
+insert into book(name,id) values ('Abook','10'),('Bbook','20'),('Cbook','20'),('Dbook','30'),('Ebook','45'),('Fbook','40'),('Gbook
+','69');
+```
+
+The output will be:
+
+```output
+mysql> create table book(name char(10),id varchar(10));
+Query OK, 0 rows affected (0.03 sec)
+
+mysql> insert into book(name,id) values ('Abook','10'),('Bbook','20'),('Cbook','20'),('Dbook','30'),('Ebook','45'),('Fbook','40'),('Gbook
+    '> ','69');
+Query OK, 7 rows affected (0.01 sec)
+Records: 7  Duplicates: 0  Warnings: 0
+
+```
+
+3. Use the below command to access the content of the table.
+
+```console
+select * from {{your_table_name}};
+```
+
+The output will be:
+
+```output
+mysql> select * from book
+    -> ;
++--------+------+
+| name   | id   |
++--------+------+
+| Abook  | 10   |
+| Bbook  | 20   |
+| Cbook  | 20   |
+| Dbook  | 30   |
+| Ebook  | 45   |
+| Fbook  | 40   |
+| Gbook
+ | 69   |
++--------+------+
+7 rows in set (0.00 sec)
+```
+
+4. Now connect to the second instance and repeat the above steps with a different data as shown below.    
+       
+The output will be:
+
+```output
+mysql> show databases;
++--------------------+
+| Database           |
++--------------------+
+| arm_test2          |
+| information_schema |
+| mysql              |
+| performance_schema |
+| sys                |
++--------------------+
+5 rows in set (0.00 sec)
+
+mysql> use arm_test2;
+Database changed
+mysql> create table movie(name char(10),id varchar(10));
+Query OK, 0 rows affected (0.02 sec)
+
+mysql> insert into movie(name,id) values ('Amovie','1'), ('Bmovie','2'), ('Cmovie','3'), ('Dmovie','4'), ('Emovie','5'), ('Fmovie','6'), ('Gmovie','7');
+Query OK, 7 rows affected (0.01 sec)
+Records: 7  Duplicates: 0  Warnings: 0
+
+mysql> select * from movie;
++--------+------+
+| name   | id   |
++--------+------+
+| Amovie | 1    |
+| Bmovie | 2    |
+| Cmovie | 3    |
+| Dmovie | 4    |
+| Emovie | 5    |
+| Fmovie | 6    |
+| Gmovie | 7    |
++--------+------+
+7 rows in set (0.00 sec)
+```
+
+## Deploy Memcached as a cache for MySQL using Python
+
+You will create two `.py` files on the host machine to deploy Memcached as a MySQL cache using Python: `values.py` and `memcached.py`.  
+
+`values.py` to store the IP addresses of the instances and the databases created in them.
+```console
+MYSQL_TEST=[["{{public_ip of MYSQL_TEST[0]}}", "arm_test1"],
+["{{public_ip of MYSQL_TEST[1]}}", "arm_test2"]]
+```
+Replace `{{public_ip of MYSQL_TEST[0]}}` & `{{public_ip of MYSQL_TEST[1]}}` with the public IPs generated in the `hosts` file after running the Terraform commands.       
+`memcached.py` to access data from Memcached and, if not present, store it in the Memcached.       
+```console
+import sys
+import MySQLdb
+import pymemcache
+from values import *
+from ast import literal_eval
+import argparse
+parser = argparse.ArgumentParser()
+
+parser.add_argument("-db", "--database", help="Database")
+parser.add_argument("-k", "--key", help="Key")
+parser.add_argument("-q", "--query", help="Query")
+args = parser.parse_args()
+
+memc = pymemcache.Client("127.0.0.1:11211");
+
+for i in range(0,2):
+    if (MYSQL_TEST[i][1]==args.database):
+        try:
+            conn = MySQLdb.connect (host = MYSQL_TEST[i][0],
+                                    user = "{{Your_database_user}}",
+                                    passwd = "{{Your_database_password}}",
+                                    db = MYSQL_TEST[i][1])
+        except MySQLdb.Error as e:
+             print ("Error %d: %s" % (e.args[0], e.args[1]))
+             sys.exit (1)
+
+        sqldata = memc.get(args.key)
+
+        if not sqldata:
+            cursor = conn.cursor()
+            cursor.execute(args.query)
+            rows = cursor.fetchall()
+            memc.set(args.key,rows,120)
+            print ("Updated memcached with MySQL data")
+            for x in rows:
+                print(x)
+        else:
+            print ("Loaded data from memcached")
+            data = tuple(literal_eval(sqldata.decode("utf-8")))
+            for row in data:
+                print (f"{row[0]},{row[1]}")
+        break
+else:
+    print("this database doesn't exist")            
+```
+Replace `{{Your_database_user}}` & `{{Your_database_password}}` with the database user and password created through Ansible-Playbook. Also change the `range` in `for loop` according to the number of instances created.
+
+To execute the script, run the following command:
+```console
+python3 mem.py -db {database_name} -k {key} -q {query}
+```
+Replace `{database_name}` with the database you want to access, `{query}` with the query you want to run in the database, and `{key}` with a variable to store the result of the query in Memcached.
+
+When the script is executed for the first time, the data is loaded from the MySQL database and stored on the Memcached server.
+
+The output will be:
+```output
+ubuntu@ip-172-31-38-39:~/aws-mysql$ python3 memcached.py -db arm_test1 -k AA -q "select * from book limit 3"
+Updated memcached with MySQL data
+('Abook', '10')
+('Bbook', '20')
+('Cbook', '20')
+```
+```output
+ubuntu@ip-172-31-38-39:~/aws-mysql$ python3 memcached.py -db arm_test2 -k BB -q "select * from movie limit 3"
+Updated memcached with MySQL data
+('Amovie', '1')
+('Bmovie', '2')
+('Cmovie', '3')
+```
+
+When executed after that, it loads the data from Memcached. In the example above, the information stored in Memcached is in the form of rows from a Python DB cursor. When accessing the information (within the 120-second expiry time), the data is loaded from Memcached and dumped.
+
+The output will be:
+```output
+ubuntu@ip-172-31-38-39:~/aws-mysql$ python3 memcached.py -db arm_test1 -k AA -q "select * from book limit 3"
+Loaded data from memcached
+Abook,10
+Bbook,20
+Cbook,20
+```
+
+```output
+ubuntu@ip-172-31-38-39:~/aws-mysql$ python3 memcached.py -db arm_test2 -k BB -q "select * from movie limit 3"
+Loaded data from memcached
+Amovie,1
+Bmovie,2
+Cmovie,3
+```
+
+### Memcached Telnet Commands
+
+Execute the steps below to verify that the MySQL query is getting stored in Memcached.
+1. Connect to the Memcached server with Telnet and start a session.
+```console
+telnet localhost 11211
+```
+2. Retrieve data from Memcached through Telnet.
+```console
+get <key>
+```
+**NOTE:-** Key is the variable in which we store the data. In the above command, we are storing the data from the tables `book` and `movie` in `AA` and `BB` respectively.
+
+The output will be:
+
+```output
+ubuntu@ip-172-31-38-39:~/aws-mysql$ telnet localhost 11211
+Trying 127.0.0.1...
+Connected to localhost.
+Escape character is '^]'.
+get AA
+VALUE AA 0 51
+(('Abook', '10'), ('Bbook', '20'), ('Cbook', '20'))
+END
+get BB
+VALUE BB 0 51
+(('Amovie', '1'), ('Bmovie', '2'), ('Cmovie', '3'))
+END
+```
+
+You have successfully deployed Memcached as a cache for MySQL on an AWS Arm based Instance.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```
+
+Continue the Learning Path to deploy Memcached as a cache for MySQL on an Azure Arm based Instance.
+

--- a/content/learning-paths/server-and-cloud/memcached/memcached_mysql_azure.md
+++ b/content/learning-paths/server-and-cloud/memcached/memcached_mysql_azure.md
@@ -1,0 +1,415 @@
+---
+# User change
+title: "Deploy Memcached as a cache for MySQL on an Azure Arm based Instance"
+
+weight: 4 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Deploy Memcached as a cache for MySQL on an Azure Arm based Instance
+
+You can deploy Memcached as a cache for MySQL on Azure using Terraform and Ansible. 
+
+In this section, you will deploy Memcached as a cache for MySQL on an Azure instance. 
+
+If you are new to Terraform, you should look at [Automate Azure instance creation using Terraform](/learning-paths/server-and-cloud/azure/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need an [Azure portal account](https://azure.microsoft.com/en-in/get-started/azure-portal) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin, you will also need:
+- Login to the Azure CLI
+- An SSH key pair
+
+The instructions to login to the Azure CLI and create the keys are below.
+
+### Azure authentication
+
+The installation of Terraform on your Desktop/Laptop needs to communicate with Azure. Thus, Terraform needs to be authenticated.
+
+For authentication, follow the [steps from the Terraform Learning Path](/learning-paths/server-and-cloud/azure/terraform#azure-authentication).
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for Azure instance access. To generate the key-pair, follow this [
+documentation](/install-guides/ssh#ssh-keys).
+
+{{% notice Note %}} 
+If you already have an SSH key-pair present in the `~/.ssh` directory, you can skip this step.
+{{% /notice %}}
+
+## Create Azure instances using Terraform
+
+For Azure Arm based instance deployment, the Terraform configuration is broken into three files: `providers.tf`, `variables.tf` and `main.tf`. Here we are creating 2 instances.
+
+Add the following code in `providers.tf` file to configure Terraform to communicate with Azure.
+    
+```console
+terraform {
+  required_version = ">=0.12"
+
+  required_providers {
+    azurerm = {
+      source= "hashicorp/azurerm"
+      version = "~>2.0"
+    }
+    random = {
+      source= "hashicorp/random"
+      version = "~>3.0"
+    }
+    tls = {
+    source = "hashicorp/tls"
+    version = "~>4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+    
+```
+Create a `variables.tf` file for describing the variables referenced in the other files with their type and a default value.
+
+```console
+variable "resource_group_location" {
+  default = "eastus2"
+  description = "Location of the resource group."
+}
+
+variable "resource_group_name_prefix" {
+  default = "rg"
+  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+}
+```
+
+Add the resources required to create a virtual machine in `main.tf`.
+
+```console
+resource "random_pet" "rg_name" {
+  prefix = var.resource_group_name_prefix
+}
+
+resource "azurerm_resource_group" "rg" {
+  location = var.resource_group_location
+  name = random_pet.rg_name.id
+}
+
+# Create virtual network
+resource "azurerm_virtual_network" "my_terraform_network" {
+  name = "myVnet"
+  address_space = ["10.1.0.0/16"]
+  location = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+# Create subnet
+resource "azurerm_subnet" "my_terraform_subnet" {
+  name = "mySubnet"
+  resource_group_name = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.my_terraform_network.name
+  address_prefixes = ["10.1.1.0/24"]
+}
+
+# Create Public IPs
+resource "azurerm_public_ip" "my_terraform_public_ip" {
+  name = "myPublicIP${format("%02d", count.index)}-test"
+  count= 2
+  location = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method = "Dynamic"
+}
+
+# Create Network Security Group and rule
+resource "azurerm_network_security_group" "my_terraform_nsg" {
+  name= "myNetworkSecurityGroup"
+  location= azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  security_rule {
+    name= "SSH"
+    priority= 1001
+    direction= "Inbound"
+    access = "Allow"
+    protocol= "Tcp"
+    source_port_range= "*"
+    destination_port_range = "22"
+    source_address_prefix= "*"
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name= "MYSQL"
+    priority= 1002
+    direction= "Inbound"
+    access = "Allow"
+    protocol= "Tcp"
+    source_port_range= "*"
+    destination_port_range = "3306"
+    source_address_prefix= "*"
+    destination_address_prefix = "*"
+  }
+}
+
+# Create network interface
+resource "azurerm_network_interface" "my_terraform_nic" {
+  count= 2
+  name= "NIC-${format("%02d", count.index)}-test"
+  location= azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  ip_configuration {
+    name= "my_nic_configuration"
+    subnet_id = azurerm_subnet.my_terraform_subnet.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id= azurerm_public_ip.my_terraform_public_ip.*.id[count.index]
+  }
+}
+
+# Connect the security group to the network interface
+resource "azurerm_network_interface_security_group_association" "example" {
+  count= 2
+  network_interface_id= azurerm_network_interface.my_terraform_nic.*.id[count.index]
+  network_security_group_id = azurerm_network_security_group.my_terraform_nsg.id
+}
+
+# Generate random text for a unique storage account name
+resource "random_id" "random_id" {
+  keepers = {
+    # Generate a new ID only when a new resource group is defined
+    resource_group = azurerm_resource_group.rg.name
+  }
+
+  byte_length = 8
+}
+
+# Create storage account for boot diagnostics
+resource "azurerm_storage_account" "my_storage_account" {
+  name = "diag${random_id.random_id.hex}"
+  location = azurerm_resource_group.rg.location
+  resource_group_name= azurerm_resource_group.rg.name
+  account_tier = "Standard"
+  account_replication_type = "LRS"
+}
+
+# Create virtual machine
+resource "azurerm_linux_virtual_machine" "MYSQL_TEST" {
+  name= "MYSQL_TEST${format("%02d", count.index + 1)}"
+  count= 2
+  location= azurerm_resource_group.rg.location
+  resource_group_name= azurerm_resource_group.rg.name
+  network_interface_ids = [azurerm_network_interface.my_terraform_nic.*.id[count.index]]
+  size= "Standard_D2ps_v5"
+
+  os_disk {
+    name = "myOsDisk${format("%02d", count.index + 1)}"
+    caching= "ReadWrite"
+    storage_account_type = "Premium_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer = "0001-com-ubuntu-server-focal"
+    sku= "20_04-lts-arm64"
+    version= "20.04.202209200"
+  }
+
+  computer_name= "myvm"
+  admin_username= "ubuntu"
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username= "ubuntu"
+    public_key = file("~/.ssh/id_rsa.pub")
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.my_storage_account.primary_blob_endpoint
+  }
+}
+resource "local_file" "inventory" {
+    depends_on=[azurerm_linux_virtual_machine.MYSQL_TEST]
+    filename = "(your_current_directory)/hosts"
+    content = <<EOF
+[mysql1]
+${azurerm_linux_virtual_machine.MYSQL_TEST[0].public_ip_address}
+[mysql2]
+${azurerm_linux_virtual_machine.MYSQL_TEST[1].public_ip_address}
+[all:vars]
+ansible_connection=ssh
+ansible_user=ubuntu
+                EOF
+}
+```
+In the `local_file` section, change the `filename` to be the path to your current directory.
+
+The hosts file is automatically generated and does not need to be changed, change the path to the location of the hosts file.
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for Azure.
+
+```console
+terraform init
+```
+    
+The output should be similar to:
+
+```output
+Initializing the backend...
+
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/tls from the dependency lock file
+- Reusing previous version of hashicorp/azurerm from the dependency lock file
+- Reusing previous version of hashicorp/random from the dependency lock file
+- Using previously-installed hashicorp/local v2.4.0
+- Using previously-installed hashicorp/tls v4.0.4
+- Using previously-installed hashicorp/azurerm v2.99.0
+- Using previously-installed hashicorp/random v3.4.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```console
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all Azure resources. 
+
+```console
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create Azure resources. 
+
+The output should be similar to:
+
+```output
+Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
+```
+
+## Configure MySQL through Ansible
+
+Install MySQL and the required dependencies on both the inastances.
+
+You can use the same `playbook.yaml` file used in the section, [Deploy Memcached as a cache for MySQL on an AWS Arm based Instance](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#configure-mysql-through-ansible).
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the  `ansible-playbook` command:
+
+```console
+ansible-playbook playbook.yaml -i hosts --key-file ~/.ssh/id_rsa
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```output
+ubuntu@ip-172-31-38-39:~/azure-mysql$ ansible-playbook playbook.yaml -i hosts --key-file ~/.ssh/id_rsa
+
+PLAY [mysql1, mysql2] ********************************************************************************************************************************************
+
+TASK [Gathering Facts] *******************************************************************************************************************************************
+The authenticity of host '20.114.166.37 (20.114.166.37)' can't be established.
+ED25519 key fingerprint is SHA256:AFYNvATg2zT/PQJ8I5Qr0JKO+3Jwq6lGYSex4/2gDKs.
+This key is not known by any other names
+The authenticity of host '20.114.166.67 (20.114.166.67)' can't be established.
+ED25519 key fingerprint is SHA256:0gpYKMdRIHpFxaXePtYFxs+k6JSioKcVEN6CMrCJUBA.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+yes
+ok: [20.114.166.37]
+ok: [20.114.166.67]
+
+TASK [Update the Machine and Install dependencies] ***************************************************************************************************************
+changed: [20.114.166.37]
+changed: [20.114.166.67]
+
+TASK [start and enable mysql service] ****************************************************************************************************************************
+ok: [20.114.166.67]
+ok: [20.114.166.37]
+
+TASK [Change Root Password] **************************************************************************************************************************************
+changed: [20.114.166.37]
+changed: [20.114.166.67]
+
+TASK [Create database user with password and all database privileges and 'WITH GRANT OPTION'] ********************************************************************
+changed: [20.114.166.37]
+changed: [20.114.166.67]
+
+TASK [Create a new database with name 'arm_test1'] ***************************************************************************************************************
+skipping: [20.114.166.67]
+changed: [20.114.166.37]
+
+TASK [Create a new database with name 'arm_test2'] ***************************************************************************************************************
+skipping: [20.114.166.37]
+changed: [20.114.166.67]
+
+TASK [MySQL secure installation] *********************************************************************************************************************************
+changed: [20.114.166.67]
+changed: [20.114.166.37]
+
+TASK [Enable remote login by changing bind-address] **************************************************************************************************************
+changed: [20.114.166.67]
+changed: [20.114.166.37]
+
+RUNNING HANDLER [Restart mysql] **********************************************************************************************************************************
+changed: [20.114.166.67]
+changed: [20.114.166.37]
+
+PLAY RECAP *******************************************************************************************************************************************************
+20.114.166.37              : ok=9    changed=7    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+20.114.166.67              : ok=9    changed=7    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+```
+
+## Connect to Database from local machine
+
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#connect-to-database-from-local-machine) to connect to the database from local machine.
+
+## Deploy Memcached as a cache for MySQL using Python
+
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#deploy-memcached-as-a-cache-for-mysql-using-python) to deploy Memcached as a cache for MySQL using Python.
+
+You have successfully deployed Memcached as a cache for MySQL on an Azure Arm based Instance.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```
+
+Continue the Learning Path to deploy Memcached as a cache for MySQL on a GCP Arm based Instance.
+

--- a/content/learning-paths/server-and-cloud/memcached/memcached_mysql_gcp.md
+++ b/content/learning-paths/server-and-cloud/memcached/memcached_mysql_gcp.md
@@ -1,0 +1,285 @@
+---
+# User change
+title: "Deploy Memcached as a cache for MySQL on a Google Cloud Arm based Instance"
+
+weight: 5 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Deploy Memcached as a cache for MySQL on a Google Cloud Arm based Instance
+
+You can deploy Memcached as a cache for MySQL on Google Cloud using Terraform and Ansible. 
+
+In this section, you will deploy Memcached as a cache for MySQL on a Google Cloud instance.
+
+If you are new to Terraform, you should look at [Automate GCP instance creation using Terraform](/learning-paths/server-and-cloud/gcp/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need a [Google Cloud account](https://console.cloud.google.com/?hl=en-au) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin you will also need:
+- Login to the Google Cloud CLI 
+- An SSH key pair
+
+The instructions to login to the Google Cloud CLI and create the keys are below.
+
+### Acquire user credentials
+
+To obtain user access credentials, follow the [steps from the Terraform Learning Path](/learning-paths/server-and-cloud/gcp/terraform#acquire-user-credentials).
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for GCP instance access. To generate the key-pair, follow this [
+documentation](/install-guides/ssh#ssh-keys).
+
+{{% notice Note %}} 
+If you already have an SSH key-pair present in the `~/.ssh` directory, you can skip this step.
+{{% /notice %}}
+
+## Create GCP instances using Terraform
+
+Using a text editor, save the code below in a file called `main.tf`. Here we are creating 2 instances.
+    
+```console
+provider "google" {
+  project = "{project_id}"
+  region = "us-central1"
+  zone = "us-central1-a"
+}
+
+resource "google_compute_instance" "MYSQL_TEST" {
+  name         = "mysqltest-${count.index+1}"
+  count        = "2"
+  machine_type = "t2a-standard-1"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts-arm64"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+  metadata = {
+     ssh-keys = "ubuntu:${file("~/.ssh/id_rsa.pub")}"
+  }  
+}
+
+resource "google_compute_firewall" "rules" {
+  project     = "{project_id}"
+  name        = "my-firewall-rule"
+  network     = "default"
+  description = "Open ssh connection and mysql port"
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol  = "tcp"
+    ports     = ["22", "3306"]
+  }
+}
+
+resource "google_compute_network" "default" {
+  name = "test-network1"
+}
+resource "local_file" "inventory" {
+    depends_on=[google_compute_instance.MYSQL_TEST]
+    filename = "(your_current_directory)/hosts"
+    content = <<EOF
+[mysql1]
+${google_compute_instance.MYSQL_TEST[0].network_interface.0.access_config.0.nat_ip}
+[mysql2]
+${google_compute_instance.MYSQL_TEST[1].network_interface.0.access_config.0.nat_ip}
+[all:vars]
+ansible_connection=ssh
+ansible_user=ubuntu
+                EOF
+}
+```
+Make the changes listed below in `main.tf` to match your account settings.
+
+1. In the `provider` and `google_compute_firewall` sections, update the `project_id` with your value.
+
+2. In the `local_file` section, change the `filename` to be the path to your current directory.
+
+The hosts file is automatically generated and does not need to be changed, change the path to the location of the hosts file.
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for GCP.
+
+```console
+terraform init
+```
+    
+The output should be similar to:
+
+```output
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding latest version of hashicorp/google...
+- Finding latest version of hashicorp/local...
+- Installing hashicorp/google v4.57.0...
+- Installed hashicorp/google v4.57.0 (signed by HashiCorp)
+- Installing hashicorp/local v2.4.0...
+- Installed hashicorp/local v2.4.0 (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```console
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all GCP resources. 
+
+```console
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create GCP resources. 
+
+The output should be similar to:
+
+```output
+Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
+
+```
+
+## Configure MySQL through Ansible
+
+Install MySQL and the required dependencies on both the instances. 
+
+You can use the same `playbook.yaml` file used in the section, [Deploy Memcached as a cache for MySQL on an AWS Arm based Instance](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#configure-mysql-through-ansible).
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the `ansible-playbook` command:
+
+```console
+ansible-playbook playbook.yaml -i hosts --key-file ~/.ssh/id_rsa
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```output
+ubuntu@ip-172-31-38-39:~/gcp-mysql$ ansible-playbook playbook.yaml -i hosts --key-file ~/.ssh/id_rsa
+
+PLAY [mysql1, mysql2] ********************************************************************************************************************************************
+
+TASK [Gathering Facts] *******************************************************************************************************************************************
+The authenticity of host '34.28.237.71 (34.28.237.71)' can't be established.
+ED25519 key fingerprint is SHA256:xOr4xr3TvaRdPxX4QlxhYpjf9mykgmhAtWElxkhqK3w.
+This key is not known by any other names
+The authenticity of host '35.222.119.249 (35.222.119.249)' can't be established.
+ED25519 key fingerprint is SHA256:gHsDuIJ9IVFrOeeYUZXMEvFOu5tXL0ZB78aHwZjooTI.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+yes
+ok: [34.28.237.71]
+ok: [35.222.119.249]
+
+TASK [Update the Machine and Install dependencies] ***************************************************************************************************************
+changed: [35.222.119.249]
+changed: [34.28.237.71]
+
+TASK [start and enable mysql service] ****************************************************************************************************************************
+ok: [34.28.237.71]
+ok: [35.222.119.249]
+
+TASK [Change Root Password] **************************************************************************************************************************************
+changed: [34.28.237.71]
+changed: [35.222.119.249]
+
+TASK [Create database user with password and all database privileges and 'WITH GRANT OPTION'] ********************************************************************
+changed: [34.28.237.71]
+changed: [35.222.119.249]
+
+TASK [Create a new database with name 'arm_test1'] ***************************************************************************************************************
+skipping: [35.222.119.249]
+changed: [34.28.237.71]
+
+TASK [Create a new database with name 'arm_test2'] ***************************************************************************************************************
+skipping: [34.28.237.71]
+changed: [35.222.119.249]
+
+TASK [MySQL secure installation] *********************************************************************************************************************************
+changed: [35.222.119.249]
+changed: [34.28.237.71]
+
+TASK [Enable remote login by changing bind-address] **************************************************************************************************************
+changed: [34.28.237.71]
+changed: [35.222.119.249]
+
+RUNNING HANDLER [Restart mysql] **********************************************************************************************************************************
+changed: [35.222.119.249]
+changed: [34.28.237.71]
+
+PLAY RECAP *******************************************************************************************************************************************************
+34.28.237.71               : ok=9    changed=7    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+35.222.119.249             : ok=9    changed=7    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+```
+
+## Connect to Database from local machine
+
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#connect-to-database-from-local-machine) to connect to the database from local machine.
+
+## Deploy Memcached as a cache for MySQL using Python
+
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#deploy-memcached-as-a-cache-for-mysql-using-python) to deploy Memcached as a cache for MySQL using Python.
+
+You have successfully deployed Memcached as a cache for MySQL on a Google Cloud Arm based Instance.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```
+


### PR DESCRIPTION
- Added section to deploy Memcached as a cache for MySQL on an AWS Arm based Instance.
- Added section to deploy Memcached as a cache for MySQL on an Azure Arm based Instance.
- Added section to deploy Memcached as a cache for MySQL on a Google Cloud Arm based Instance.