### PR TITLE
Add learning path to deploy MariaDB on ARM64

### DIFF
--- a/content/learning-paths/server-and-cloud/mariadb/_index.md
+++ b/content/learning-paths/server-and-cloud/mariadb/_index.md
@@ -1,0 +1,41 @@
+---
+title: Deploy MariaDB on Arm
+
+description: Deploy single instance of MariaDB through Docker, RDS and EC2 instance
+
+minutes_to_complete: 30   
+
+who_is_this_for: This is an introductory topic for software developers who want to deploy MariaDB.
+
+learning_objectives: 
+    - Deploy single instance of MariaDB through Docker, RDS and an AWS EC2
+    - Deploy single instance of MariaDB through an Azure
+    - Deploy single instance of MariaDB through GCP
+    - Automate MariaDB EC2 instance creation using Terraform and Ansible
+
+prerequisites:
+    - An [AWS account](https://portal.aws.amazon.com/billing/signup?nc2=h_ct&src=default&redirect_url=https%3A%2F%2Faws.amazon.com%2Fregistration-confirmation#/start). Create an account if needed.
+    - A computer with [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed
+    - A computer with [AWS IAM authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html) installed
+    - A computer with [Ansible](https://www.cyberciti.biz/faq/how-to-install-and-configure-latest-version-of-ansible-on-ubuntu-linux/) installed
+    - A computer with [Terraform](/install-guides/terraform) installed
+    - A computer with [Docker](https://www.simplilearn.com/tutorials/docker-tutorial/how-to-install-docker-on-ubuntu) installed
+
+author_primary: Jason Andrews
+### Tags
+skilllevels: Introductory
+subjects: Databases
+armips:
+    - Neoverse
+operatingsystems:
+    - Linux
+tools_software_languages:
+    - Terraform
+    - Ansible
+
+### FIXED, DO NOT MODIFY
+# ================================================================================
+weight: 1                       # _index.md always has weight of 1 to order correctly
+layout: "learningpathall"       # All files under learning paths have this same wrapper
+learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
+---

--- a/content/learning-paths/server-and-cloud/mariadb/_next_step.md
+++ b/content/learning-paths/server-and-cloud/mariadb/_next_step.md
@@ -1,0 +1,39 @@
+---
+# ================================================================================
+#       Edit
+# ================================================================================
+
+next_step_guidance: >
+    We recommend you to continue learning about porting cloud applications to the Arm architecture for increased performance and cost savings. The learning path on how to tune MariaDB is a great next step.
+# 1-3 sentence recommendation outlining how the reader can generally keep learning about these topics, and a specific explanation of why the next step is being recommended.
+
+recommended_path: "/learning-paths/server-and-cloud/mysql/"
+# Link to the next learning path being recommended.
+
+
+# further_reading links to references related to this path. Can be:
+    # Manuals for a tool / software mentioned   (type: documentation)
+    # Blog about related topics                 (type: blog)
+    # General online references                 (type: website) 
+
+further_reading:
+    - resource:
+        title: MariaDB Manual
+        link: https://mariadb.org/documentation/ 
+        type: documentation
+    - resource:
+        title: RDS
+        link: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_GettingStarted.CreatingConnecting.MariaDB.html 
+        type: documentation
+    - resource:
+        title: Ansible
+        link: https://docs.ansible.com/
+        type: documentation
+
+# ================================================================================
+#       FIXED, DO NOT MODIFY
+# ================================================================================
+weight: 21                  # set to always be larger than the content in this path, and one more than 'review'
+title: "Next Steps"         # Always the same
+layout: "learningpathall"   # All files under learning paths have this same wrapper
+---

--- a/content/learning-paths/server-and-cloud/mariadb/_review.md
+++ b/content/learning-paths/server-and-cloud/mariadb/_review.md
@@ -1,0 +1,49 @@
+---
+# ================================================================================
+#       Edit
+# ================================================================================
+
+# Always 3 questions. Should try to test the reader's knowledge, and reinforce the key points you want them to remember.
+    # question:         A one sentence question
+    # answers:          The correct answers (from 2-4 answer options only). Should be surrounded by quotes.
+    # correct_answer:   An integer indicating what answer is correct (index starts from 0)
+    # explanation:      A short (1-3 sentence) explanation of why the correct answer is correct. Can add aditional context if desired
+
+
+review:
+    - questions:
+        question: >
+            The default MariaDB port is 3306
+        answers:
+            - "True"
+            - "False"
+        correct_answer: 1                     
+        explanation: >
+             The default port number for both MySQL and MariaDB is 3306, but you can change it as required with changing the port variable in the /etc/mysql/mariadb.conf.d/50-server.cnf file.
+    - questions:
+        question: >
+            Ansible is a pull-based configuration management tool
+        answers:
+            - "True"
+            - "False"
+        correct_answer: 2                     
+        explanation: >
+            Ansible works on the Push mechanism.
+    - questions:
+        question: >
+            We can keep secret data in the playbook
+        answers:
+            - "True"
+            - "False"
+        correct_answer: 1                     
+        explanation: >
+             Yes, it is possible to keep secret data in your Ansible content with the use of Vault in playbooks.
+               
+# ================================================================================
+#       FIXED, DO NOT MODIFY
+# ================================================================================
+title: "Review"                 # Always the same title
+weight: 20                      # Set to always be larger than the content in this path
+layout: "learningpathall"       # All files under learning paths have this same wrapper
+---
+

--- a/content/learning-paths/server-and-cloud/mariadb/azure_deployment.md
+++ b/content/learning-paths/server-and-cloud/mariadb/azure_deployment.md
@@ -1,0 +1,394 @@
+---
+# User change
+title: "Install MariaDB on an Azure Arm based instance"
+
+weight: 5 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Install MariaDB on an Azure Arm based instance 
+
+You can deploy MariaDB on Azure using Terraform and Ansible. 
+
+In this section, you will deploy MariaDB on a single Azure instance. 
+
+If you are new to Terraform, you should look at [Automate Azure instance creation using Terraform](/learning-paths/server-and-cloud/azure/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need an [an Azure portal account](https://azure.microsoft.com/en-in/get-started/azure-portal) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin you will also need:
+- Login to Azure CLI
+- An SSH key pair
+
+The instructions to login to Azure CLI and to create the keys are below.
+
+### Acquire Azure Access Credentials
+
+The installation of Terraform on your Desktop/Laptop needs to communicate with Azure. Thus, Terraform needs to be authenticated.
+
+For Azure authentication, follow this [documentation](/install-guides/azure_login).
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for Arm VMs access. To generate the key-pair, follow this [
+guide](/install-guides/ssh#ssh-keys).
+
+{{% notice Note %}} 
+If you already have an SSH key-pair present in the `~/.ssh` directory, you can skip this step.
+{{% /notice %}}
+
+## Create an Azure instance using Terraform
+For Azure Arm based instance deployment, the Terraform configuration is broken into four files: `providers.tf`, `variables.tf`, `main.tf`, and `outputs.tf`.
+
+Add the following code in `providers.tf` file to configure Terraform to communicate with Azure.
+
+```terraform
+terraform {
+  required_version = ">=0.12"
+
+  required_providers {
+    azurerm = {
+      source= "hashicorp/azurerm"
+      version = "~>2.0"
+    }
+    random = {
+      source= "hashicorp/random"
+      version = "~>3.0"
+    }
+    tls = {
+    source = "hashicorp/tls"
+    version = "~>4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+``` 
+
+Create a `variables.tf` file for describing the variables referenced in the other files with their type and a default value.
+
+```terraform
+variable "resource_group_location" {
+  default = "eastus2"
+  description = "Location of the resource group."
+}
+
+variable "resource_group_name_prefix" {
+  default = "rg"
+  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+}
+```
+
+Add the resources required to create a virtual machine in `main.tf`.
+
+Scroll down to see the information you need to change in `main.tf`.
+
+```terraform
+resource "random_pet" "rg_name" {
+  prefix = var.resource_group_name_prefix
+}
+
+resource "azurerm_resource_group" "rg" {
+  location = var.resource_group_location
+  name = random_pet.rg_name.id
+}
+
+# Create virtual network
+resource "azurerm_virtual_network" "my_terraform_network" {
+  name = "myVnet"
+  address_space = ["10.0.0.0/16"]
+  location = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+# Create subnet
+resource "azurerm_subnet" "my_terraform_subnet" {
+  name = "mySubnet"
+  resource_group_name = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.my_terraform_network.name
+  address_prefixes = ["10.0.1.0/24"]
+}
+
+# Create Public IPs
+resource "azurerm_public_ip" "my_terraform_public_ip" {
+  name = "myPublicIP"
+  location = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method = "Dynamic"
+}
+
+# Create Network Security Group and rule
+resource "azurerm_network_security_group" "my_terraform_nsg" {
+  name= "myNetworkSecurityGroup"
+  location= azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  security_rule {
+    name= "SSH"
+    priority= 1001
+    direction= "Inbound"
+    access = "Allow"
+    protocol= "Tcp"
+    source_port_range= "*"
+    destination_port_range = "22"
+    source_address_prefix= "*"
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name= "MariaDB"
+    priority= 1002
+    direction= "Inbound"
+    access = "Allow"
+    protocol= "Tcp"
+    source_port_range= "*"
+    destination_port_range = "3306"
+    source_address_prefix= "*"
+    destination_address_prefix = "*"
+  }
+}
+
+# Create network interface
+resource "azurerm_network_interface" "my_terraform_nic" {
+  name= "myNIC"
+  location= azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  ip_configuration {
+    name= "my_nic_configuration"
+    subnet_id = azurerm_subnet.my_terraform_subnet.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id= azurerm_public_ip.my_terraform_public_ip.id
+  }
+}
+
+# Connect the security group to the network interface
+resource "azurerm_network_interface_security_group_association" "example" {
+  network_interface_id= azurerm_network_interface.my_terraform_nic.id
+  network_security_group_id = azurerm_network_security_group.my_terraform_nsg.id
+}
+
+# Generate random text for a unique storage account name
+resource "random_id" "random_id" {
+  keepers = {
+    # Generate a new ID only when a new resource group is defined
+    resource_group = azurerm_resource_group.rg.name
+  }
+
+  byte_length = 8
+}
+
+# Create storage account for boot diagnostics
+resource "azurerm_storage_account" "my_storage_account" {
+  name = "diag${random_id.random_id.hex}"
+  location = azurerm_resource_group.rg.location
+  resource_group_name= azurerm_resource_group.rg.name
+  account_tier = "Standard"
+  account_replication_type = "LRS"
+}
+
+# Create virtual machine
+resource "azurerm_linux_virtual_machine" "my_terraform_vm" {
+  name= "myVM"
+  location= azurerm_resource_group.rg.location
+  resource_group_name= azurerm_resource_group.rg.name
+  network_interface_ids = [azurerm_network_interface.my_terraform_nic.id]
+  size= "Standard_D2ps_v5"
+
+  os_disk {
+    name = "myOsDisk"
+    caching= "ReadWrite"
+    storage_account_type = "Premium_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer = "0001-com-ubuntu-server-focal"
+    sku= "20_04-lts-arm64"
+    version= "20.04.202209200"
+  }
+
+  computer_name= "myvm"
+  admin_username= "ubuntu"
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username= "ubuntu"
+    public_key = file("~/.ssh/id_rsa.pub")
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.my_storage_account.primary_blob_endpoint
+  }
+}
+
+resource "local_file" "inventory" {
+    depends_on=[azurerm_linux_virtual_machine.my_terraform_vm]
+    filename = "/tmp/inventory"
+    content = <<EOF
+[all]
+ansible-target1 ansible_connection=ssh ansible_host=${azurerm_linux_virtual_machine.my_terraform_vm.public_ip_address} ansible_user=ubuntu
+                EOF
+}
+```
+The inventory file is automatically generated and does not need to be changed.
+
+Add the below code in `outputs.tf` to get Resource group name and Public IP.
+
+```terraform
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "public_ip_address" {
+  value = azurerm_linux_virtual_machine.my_terraform_vm.public_ip_address
+}
+```
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for Azure.
+
+```bash
+terraform init
+```
+    
+The output should be similar to:
+
+```output
+Initializing the backend...
+
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/tls from the dependency lock file
+- Reusing previous version of hashicorp/azurerm from the dependency lock file
+- Reusing previous version of hashicorp/random from the dependency lock file
+- Using previously-installed hashicorp/local v2.4.0
+- Using previously-installed hashicorp/tls v4.0.4
+- Using previously-installed hashicorp/azurerm v2.99.0
+- Using previously-installed hashicorp/random v3.4.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```bash
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all Azure resources. 
+
+```bash
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create Azure resources. 
+
+The public IP address will be different, but the output should be similar to:
+
+```output
+Apply complete! Resources: 12 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+public_ip_address = "20.110.185.235"
+resource_group_name = "rg-tight-dove"
+```
+
+## Configure MariaDB through Ansible
+
+Install the MariaDB and the required dependencies.
+
+You can use the same `playbook.yaml` file used in the topic, [Install MariaDB on a single AWS Arm based instance](/learning-paths/server-and-cloud/mariadb/ec2_deployment#configure-mariadb-through-ansible).
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the  `ansible-playbook` command.
+
+```bash
+ansible-playbook playbook.yaml -i /tmp/inventory
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```output
+PLAY [all] ******************************************************************************************************************************
+
+TASK [Gathering Facts] ******************************************************************************************************************
+The authenticity of host '20.110.185.235 (20.110.185.235)' can't be established.
+ED25519 key fingerprint is SHA256:XC9CnqxdGvrGCyo19WtfBsnUyFJU8hCoIDKWxiNaAVc.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+ok: [ansible-target1]
+
+TASK [Update the Machine and Install dependencies] **************************************************************************************
+changed: [ansible-target1]
+
+TASK [start and enable maridb service] **************************************************************************************************
+ok: [ansible-target1]
+
+TASK [Change Root Password] *************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Create database user with password and all database privileges and 'WITH GRANT OPTION'] *******************************************
+changed: [ansible-target1]
+
+TASK [MariaDB secure installation] ******************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Enable remote login by changing bind-address] *************************************************************************************
+changed: [ansible-target1]
+
+RUNNING HANDLER [Restart mariadb] *******************************************************************************************************
+changed: [ansible-target1]
+
+PLAY RECAP ******************************************************************************************************************************
+ansible-target1            : ok=8    changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+## Connect to Database from local machine
+
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/mariadb/ec2_deployment#connect-to-database-from-local-machine) to connect to the database from local machine.
+
+You have successfully deploy MariaDB on an Azure instance.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```bash
+terraform destroy
+```
+

--- a/content/learning-paths/server-and-cloud/mariadb/docker_deployment.md
+++ b/content/learning-paths/server-and-cloud/mariadb/docker_deployment.md
@@ -1,0 +1,197 @@
+---
+# User change
+title: "Deploy MariaDB via Docker"
+
+weight: 3 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+
+##  Install MariaDB with a Docker container 
+
+You can deploy MariaDB with a Docker container using Terraform and Ansible. 
+
+In this topic, you will deploy MariaDB with a Docker container.
+
+## Before you begin
+
+You should have the prerequisite tools installed from the topic, [Install MariaDB on a single AWS Arm based instance](/learning-paths/server-and-cloud/mariadb/ec2_deployment#deploy-ec2-instance-via-terraform).
+
+Use the same SSH key pair.
+
+## Create an AWS EC2 instance using Terraform
+
+You can use the same `main.tf` file used in the topic, [Install MariaDB on a single AWS Arm based instance](/learning-paths/server-and-cloud/mariadb/ec2_deployment#deploy-ec2-instance-via-terraform).
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for AWS.
+
+```bash
+terraform init
+```
+    
+The output should be similar to:
+
+```output
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding latest version of hashicorp/local...
+- Finding latest version of hashicorp/aws...
+- Installing hashicorp/local v2.4.0...
+- Installed hashicorp/local v2.4.0 (signed by HashiCorp)
+- Installing hashicorp/aws v4.58.0...
+- Installed hashicorp/aws v4.58.0 (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```bash
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all AWS resources. 
+
+```bash
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create AWS resources. 
+
+The public IP address will be different, but the output should be similar to:
+
+```output
+Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
+```
+
+## Deploy MariaDB container using Ansible
+Docker is an open platform for developing, shipping, and running applications. Docker enables you to separate your applications from your infrastructure so you can deliver software quickly.
+
+To run Ansible, we have to create a `playbook.yml` file, which is also known as `Ansible-Playbook`.
+In our `playbook.yml` file, we use the **community.docker** collection to deploy the MariaDB container.
+We also need to map the container port to the host port, which is `3306`. Below is the complete `playbook.yml` file that will do this for us.
+
+```yml
+---
+- hosts: all
+  remote_user: root
+  become: true
+  tasks:
+    - name: Update the Machine and Install dependencies
+      shell: |
+             apt-get update -y
+             apt-get -y install mariadb-client
+             apt-get install docker.io -y
+             usermod -aG docker ubuntu
+             apt-get -y install python3-pip
+             pip3 install PyMySQL
+             pip3 install docker
+      become: true
+    - name: Reset ssh connection for changes to take effect
+      meta: "reset_connection"
+    - name: Log into DockerHub
+      community.docker.docker_login:
+        username: {{dockerhub_uname}}
+        password: {{dockerhub_pass}}
+    - name: Deploy mariadb docker container
+      docker_container:
+        image: mariadb:latest
+        name: mariadb_test
+        state: started
+        ports:
+          - "3306:3306"
+        pull: true
+        volumes:
+         - "db_data:/var/lib/mysql:rw"
+         - "mariadb-socket:/var/run/mysqld:rw"
+         - "/tmp:/tmp:rw"
+        restart: true
+        env:
+          MARIADB_ROOT_PASSWORD: {{your_mariadb_password}}
+          MARIADB_USER: local_us
+          MARIADB_PASSWORD: Armtest123
+          MARIADB_DATABASE: arm_test
+
+```
+{{% notice Note %}} Replace **docker_container.env** variables of **Deploy mariadb docker container** task with your own MariaDB user and password. Also, replace **{{dockerhub_uname}}** and **{{dockerhub_pass}}** with your dockerhub credentials. {{% /notice %}}
+
+In our case, the inventory file will generate automatically after the `terraform apply` command.
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the  `ansible-playbook` command.
+
+```bash
+ansible-playbook playbook.yaml -i /tmp/inventory
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```output
+PLAY [all] *****************************************************************************************************************************************************
+
+TASK [Gathering Facts] *****************************************************************************************************************************************
+The authenticity of host 'ec2-3-135-226-118.us-east-2.compute.amazonaws.com (172.31.30.40)' can't be established.
+ED25519 key fingerprint is SHA256:uWZgVeACoIxRDQ9TrqbpnjUz14x57jTca6iASH3gU7M.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+ok: [ansible-target1]
+
+TASK [Update the Machine and install docker dependencies] *************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Reset ssh connection for changes to take effect] ****************************************************************************************************************
+
+TASK [Log into DockerHub] *********************************************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Deploy mariadb docker containere] *******************************************************************************************************************************
+changed: [ansible-target1]
+
+PLAY RECAP ************************************************************************************************************************************************************
+ansible-target1            : ok=3    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+## Connect to Database using local machine
+
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/mariadb/ec2_deployment#connect-to-database-from-local-machine) to connect to the database from local machine.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```bash
+terraform destroy
+```

--- a/content/learning-paths/server-and-cloud/mariadb/ec2_deployment.md
+++ b/content/learning-paths/server-and-cloud/mariadb/ec2_deployment.md
@@ -1,0 +1,488 @@
+---
+# User change
+title: "Install MariaDB on an AWS Arm based instance"
+
+weight: 2 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Install MariaDB on an AWS Arm based instance
+
+You can deploy MariaDB on AWS Graviton processors using Terraform and Ansible. 
+
+In this topic, you will deploy MariaDB on a single AWS EC2 instance. 
+
+If you are new to Terraform, you should look at [Automate AWS EC2 instance creation using Terraform](/learning-paths/server-and-cloud/aws-terraform/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need an [AWS account](https://portal.aws.amazon.com/billing/signup?nc2=h_ct&src=default&redirect_url=https%3A%2F%2Faws.amazon.com%2Fregistration-confirmation#/start) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin, you will also need:
+- An AWS access key ID and secret access key. 
+- An SSH key pair
+
+The instructions to create the keys are below.
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for AWS EC2 access. To generate the key-pair, follow this [
+guide](/install-guides/ssh#ssh-keys).
+
+{{% notice Note %}}
+If you already have an SSH key-pair present in the `~/.ssh` directory, you can skip this step.
+{{% /notice %}}
+
+
+### Acquire AWS Access Credentials
+
+Terraform requires AWS authentication to create AWS resources. You can generate access keys (access key ID and secret access key) to perform authentication. Terraform uses the access keys to make calls to AWS using the AWS CLI. 
+
+To generate and configure the Access key ID and Secret access key, follow this [documentation](/install-guides/aws_access_keys).
+
+## Deploy EC2 instance via Terraform
+
+After generating the public and private keys, we have to create an EC2 instance. Then we will push our public key to the **authorized_keys** folder in `~/.ssh`. We will also create a security group that opens inbound ports `22`(ssh) and `3306`(MariaDB). Below is a Terraform file named `main.tf` that will do this for us.
+   
+
+```terraform
+provider "aws" {
+  region = "us-east-2"
+}
+
+resource "aws_instance" "Mariadb_TEST" {
+  ami           = "ami-0ca2eafa23bc3dd01"
+  instance_type = "t4g.small"
+  security_groups= [aws_security_group.Terraformsecurity.name]
+  key_name = aws_key_pair.deployer.key_name
+  tags = {
+    Name = "Mariadb_TEST"
+  }
+}
+
+resource "aws_default_vpc" "main" {
+  tags = {
+    Name = "main"
+  }
+}
+
+resource "aws_security_group" "Terraformsecurity" {
+  name        = "Terraformsecurity"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = aws_default_vpc.main.id
+
+  ingress {
+    description      = "TLS from VPC"
+    from_port        = 3306
+    to_port          = 3306
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+  ingress {
+    description      = "TLS from VPC"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "Terraformsecurity"
+  }
+}
+
+resource "local_file" "inventory" {
+    depends_on=[aws_instance.Mariadb_TEST]
+    filename = "/tmp/inventory"
+    content = <<EOF
+[all]
+ansible-target1 ansible_connection=ssh ansible_host=${aws_instance.Mariadb_TEST.public_ip} ansible_user=ubuntu
+                EOF
+}
+
+resource "aws_key_pair" "deployer" {
+        key_name   = "id_rsa"
+        public_key = file("~/.ssh/id_rsa.pub")
+}
+
+```
+Make the changes listed below in `main.tf` to match your account settings.
+
+1. In the `provider` section, update value to use your preferred AWS region.
+
+2. (optional) In the `aws_instance` section, change the ami value to your preferred Linux distribution. The AMI ID for Ubuntu 22.04 on Arm is `ami-0ca2eafa23bc3dd01`. No change is needed if you want to use Ubuntu AMI. 
+
+{{% notice Note %}}
+The instance type is t4g.small. This an an Arm-based instance and requires an Arm Linux distribution.
+{{% /notice %}}
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for AWS.
+
+```bash
+terraform init
+```
+    
+The output should be similar to:
+
+```output
+Initializing the backend...
+
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/aws from the dependency lock file
+- Using previously-installed hashicorp/local v2.3.0
+- Using previously-installed hashicorp/aws v4.52.0
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```bash
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all AWS resources.
+
+```bash
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create AWS resources.
+
+The output should be similar to:
+
+```output
+Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
+```
+
+
+## Configure MariaDB through Ansible
+Ansible is a software tool that provides simple but powerful automation for cross-platform computer support.
+Using a text editor, save the code below to in a file called `playbook.yaml`. This is the YAML file for the Ansible playbook.
+
+```yml
+---
+- hosts: all
+  remote_user: root
+  become: true
+  tasks:
+    - name: Update the Machine and Install dependencies
+      shell: |
+             apt-get update -y
+             apt-get -y install mariadb-server
+             apt -y install python3-pip
+             pip3 install PyMySQL
+      become: true
+    - name: start and enable maridb service
+      service:
+        name: mariadb
+        state: started
+        enabled: yes
+    - name: Change Root Password
+      shell: sudo mariadb -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '{{Your_mariadb_password}}'"
+    - name: Create database user with password and all database privileges and 'WITH GRANT OPTION'
+      mysql_user:
+         login_user: root
+         login_password: {{Your_mariadb_password}}
+         login_host: localhost
+         name: Local_user
+         host: '%'
+         password: {{Give_any_password}}
+         priv: '*.*:ALL,GRANT'
+         state: present
+    - name: MariaDB secure installation
+      become: yes
+      expect:
+        command: mariadb-secure-installation
+        responses:
+           'Enter current password for root': '{{Your_mariadb_password}}'
+           'Set root password': 'n'
+           'Remove anonymous users': 'y'
+           'Disallow root login remotely': 'n'
+           'Remove test database': 'y'
+           'Reload privilege tables now': 'y'
+        timeout: 1
+      register: secure_mariadb
+      failed_when: "'... Failed!' in secure_mariadb.stdout_lines"
+    - name: Enable remote login by changing bind-address
+      lineinfile:
+         path: /etc/mysql/mariadb.conf.d/50-server.cnf
+         regexp: '^bind-address'
+         line: 'bind-address = 0.0.0.0'
+         backup: yes
+      notify:
+         - Restart mariadb
+  handlers:
+    - name: Restart mariadb
+      service:
+        name: mariadb
+        state: restarted
+
+```
+{{% notice Note %}} Replace **{{Your_mariadb_password}}** and **{{Give_any_password}}** with your password. {{% /notice %}}
+
+In the above `playbook.yml` file, we are creating a user (**Local_user**) with all privileges granted and setting the password for the **root** user.
+We are also enabling remote login by changing the **bind address** to **0.0.0.0** in the **/mariadb.conf.d/50-server.cnf** file.
+
+In our case, the inventory file `/tmp/inventory` will be generated automatically after the `terraform apply` command.
+
+### Ansible Commands
+
+This `ansible` Playbook uses the MySQL community module that can be installed by running the following command after installation:
+
+```bash
+ansible-galaxy collection install community.mysql
+```
+
+To run a Playbook, we need to use the `ansible-playbook` command. 
+
+```bash
+ansible-playbook playbook.yml -i /tmp/inventory
+```
+
+Answer `yes` when prompted for the SSH connection.
+
+Deployment may take a few minutes.
+
+The output should be similar to:
+
+```output
+PLAY [all] ******************************************************************************************************************************
+
+TASK [Gathering Facts] ******************************************************************************************************************
+The authenticity of host '3.19.244.136 (3.19.244.136)' can't be established.
+ED25519 key fingerprint is SHA256:XC9CnqxdGvrGCyo19WtfBsnUyFJU8hCoIDKWxiNaAVc.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+ok: [ansible-target1]
+
+TASK [Update the Machine and Install dependencies] **************************************************************************************
+changed: [ansible-target1]
+
+TASK [start and enable maridb service] **************************************************************************************************
+ok: [ansible-target1]
+
+TASK [Change Root Password] *************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Create database user with password and all database privileges and 'WITH GRANT OPTION'] *******************************************
+changed: [ansible-target1]
+
+TASK [MariaDB secure installation] ******************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Enable remote login by changing bind-address] *************************************************************************************
+changed: [ansible-target1]
+
+RUNNING HANDLER [Restart mariadb] *******************************************************************************************************
+changed: [ansible-target1]
+
+PLAY RECAP ******************************************************************************************************************************
+ansible-target1            : ok=8    changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+
+## Connect to Database from local machine
+
+To connect to the database, we need the `public-ip` of the instance where MariaDB is deployed. We also need to use the MariaDB Client to interact with the MariaDB database.
+
+```console
+apt install mariadb-client
+```
+
+```console
+mariadb -h {public_ip of instance where MariaDB deployed} -P3306 -u {user of database} -p{password of database}
+```
+
+{{% notice Note %}} Replace `{public_ip of instance where MariaDB deployed}`, `{user_name of database}` and `{password of database}` with your values. In our case `user_name`= `Local_user`, which we have created through the `playbook.yml` file. {{% /notice %}}
+
+The output will be:
+```output
+Welcome to the MariaDB monitor.  Commands end with ; or \g.
+Your MariaDB connection id is 6
+Server version: 10.6.12-MariaDB-0ubuntu0.22.04.1 Ubuntu 22.04
+
+Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+MariaDB [(none)]>
+```
+
+### Access Database and Create Table
+
+Execute the steps below to try out MariaDB.
+
+1. Create a database:
+
+```mysql
+create database {your_database};
+```
+
+The output will be:
+```output
+MariaDB [(none)]> create database arm_test;
+Query OK, 1 row affected (0.001 sec)
+```
+2. List all databases:
+
+```mysql
+show databases;
+```
+
+The output will be:
+```mysql
+MariaDB [(none)]> show databases;
++--------------------+
+| Database           |
++--------------------+
+| arm_test          |
+| information_schema |
+| mysql              |
+| performance_schema |
+| sys                |
++--------------------+
+5 rows in set (0.00 sec)
+```
+
+3. Switch to the new databases:
+
+```mysql
+use {your_database};
+```
+
+The output will be:
+
+```output
+MariaDB [(none)]> use arm_test;
+Database changed
+```
+
+4. Create a new table in the database.
+
+```mysql
+create table book(name char(10),id varchar(10));
+```
+The output will be:
+
+```output
+MariaDB [arm_test]> create table book(name char(10),id varchar(10));
+Query OK, 0 rows affected (0.03 sec)
+
+```
+
+5. Insert data into the table:
+```mysql
+insert into book(name,id) values ('Abook','10'),('Bbook','20'),('Cbook','20'),('Dbook','30'),('Ebook','45'),('Fbook','40'),('Gbook
+','69');
+```
+
+The output will be:
+
+```output
+MariaDB [arm_test]> insert into book(name,id) values ('Abook','10'),('Bbook','20'),('Cbook','20'),('Dbook','30'),('Ebook','45'),('Fbook','40'),('Gbook','69');
+Query OK, 7 rows affected (0.01 sec)
+Records: 7  Duplicates: 0  Warnings: 0
+```
+6. Display the database tables:
+
+```mysql
+show tables;
+```
+
+The output will be:
+
+```output
+MariaDB [arm_test]> show tables;
++--------------------+
+| Tables_in_arm_test |
++--------------------+
+| book               |
++--------------------+
+1 row in set (0.001 sec)
+```
+
+7. Display the structure of table:
+
+```mysql
+describe {{your_table_name}};
+```
+
+The output will be:
+
+```output
+MariaDB [arm_test]> describe book;
++-------+-------------+------+-----+---------+-------+
+| Field | Type        | Null | Key | Default | Extra |
++-------+-------------+------+-----+---------+-------+
+| name  | char(10)    | YES  |     | NULL    |       |
+| id    | varchar(10) | YES  |     | NULL    |       |
++-------+-------------+------+-----+---------+-------+
+2 rows in set (0.001 sec)
+```
+
+8. Print the contents of the table:
+
+```mysql
+select * from {{your_table_name}};
+```
+
+The output will be:
+
+```output
+MariaDB [arm_test]> select * from book;
+
++--------+------+
+| name   | id   |
++--------+------+
+| Abook  | 10   |
+| Bbook  | 20   |
+| Cbook  | 20   |
+| Dbook  | 30   |
+| Ebook  | 45   |
+| Fbook  | 40   |
+| Gbook  | 69   |
++--------+------+
+7 rows in set (0.00 sec)
+```
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```bash
+terraform destroy
+```
+

--- a/content/learning-paths/server-and-cloud/mariadb/gcp_deployment.md
+++ b/content/learning-paths/server-and-cloud/mariadb/gcp_deployment.md
@@ -1,0 +1,254 @@
+---
+# User change
+title: "Install MariaDB on a GCP Arm based instance"
+
+weight: 6 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Install MariaDB on a GCP Arm based instance 
+
+You can deploy MariaDB on Google Cloud using Terraform and Ansible. 
+
+In this section, you will deploy MariaDB on a single Google Cloud instance.
+
+If you are new to Terraform, you should look at [Automate GCP instance creation using Terraform](/learning-paths/server-and-cloud/gcp/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need an [Google Cloud account](https://console.cloud.google.com/?hl=en-au) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin you will also need:
+- Login to Google Cloud CLI 
+- An SSH key pair
+
+The instructions to login to Google Cloud CLI and to create the keys are below.
+
+### Acquire GCP Access Credentials
+
+The installation of Terraform on your Desktop/Laptop needs to communicate with GCP. Thus, Terraform needs to be authenticated.
+
+To obtain GCP user credentials, follow this [documentation](/install-guides/gcp_login).
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for Arm VMs access. To generate the key-pair, follow this [
+documentation](/install-guides/ssh#ssh-keys).
+
+{{% notice Note %}} 
+If you already have an SSH key-pair present in the `~/.ssh` directory, you can skip this step.
+{{% /notice %}}
+
+## Create a GCP instance using Terraform
+
+Using a text editor, save the code below in a file called `main.tf`.
+
+Scroll down to see the information you need to change in `main.tf`.
+```terraform
+// instance creation
+provider "google" {
+  project = "{project_id}"
+  region = "us-central1"
+  zone = "us-central1-a"
+}
+resource "google_compute_firewall" "rules" {
+  project     = "{project_id}"
+  name        = "my-firewall-rule"
+  network     = "default"
+  description = "Open SSH connection port"
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol  = "tcp"
+    ports     = ["22", "3306"]
+  }
+}
+resource "google_compute_instance" "vm_instance" {
+  name         = "vmname"
+  machine_type = "t2a-standard-1"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts-arm64"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+  metadata = {
+     ssh-keys = "ubuntu:${file("~/.ssh/id_rsa.pub")}"
+  }
+}
+output "Master_public_IP" {
+  value = [google_compute_instance.vm_instance.network_interface.0.access_config.0.nat_ip]
+}
+// Generate inventory file
+resource "local_file" "inventory" {
+    depends_on=[google_compute_instance.vm_instance]
+    filename = "/tmp/inventory"
+    content = <<EOF
+[all]
+ansible-target1 ansible_connection=ssh ansible_host=${google_compute_instance.vm_instance.network_interface.0.access_config.0.nat_ip} ansible_user=ubuntu
+                EOF
+}
+```
+In the `provider` and `google_compute_firewall` sections, update the `project_id` with your value.
+
+The inventory file is automatically generated and does not need to be changed.
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for Google Cloud.
+
+```bash
+terraform init
+```
+    
+The output should be similar to:
+
+```output
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding latest version of hashicorp/google...
+- Finding latest version of hashicorp/local...
+- Installing hashicorp/google v4.57.0...
+- Installed hashicorp/google v4.57.0 (signed by HashiCorp)
+- Installing hashicorp/local v2.4.0...
+- Installed hashicorp/local v2.4.0 (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```bash
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all GCP resources. 
+
+```bash
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create GCP resources. 
+
+The public IP address will be different, but the output should be similar to:
+
+```output
+Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+Master_public_IP = [
+  "34.67.224.55",
+]
+```
+
+## Configure MariaDB through Ansible
+Install the MariaDB and the required dependencies. 
+
+You can use the same `playbook.yaml` file used in the topic, [Install MariaDB on an AWS Arm based instance](/learning-paths/server-and-cloud/mariadb/ec2_deployment#configure-mariadb-through-ansible).
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the  `ansible-playbook` command.
+
+```bash
+ansible-playbook playbook.yaml -i /tmp/inventory 
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```output
+PLAY [all] ******************************************************************************************************************************
+
+TASK [Gathering Facts] ******************************************************************************************************************
+The authenticity of host '34.67.224.55 (34.67.224.55)' can't be established.
+ED25519 key fingerprint is SHA256:XC9CnqxdGvrGCyo19WtfBsnUyFJU8hCoIDKWxiNaAVc.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+ok: [ansible-target1]
+
+TASK [Update the Machine and Install dependencies] **************************************************************************************
+changed: [ansible-target1]
+
+TASK [start and enable maridb service] **************************************************************************************************
+ok: [ansible-target1]
+
+TASK [Change Root Password] *************************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Create database user with password and all database privileges and 'WITH GRANT OPTION'] *******************************************
+changed: [ansible-target1]
+
+TASK [MariaDB secure installation] ******************************************************************************************************
+changed: [ansible-target1]
+
+TASK [Enable remote login by changing bind-address] *************************************************************************************
+changed: [ansible-target1]
+
+RUNNING HANDLER [Restart mariadb] *******************************************************************************************************
+changed: [ansible-target1]
+
+PLAY RECAP ******************************************************************************************************************************
+ansible-target1            : ok=8    changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+## Connect to Database from local machine
+
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/mariadb/ec2_deployment#connect-to-database-from-local-machine) to connect to the database from local machine.
+
+You have successfully deploy MariaDB on a Google Cloud instance.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```bash
+terraform destroy
+```
+

--- a/content/learning-paths/server-and-cloud/mariadb/rds_deployment.md
+++ b/content/learning-paths/server-and-cloud/mariadb/rds_deployment.md
@@ -1,0 +1,157 @@
+---
+# User change
+title: "Deploy MariaDB using RDS"
+
+weight: 4 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path.
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools.
+
+You will need an [AWS account](https://portal.aws.amazon.com/billing/signup?nc2=h_ct&src=default&redirect_url=https%3A%2F%2Faws.amazon.com%2Fregistration-confirmation#/start) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin you will also need:
+- An AWS access key ID and secret access key
+
+The instructions to create the keys are below
+
+### Acquire AWS Access Credentials
+
+Terraform requires AWS authentication to create AWS resources. You can generate access keys (access key ID and secret access key) to perform authentication. Terraform uses the access keys to make calls to AWS using the AWS CLI.
+To generate and configure the Access key ID and Secret access key, follow this [documentation](/install-guides/aws_access_keys).
+
+## Deploy MariaDB RDS instances
+
+RDS is a Relational database service provided by AWS. More information can be found [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_GettingStarted.CreatingConnecting.MariaDB.html).
+To deploy an RDS instance of MariaDB, we have to create a Terraform file called `main.tf`. Below is the complete `main.tf`.
+
+```terraform
+
+provider "aws" {
+  region = "us-east-2"
+}
+
+resource "aws_db_parameter_group" "default" {
+  name   = "mariadb"
+  family = "mariadb10.6"
+}
+
+resource "aws_db_instance" "Testing_mariadb" {
+  identifier           = "mariadbdatabase"
+  allocated_storage    = 10
+  db_name              = "mydb"
+  engine               = "mariadb"
+  engine_version       = "10.6.10"
+  instance_class       = "db.m6g.large"
+  parameter_group_name = "mariadb"
+  skip_final_snapshot  =  true
+  username              = var.username
+  password              = var.password
+  availability_zone     = "us-east-2a"
+  publicly_accessible  = true
+  deletion_protection   = false
+
+  tags = {
+        name                 = "TEST MariaDB"
+  }
+}
+
+```  
+
+We also need to create a `credential.tf` file, for passing our password. Below is the `credential.tf` file
+
+```terraform
+variable "username"{
+      default  = "admin"
+}
+
+variable "password"{
+      default  = "Armtest"    #we_can_choose_any_password, except special_characters.
+}
+
+```
+
+To run Graviton (Arm) based DB instance, we need to select Amazon **M6g** and **R6g** as a [instance type](https://aws.amazon.com/blogs/database/key-considerations-in-moving-to-graviton2-for-amazon-rds-and-amazon-aurora-databases/). Here, we select **db.m6g.large** as a **instance_class**. 
+
+Now, use the below Terraform commands to deploy `main.tf` file.
+
+## Terraform commands
+
+Same instructions as on the [previous page](/learning-paths/server-and-cloud/mariadb/ec2_deployment#terraform-commands).
+
+### Initialize Terraform
+
+```bash
+terraform init
+```
+
+### Create a Terraform execution plan (optional)
+
+```bash
+terraform plan
+```
+
+### Apply a Terraform execution plan
+
+```bash
+terraform apply
+```      
+
+{{% notice Note %}}
+Creating the RDS database may take a few minutes.
+{{% /notice %}}
+
+                                                                                                           
+### Verify RDS
+
+
+To verify the setup on AWS console, go to **RDS » Databases**, you should see the instance running.  
+
+![Screenshot (374)](https://user-images.githubusercontent.com/92315883/218340185-097c876e-2c3c-4630-adef-ac9b905c08ec.png)
+
+
+## Connect to RDS 
+
+To access the RDS instance, make sure that our instance is correctly associated with a security group and VPC. To access RDS outside the VPC, follow this [document](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_CommonTasks.Connect.html).
+
+To connect to the RDS instance, we need the **Endpoint** of the RDS instance. To find the Endpoint, go to **RDS »Dashboard » {{YOUR_RDS_INSTANCE}}**.
+
+![Screenshot (372)](https://user-images.githubusercontent.com/92315883/218339661-0ac51c95-8789-42bc-962c-0b43fc64fb5b.png)
+
+
+Now, we can connect to RDS by using the above **Endpoint**. Use the **user** and **password** mentioned in the `credential.tf` file.
+
+```console
+mariadb -h {{Endpoint}} -u {{user}} -p {{password}}
+```
+{{% notice Note %}} Replace **{{Endpoint}}**, **{{user}}** and **{{password}}** with your values.{{% /notice %}}
+                   
+```bash { output_lines="2-15"}
+mariadb -h {{Endpoint}} -u admin -pArmtest
+Welcome to the MariaDB monitor.  Commands end with ; or \g.
+Your MariaDB connection id is 6
+Server version: 10.6.12-MariaDB-0ubuntu0.22.04.1 Ubuntu 22.04
+
+Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+MariaDB [(none)]>
+```
+
+### Create Database and Table
+To create database and table, follow this [document](/learning-paths/server-and-cloud/mariadb/ec2_deployment#access-database-and-create-table).
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```
+


### PR DESCRIPTION
- Add section to deploy MariaDB on an AWS Arm based instance.
- Add section to deploy MariaDB on an Azure Arm based instance.
- Add section to deploy MariaDB on a GCP Arm based instance.
- Add section to deploy MariaDB with a docker container.
- Add section to deploy MariaDB as RDS on an AWS Arm based instance.