### PR TITLE
Add learning path to deploy Memcached as a cache for Postgres

### DIFF
--- a/content/learning-paths/server-and-cloud/memcached/_index.md
+++ b/content/learning-paths/server-and-cloud/memcached/_index.md
@@ -8,17 +8,13 @@ layout: learningpathall
 learning_objectives:
 - Install and run memcached on your Arm-based cloud server
 - Use an open-source benchmark to test memcached performance
-- Deploy memcached as a cache for MySQL
 learning_path_main_page: 'yes'
-minutes_to_complete: 40
+minutes_to_complete: 10
 operatingsystems:
 - Linux
 prerequisites:
-- An Amazon Web Services (AWS) [account](https://aws.amazon.com/)
-- An Azure portal [account](https://azure.microsoft.com/en-in/get-started/azure-portal)
-- A Google Cloud [account](https://console.cloud.google.com/)
-- A machine with [Terraform](/install-guides/terraform/), [AWS CLI](/install-guides/aws-cli), [Google Cloud CLI](/install-guides/gcloud), [Azure CLI](/install-guides/azure-cli), [AWS IAM authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html), and [Ansible](/install-guides/ansible/) installed
-skilllevels: Advanced
+- An Arm based instance from an appropriate cloud service provider.
+skilllevels: Introductory
 subjects: Web
 test_images:
 - ubuntu:latest
@@ -30,6 +26,6 @@ title: Run memcached on Arm servers and measure its performance
 tools_software_languages:
 - Memcached
 weight: 1
-who_is_this_for: This is an advanced topic for developers who want to use memcached as their in-memory key-value store.
+who_is_this_for: This is an introductory topic for developers who want to use memcached as their in-memory key-value store.
 
 ---

--- a/content/learning-paths/server-and-cloud/memcached_cache/_index.md
+++ b/content/learning-paths/server-and-cloud/memcached_cache/_index.md
@@ -2,7 +2,7 @@
 armips:
 - Neoverse
 author_primary: Pareena Verma
-description: Learn how to deploy Memcached as a cache for MySQL and PostgreSQL on Arm servers
+description: Deploy Memcached as a cache for MySQL and PostgreSQL on Arm servers
 layout: learningpathall
 learning_objectives:
 - Deploy memcached as a cache for MySQL on AWS, Azure and GCP Arm based Instance

--- a/content/learning-paths/server-and-cloud/memcached_cache/_index.md
+++ b/content/learning-paths/server-and-cloud/memcached_cache/_index.md
@@ -1,0 +1,33 @@
+---
+armips:
+- Neoverse
+author_primary: Pareena Verma
+description: Learn how to deploy Memcached as a cache for MySQL and PostgreSQL on Arm servers
+layout: learningpathall
+learning_objectives:
+- Deploy memcached as a cache for MySQL on AWS, Azure and GCP Arm based Instance
+- Deploy memcached as a cache for PostgreSQL on AWS, Azure and GCP Arm based Instance
+learning_path_main_page: 'yes'
+minutes_to_complete: 60
+operatingsystems:
+- Linux
+prerequisites:
+- An Amazon Web Services (AWS) [account](https://aws.amazon.com/)
+- An Azure portal [account](https://azure.microsoft.com/en-in/get-started/azure-portal)
+- A Google Cloud [account](https://console.cloud.google.com/)
+- A machine with [Terraform](/install-guides/terraform/), [AWS CLI](/install-guides/aws-cli), [Google Cloud CLI](/install-guides/gcloud), [Azure CLI](/install-guides/azure-cli), [AWS IAM authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html), and [Ansible](/install-guides/ansible/) installed
+skilllevels: Advanced
+subjects: Web
+test_images:
+- ubuntu:latest
+test_link: https://github.com/armflorentlebeau/arm-learning-paths/actions/runs/4312122327
+test_maintenance: true
+test_status:
+- passed
+title: Deploy Memcached as a cache for MySQL & PostgreSQL
+tools_software_languages:
+- Memcached
+weight: 1
+who_is_this_for: This is an advanced topic for developers who want to use memcached as their in-memory key-value store.
+
+---

--- a/content/learning-paths/server-and-cloud/memcached_cache/_next-steps.md
+++ b/content/learning-paths/server-and-cloud/memcached_cache/_next-steps.md
@@ -4,10 +4,10 @@
 # ================================================================================
 
 next_step_guidance: >
-    We recommend you continue learning about porting cloud applications to the Arm architecture for increased performance and cost savings. The learning path on deploying Memcached as a cache is a great next step.
+    We recommend you continue learning about porting cloud applications to the Arm architecture for increased performance and cost savings. The learning path on MongoDB is a great next step.
 # 1-3 sentence recommendation outlining how the reader can generally keep learning about these topics, and a specific explanation of why the next step is being recommended.
 
-recommended_path: "/learning-paths/server-and-cloud/memcached_cache/"
+recommended_path: "/learning-paths/server-and-cloud/mongodb/"
 # Link to the next learning path being recommended.
 
 
@@ -20,11 +20,7 @@ further_reading:
     - resource:
         title: Memcached Wiki
         link: https://github.com/memcached/memcached/wiki
-        type: documentation
-    - resource:
-        title: Benchmarking memcached performance on AWS Graviton2 servers
-        link: https://community.arm.com/arm-community-blogs/b/tools-software-ides-blog/posts/memcached-benchmarking-aws-graviton2-50-p-p-gains
-        type: blog
+        type: documentation    
 
 
 # ================================================================================

--- a/content/learning-paths/server-and-cloud/memcached_cache/_review.md
+++ b/content/learning-paths/server-and-cloud/memcached_cache/_review.md
@@ -37,7 +37,7 @@ review:
             - "False"
         correct_answer: 1
         explanation: >
-            Yes, it is possible to share a single instance of Memcache between multiple projects because Memcache is a memory store space and it can be run on one or more servers. 
+            It is possible to share a single instance of Memcache between multiple projects because Memcache is a memory store space and can be run on one or more servers. 
 # ================================================================================
 #       FIXED, DO NOT MODIFY
 # ================================================================================

--- a/content/learning-paths/server-and-cloud/memcached_cache/_review.md
+++ b/content/learning-paths/server-and-cloud/memcached_cache/_review.md
@@ -1,0 +1,47 @@
+---
+# ================================================================================
+#       Edit
+# ================================================================================
+
+# Always 3 questions. Should try to test the reader's knowledge, and reinforce the key points you want them to remember.
+    # question:         A one sentence question
+    # answers:          The correct answers (from 2-4 answer options only). Should be surrounded by quotes.
+    # correct_answer:   An integer indicating what answer is correct (index starts from 0)
+    # explanation:      A short (1-3 sentence) explanation of why the correct answer is correct. Can add additional context if desired
+
+
+review:
+    - questions:
+        question: >
+            Memcached cannot cache large objects.
+        answers:
+            - "True"
+            - "False"
+        correct_answer: 1                   
+        explanation: >
+            Memorystore in Memcached has the minimum value of 512 KiB, the maximum value of 128 MiB, and the default value is 1 MiB.
+    - questions:
+        question: >
+            Memcached can retain the stored information even when item from the cache is deleted.
+        answers:
+            - "True"
+            - "False"
+        correct_answer: 2
+        explanation: >
+            Memcached cannot retain the stored information when item from the cache is deleted.
+    - questions:
+        question: >
+            It is possible to share a single instance of Memcache between multiple projects.
+        answers:
+            - "True"
+            - "False"
+        correct_answer: 1
+        explanation: >
+            Yes, it is possible to share a single instance of Memcache between multiple projects because Memcache is a memory store space and it can be run on one or more servers. 
+# ================================================================================
+#       FIXED, DO NOT MODIFY
+# ================================================================================
+title: "Review"                 # Always the same title
+weight: 20                      # Set to always be larger than the content in this path
+layout: "learningpathall"       # All files under learning paths have this same wrapper
+---

--- a/content/learning-paths/server-and-cloud/memcached_cache/memcached_mysql_aws.md
+++ b/content/learning-paths/server-and-cloud/memcached_cache/memcached_mysql_aws.md
@@ -2,7 +2,7 @@
 # User change
 title: "Deploy Memcached as a cache for MySQL on an AWS Arm based Instance"
 
-weight: 3 # 1 is first, 2 is second, etc.
+weight: 2 # 1 is first, 2 is second, etc.
 
 # Do not modify these elements
 layout: "learningpathall"

--- a/content/learning-paths/server-and-cloud/memcached_cache/memcached_mysql_azure.md
+++ b/content/learning-paths/server-and-cloud/memcached_cache/memcached_mysql_azure.md
@@ -1,0 +1,411 @@
+---
+# User change
+title: "Deploy Memcached as a cache for MySQL on an Azure Arm based Instance"
+
+weight: 3 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Deploy Memcached as a cache for MySQL on an Azure Arm based Instance
+
+You can deploy Memcached as a cache for MySQL on Azure using Terraform and Ansible. 
+
+In this section, you will deploy Memcached as a cache for MySQL on an Azure instance. 
+
+If you are new to Terraform, you should look at [Automate Azure instance creation using Terraform](/learning-paths/server-and-cloud/azure-terraform/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need an [Azure portal account](https://azure.microsoft.com/en-in/get-started/azure-portal) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin, you will also need:
+- Login to the Azure CLI
+- An SSH key pair
+
+The instructions to login to the Azure CLI and create the keys are below.
+
+### Acquire Azure Access Credentials
+
+The installation of Terraform on your Desktop/Laptop needs to communicate with Azure. Thus, Terraform needs to be authenticated.
+
+For Azure authentication, follow this [guide](/install-guides/azure_login).
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for Azure instance access. To generate the key-pair, follow this [
+guide](/install-guides/ssh#ssh-keys).
+
+{{% notice Note %}} 
+If you already have an SSH key-pair present in the `~/.ssh` directory, you can skip this step.
+{{% /notice %}}
+
+## Create Azure instances using Terraform
+
+For Azure Arm based instance deployment, the Terraform configuration is broken into three files: `providers.tf`, `variables.tf` and `main.tf`. Here you are creating 2 instances.
+
+Add the following code in `providers.tf` file to configure Terraform to communicate with Azure.
+    
+```console
+terraform {
+  required_version = ">=0.12"
+
+  required_providers {
+    azurerm = {
+      source= "hashicorp/azurerm"
+      version = "~>2.0"
+    }
+    random = {
+      source= "hashicorp/random"
+      version = "~>3.0"
+    }
+    tls = {
+    source = "hashicorp/tls"
+    version = "~>4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+    
+```
+Create a `variables.tf` file for describing the variables referenced in the other files with their type and a default value.
+
+```console
+variable "resource_group_location" {
+  default = "eastus2"
+  description = "Location of the resource group."
+}
+
+variable "resource_group_name_prefix" {
+  default = "rg"
+  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+}
+```
+
+Add the resources required to create a virtual machine in `main.tf`.
+
+```console
+resource "random_pet" "rg_name" {
+  prefix = var.resource_group_name_prefix
+}
+
+resource "azurerm_resource_group" "rg" {
+  location = var.resource_group_location
+  name = random_pet.rg_name.id
+}
+
+# Create virtual network
+resource "azurerm_virtual_network" "my_terraform_network" {
+  name = "myVnet"
+  address_space = ["10.1.0.0/16"]
+  location = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+# Create subnet
+resource "azurerm_subnet" "my_terraform_subnet" {
+  name = "mySubnet"
+  resource_group_name = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.my_terraform_network.name
+  address_prefixes = ["10.1.1.0/24"]
+}
+
+# Create Public IPs
+resource "azurerm_public_ip" "my_terraform_public_ip" {
+  name = "myPublicIP${format("%02d", count.index)}-test"
+  count= 2
+  location = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method = "Dynamic"
+}
+
+# Create Network Security Group and rule
+resource "azurerm_network_security_group" "my_terraform_nsg" {
+  name= "myNetworkSecurityGroup"
+  location= azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  security_rule {
+    name= "SSH"
+    priority= 1001
+    direction= "Inbound"
+    access = "Allow"
+    protocol= "Tcp"
+    source_port_range= "*"
+    destination_port_range = "22"
+    source_address_prefix= "*"
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name= "MYSQL"
+    priority= 1002
+    direction= "Inbound"
+    access = "Allow"
+    protocol= "Tcp"
+    source_port_range= "*"
+    destination_port_range = "3306"
+    source_address_prefix= "*"
+    destination_address_prefix = "*"
+  }
+}
+
+# Create network interface
+resource "azurerm_network_interface" "my_terraform_nic" {
+  count= 2
+  name= "NIC-${format("%02d", count.index)}-test"
+  location= azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  ip_configuration {
+    name= "my_nic_configuration"
+    subnet_id = azurerm_subnet.my_terraform_subnet.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id= azurerm_public_ip.my_terraform_public_ip.*.id[count.index]
+  }
+}
+
+# Connect the security group to the network interface
+resource "azurerm_network_interface_security_group_association" "example" {
+  count= 2
+  network_interface_id= azurerm_network_interface.my_terraform_nic.*.id[count.index]
+  network_security_group_id = azurerm_network_security_group.my_terraform_nsg.id
+}
+
+# Generate random text for a unique storage account name
+resource "random_id" "random_id" {
+  keepers = {
+    # Generate a new ID only when a new resource group is defined
+    resource_group = azurerm_resource_group.rg.name
+  }
+
+  byte_length = 8
+}
+
+# Create storage account for boot diagnostics
+resource "azurerm_storage_account" "my_storage_account" {
+  name = "diag${random_id.random_id.hex}"
+  location = azurerm_resource_group.rg.location
+  resource_group_name= azurerm_resource_group.rg.name
+  account_tier = "Standard"
+  account_replication_type = "LRS"
+}
+
+# Create virtual machine
+resource "azurerm_linux_virtual_machine" "MYSQL_TEST" {
+  name= "MYSQL_TEST${format("%02d", count.index + 1)}"
+  count= 2
+  location= azurerm_resource_group.rg.location
+  resource_group_name= azurerm_resource_group.rg.name
+  network_interface_ids = [azurerm_network_interface.my_terraform_nic.*.id[count.index]]
+  size= "Standard_D2ps_v5"
+
+  os_disk {
+    name = "myOsDisk${format("%02d", count.index + 1)}"
+    caching= "ReadWrite"
+    storage_account_type = "Premium_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer = "0001-com-ubuntu-server-focal"
+    sku= "20_04-lts-arm64"
+    version= "20.04.202209200"
+  }
+
+  computer_name= "myvm"
+  admin_username= "ubuntu"
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username= "ubuntu"
+    public_key = file("~/.ssh/id_rsa.pub")
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.my_storage_account.primary_blob_endpoint
+  }
+}
+resource "local_file" "inventory" {
+    depends_on=[azurerm_linux_virtual_machine.MYSQL_TEST]
+    filename = "/tmp/inventory"
+    content = <<EOF
+[mysql1]
+${azurerm_linux_virtual_machine.MYSQL_TEST[0].public_ip_address}
+[mysql2]
+${azurerm_linux_virtual_machine.MYSQL_TEST[1].public_ip_address}
+[all:vars]
+ansible_connection=ssh
+ansible_user=ubuntu
+                EOF
+}
+```
+The inventory file is automatically generated and does not need to be changed.
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for Azure.
+
+```console
+terraform init
+```
+    
+The output should be similar to:
+
+```output
+Initializing the backend...
+
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/tls from the dependency lock file
+- Reusing previous version of hashicorp/azurerm from the dependency lock file
+- Reusing previous version of hashicorp/random from the dependency lock file
+- Using previously-installed hashicorp/local v2.4.0
+- Using previously-installed hashicorp/tls v4.0.4
+- Using previously-installed hashicorp/azurerm v2.99.0
+- Using previously-installed hashicorp/random v3.4.3
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```console
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all Azure resources. 
+
+```console
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create Azure resources. 
+
+The output should be similar to:
+
+```output
+Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
+```
+
+## Configure MySQL through Ansible
+
+Install MySQL and the required dependencies on both the instances.
+
+You can use the same `playbook.yaml` file used in the section, [Deploy Memcached as a cache for MySQL on an AWS Arm based Instance](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#configure-mysql-through-ansible).
+
+### Ansible Commands
+
+Substitute your private key name, and run the playbook using the  `ansible-playbook` command:
+
+```console
+ansible-playbook playbook.yaml -i /tmp/inventory
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```output
+PLAY [mysql1, mysql2] ********************************************************************************************************************************************
+
+TASK [Gathering Facts] *******************************************************************************************************************************************
+The authenticity of host '20.114.166.37 (20.114.166.37)' can't be established.
+ED25519 key fingerprint is SHA256:AFYNvATg2zT/PQJ8I5Qr0JKO+3Jwq6lGYSex4/2gDKs.
+This key is not known by any other names
+The authenticity of host '20.114.166.67 (20.114.166.67)' can't be established.
+ED25519 key fingerprint is SHA256:0gpYKMdRIHpFxaXePtYFxs+k6JSioKcVEN6CMrCJUBA.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+yes
+ok: [20.114.166.37]
+ok: [20.114.166.67]
+
+TASK [Update the Machine and Install dependencies] ***************************************************************************************************************
+changed: [20.114.166.37]
+changed: [20.114.166.67]
+
+TASK [start and enable mysql service] ****************************************************************************************************************************
+ok: [20.114.166.67]
+ok: [20.114.166.37]
+
+TASK [Change Root Password] **************************************************************************************************************************************
+changed: [20.114.166.37]
+changed: [20.114.166.67]
+
+TASK [Create database user with password and all database privileges and 'WITH GRANT OPTION'] ********************************************************************
+changed: [20.114.166.37]
+changed: [20.114.166.67]
+
+TASK [Create a new database with name 'arm_test1'] ***************************************************************************************************************
+skipping: [20.114.166.67]
+changed: [20.114.166.37]
+
+TASK [Create a new database with name 'arm_test2'] ***************************************************************************************************************
+skipping: [20.114.166.37]
+changed: [20.114.166.67]
+
+TASK [MySQL secure installation] *********************************************************************************************************************************
+changed: [20.114.166.67]
+changed: [20.114.166.37]
+
+TASK [Enable remote login by changing bind-address] **************************************************************************************************************
+changed: [20.114.166.67]
+changed: [20.114.166.37]
+
+RUNNING HANDLER [Restart mysql] **********************************************************************************************************************************
+changed: [20.114.166.67]
+changed: [20.114.166.37]
+
+PLAY RECAP *******************************************************************************************************************************************************
+20.114.166.37              : ok=9    changed=7    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+20.114.166.67              : ok=9    changed=7    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+```
+
+## Connect to Database from local machine
+
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#connect-to-database-from-local-machine) to connect to the database from local machine.
+
+## Deploy Memcached as a cache for MySQL using Python
+
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#deploy-memcached-as-a-cache-for-mysql-using-python) to deploy Memcached as a cache for MySQL using Python.
+
+You have successfully deployed Memcached as a cache for MySQL on an Azure Arm based Instance.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```
+
+Continue the Learning Path to deploy Memcached as a cache for MySQL on a GCP Arm based Instance.
+

--- a/content/learning-paths/server-and-cloud/memcached_cache/memcached_mysql_gcp.md
+++ b/content/learning-paths/server-and-cloud/memcached_cache/memcached_mysql_gcp.md
@@ -2,7 +2,7 @@
 # User change
 title: "Deploy Memcached as a cache for MySQL on a Google Cloud Arm based Instance"
 
-weight: 5 # 1 is first, 2 is second, etc.
+weight: 4 # 1 is first, 2 is second, etc.
 
 # Do not modify these elements
 layout: "learningpathall"

--- a/content/learning-paths/server-and-cloud/memcached_cache/memcached_psql_aws.md
+++ b/content/learning-paths/server-and-cloud/memcached_cache/memcached_psql_aws.md
@@ -1,0 +1,571 @@
+---
+# User change
+title: "Deploy Memcached as a cache for Postgres on an AWS Arm based Instance"
+
+weight: 5 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Deploy Memcached as a cache for Postgres on an AWS Arm based Instance
+
+You can deploy Memcached as a cache for Postgres on an AWS Arm based Instance using Terraform and Ansible. 
+
+In this section, you will deploy Memcached as a cache for Postgres on an AWS Instance. 
+
+If you are new to Terraform, you should look at [Automate AWS EC2 instance creation using Terraform](/learning-paths/server-and-cloud/aws-terraform/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need an [AWS account](https://portal.aws.amazon.com/billing/signup?nc2=h_ct&src=default&redirect_url=https%3A%2F%2Faws.amazon.com%2Fregistration-confirmation#/start) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin, you will also need:
+- An AWS access key ID and secret access key
+- An SSH key pair
+
+The instructions to create the keys are below.
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for AWS EC2 access. To generate the key-pair, follow this [
+guide](/install-guides/ssh#ssh-keys).
+
+{{% notice Note %}}
+If you already have an SSH key-pair present in the `~/.ssh` directory, you can skip this step.
+{{% /notice %}}
+
+
+### Acquire AWS Access Credentials
+
+The installation of Terraform on your desktop or laptop needs to communicate with AWS. Thus, Terraform needs to be able to authenticate with AWS.
+
+To generate and configure the Access key ID and Secret access key, follow this [guide](/install-guides/aws_access_keys).
+
+## Create an AWS EC2 instance using Terraform
+
+Using a text editor, save the code below in a file called `main.tf`.
+
+```console
+provider "aws" {
+  region = "us-east-2"
+}
+resource "aws_instance" "PSQL_TEST" {
+  count         = "2"
+  ami           = "ami-0ca2eafa23bc3dd01"
+  instance_type = "t4g.small"
+  security_groups= [aws_security_group.Terraformsecurity.name]
+  key_name = aws_key_pair.deployer.key_name
+
+  tags = {
+    Name = "PSQL_TEST"
+  }
+}
+resource "aws_default_vpc" "main" {
+  tags = {
+    Name = "main"
+  }
+}
+resource "aws_security_group" "Terraformsecurity" {
+  name        = "Terraformsecurity"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = aws_default_vpc.main.id
+
+ingress {
+    description      = "TLS from VPC"
+    from_port        = 5432
+    to_port          = 5432
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+}
+ingress {
+    description      = "TLS from VPC"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+ tags = {
+    Name = "Terraformsecurity"
+  }
+ }
+output "Master_public_IP" {
+  value = [aws_instance.PSQL_TEST[0].public_ip, aws_instance.PSQL_TEST[1].public_ip]
+}
+resource "aws_key_pair" "deployer" {
+        key_name   = "id_rsa"
+        public_key = file("~/.ssh/id_rsa.pub")
+} 
+// Generate inventory file
+resource "local_file" "inventory" {
+    depends_on= [aws_instance.PSQL_TEST]
+    filename = "/tmp/inventory"
+    content = <<EOF
+          [db_master]
+          ${aws_instance.PSQL_TEST[0].public_ip}
+          ${aws_instance.PSQL_TEST[1].public_ip}
+          [all:vars]
+          ansible_connection=ssh
+          ansible_user=ubuntu
+          EOF
+}    
+```
+Make the changes listed below in `main.tf` to match your account settings.
+
+1. In the `provider` section, update value to use your preferred AWS region.
+
+2. (optional) In the `aws_instance` section, change the ami value to your preferred Linux distribution. The AMI ID for Ubuntu 22.04 on Arm is `ami-0ca2eafa23bc3dd01`. No change is needed if you want to use Ubuntu AMI. 
+
+{{% notice Note %}}
+The instance type is t4g.small. This is an Arm-based instance and requires an Arm Linux distribution.
+{{% /notice %}}
+
+The inventory file is automatically generated and does not need to be changed.
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for AWS.
+
+```console
+terraform init
+```
+
+The output should be similar to:
+
+```output
+Initializing the backend...
+Initializing provider plugins...
+- Reusing previous version of hashicorp/local from the dependency lock file
+- Reusing previous version of hashicorp/aws from the dependency lock file
+- Using previously-installed hashicorp/local v2.3.0
+- Using previously-installed hashicorp/aws v4.52.0
+Terraform has been successfully initialized!
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```console
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all AWS resources.
+
+```console
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create AWS resources.
+
+The public IP address will be different, but the output should be similar to:
+
+```output
+Apply complete! Resources: 6 added, 0 changed, 0 destroyed.
+Outputs:
+Master_public_IP = [
+  "3.133.99.23",
+  "18.217.248.242",
+]
+```
+
+## Configure Postgres through Ansible
+
+Install Postgres and the required dependencies.
+
+Using a text editor, save the code below in a file called `playbook.yaml`. This Playbook installs & enables Postgres in the instances.
+
+```console
+---
+- hosts: all
+  become: yes
+
+  tasks:
+    - name: Update the Machine & Install PostgreSQL
+      shell: |
+             sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
+             sudo wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | sudo apt-key add -
+             sudo apt-get update
+             sudo apt-get install postgresql -y
+             sudo systemctl start postgresql
+      become: true
+    - name: Update apt repo and cache on all Debian/Ubuntu boxes
+      apt:  upgrade=yes update_cache=yes force_apt_get=yes cache_valid_time=3600
+      become: true
+    - name: Install Python pip and PostgreSQL package
+      apt: name={{ item }} update_cache=true state=present force_apt_get=yes
+      with_items:
+      - python3-pip
+      - acl
+      become: true
+    - name: Start and enable services
+      service: "name={{ item }} state=started enabled=yes"
+      with_items:
+      - postgresql
+    - name: Utility present
+      ansible.builtin.package:
+        name: python3-psycopg2
+        state: present
+    - name: Replace postgresql configuration file to allow remote connection
+      ansible.builtin.lineinfile:
+         path: "/etc/postgresql/15/main/postgresql.conf"
+         line: '{{ item }}'
+         owner: postgres
+         group: postgres
+         mode: '0777'
+      with_items:
+          - "listen_addresses = '*'"
+      become: yes
+      become_user: postgres
+    - name: Allow trust connection for the db user
+      postgresql_pg_hba:
+        dest: "/etc/postgresql/15/main/pg_hba.conf"
+        contype: host
+        databases: all
+        method: trust
+        address: 0.0.0.0/0
+        users: "all"
+        create: true
+      become: yes
+      become_user: postgres
+      notify: restart postgres
+
+  handlers:
+    - name: restart postgres
+      service: name=postgresql state=restarted        
+```
+
+### Ansible Commands
+
+Run the playbook using the  `ansible-playbook` command:
+
+```console
+ansible-playbook playbook.yaml -i /tmp/inventory
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```output
+PLAY [all] **************************************************************************************************************************************************
+TASK [Gathering Facts] **************************************************************************************************************************************
+ok: [3.133.99.23]
+ok: [18.217.248.242]
+TASK [Update the Machine & Install PostgreSQL] **************************************************************************************************************
+changed: [18.217.248.242]
+changed: [3.133.99.23]
+TASK [Update apt repo and cache on all Debian/Ubuntu boxes] *************************************************************************************************
+ok: [3.133.99.23]
+ok: [18.217.248.242]
+TASK [Install Python pip and PostgreSQL package] ***************************************************************************************************************
+ok: [18.217.248.242] => (item=python3-pip)
+ok: [3.133.99.23] => (item=python3-pip)
+TASK [Start and enable services] ****************************************************************************************************************************
+ok: [18.217.248.242] => (item=postgresql)
+ok: [3.133.99.23] => (item=postgresql)
+TASK [Utility present] **************************************************************************************************************************************
+ok: [3.133.99.23]
+ok: [18.217.248.242]
+TASK [Replace postgresql configuration file to allow remote connection] *************************************************************************************
+changed: [3.133.99.23] => (item=listen_addresses = '*')
+changed: [18.217.248.242] => (item=listen_addresses = '*')
+TASK [Allow trust connection for the db user] ***************************************************************************************************************
+ok: [3.133.99.23]
+ok: [18.217.248.242]
+PLAY RECAP **************************************************************************************************************************************************
+18.217.248.242             : ok=8    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+3.133.99.23                : ok=8    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+## Connect to Database from local machine
+
+To connect to the database, you need the `public-ip` of the instance where Postgres is deployed. You also need to use the Postgres Client to interact with the PostgreSQL database.
+
+```console
+apt install -y postgresql-client
+```
+
+```console
+psql -h {public_ip of instance where Postgres deployed} -U postgres
+```
+Replace `{public_ip of instance where Postgres deployed}` with your value. 
+
+The output will be:
+```output
+ubuntu@ip-172-31-38-39:~/psql$ psql -h 3.133.99.23 -U postgres
+psql (14.7 (Ubuntu 14.7-0ubuntu0.22.04.1), server 15.2 (Ubuntu 15.2-1.pgdg22.04+1))
+WARNING: psql major version 14, server major version 15.
+         Some psql features might not work.
+SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
+Type "help" for help.
+postgres=#
+```
+
+### Access Database and Create Table
+
+1. You can create and access your database by using the below commands.
+
+```console
+create database {your_database};
+```
+
+```console
+\c {your_database};
+```
+
+The output will be:
+
+```output
+postgres=# create database arm_test1;
+CREATE DATABASE
+postgres=# \c arm_test1
+psql (14.7 (Ubuntu 14.7-0ubuntu0.22.04.1), server 15.2 (Ubuntu 15.2-1.pgdg22.04+1))
+WARNING: psql major version 14, server major version 15.
+         Some psql features might not work.
+SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
+You are now connected to database "arm_test1" as user "postgres".```
+```
+
+2. Use the below commands to create a table and insert values into it.
+
+```console
+create table book(name char(10),id varchar(10));
+```
+```console
+insert into book(name,id) values ('Abook','10'),('Bbook','20'),('Cbook','20'),('Dbook','30'),('Ebook','45'),('Fbook','40'),('Gbook
+','69');
+```
+
+The output will be:
+
+```output
+arm_test1=# create table book(name char(10),id varchar(10));
+CREATE TABLE
+arm_test1=# insert into book(name,id) values ('Abook','10'),('Bbook','20'),('Cbook','20'),('Dbook','30'),('Ebook','45'),('Fbook','40'),('Gbook
+','69');
+INSERT 0 7
+```
+
+3. Use the below command to access the content of the table.
+
+```console
+select * from {{your_table_name}};
+```
+
+The output will be:
+
+```output
+arm_test1=# select * from book;
+    name    | id
+------------+----
+ Abook      | 10
+ Bbook      | 20
+ Cbook      | 20
+ Dbook      | 30
+ Ebook      | 45
+ Fbook      | 40
+ Gbook     +| 69
+            |
+(7 rows)
+```
+
+4. Now connect to the second instance and repeat the above steps with a different data as shown below.    
+
+The output will be:
+
+```output
+postgres=# create database arm_test2;
+CREATE DATABASE
+postgres=# \c arm_test2
+psql (14.7 (Ubuntu 14.7-0ubuntu0.22.04.1), server 15.2 (Ubuntu 15.2-1.pgdg22.04+1))
+WARNING: psql major version 14, server major version 15.
+         Some psql features might not work.
+SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
+You are now connected to database "arm_test2" as user "postgres".
+arm_test2=# create table movie(name char(10),id varchar(10));
+CREATE TABLE
+arm_test2=# insert into movie(name,id) values ('Amovie','1'), ('Bmovie','2'), ('Cmovie','3'), ('Dmovie','4'), ('Emovie','5'), ('Fmovie','6'), ('Gmovie','7');
+INSERT 0 7
+arm_test2=# select * from movie;
+    name    | id
+------------+----
+ Amovie     | 1
+ Bmovie     | 2
+ Cmovie     | 3
+ Dmovie     | 4
+ Emovie     | 5
+ Fmovie     | 6
+ Gmovie     | 7
+(7 rows)
+```
+
+## Deploy Memcached as a cache for Postgres using Python
+
+You will create two `.py` files on the host machine to deploy Memcached as a PostgreSQL cache using Python: `values.py` and `memcached.py`.  
+
+`values.py` to store the IP addresses of the instances and the databases created in them.
+```console
+PSQL_TEST=[["{{public_ip of PSQL_TEST[0]}}", "arm_test1"],
+["{{public_ip of PSQL_TEST[1]}}", "arm_test2"]]
+```
+Replace `{{public_ip of PSQL_TEST[0]}}` & `{{public_ip of PSQL_TEST[1]}}` with the public IPs generated in the `/tmp/inventory` file after running the Terraform commands.
+
+`memcached.py` to access data from Memcached and, if not present, store it in the Memcached.       
+```console
+import sys
+import psycopg2
+import pymemcache
+from values import *
+from ast import literal_eval
+import argparse
+parser = argparse.ArgumentParser()
+
+parser.add_argument("-db", "--database", help="Database")
+parser.add_argument("-k", "--key", help="Key")
+parser.add_argument("-q", "--query", help="Query")
+args = parser.parse_args()
+
+memc = pymemcache.Client("127.0.0.1:11211");
+
+for i in range(0,2):
+    if (PSQL_TEST[i][1]==args.database):
+        try:
+            conn = psycopg2.connect (host = PSQL_TEST[i][0], dbname = PSQL_TEST[i][1], user="postgres")
+        except psycopg2.OperationalError as e:
+             print('Unable to connect!\n{0}').format(e)
+             sys.exit (1)
+
+        psqldata = memc.get(args.key)
+
+        if not psqldata:
+            cursor = conn.cursor()
+            cursor.execute(args.query)
+            rows = cursor.fetchall()
+            memc.set(args.key,rows,120)
+            print ("Updated memcached with PSQL data")
+            for x in rows:
+                print(x)
+        else:
+            print ("Loaded data from memcached")
+            data = tuple(literal_eval(psqldata.decode("utf-8")))
+            for row in data:
+                print (row)
+        break
+else:
+    print("this database doesn't exist")        
+```
+Change the `range` in `for loop` according to the number of instances created.
+
+To execute the script, run the following command:
+```console
+python3 memcached.py -db {database_name} -k {key} -q {query}
+```
+Replace `{database_name}` with the database you want to access, `{query}` with the query you want to run in the database, and `{key}` with a variable to store the result of the query in Memcached.
+
+When the script is executed for the first time, the data is loaded from the PostgreSQL database and stored on the Memcached server.
+
+The output will be:
+```output
+ubuntu@ip-172-31-38-39:~/psql$ python3 memcached.py -db arm_test1 -k aa -q "select * from book limit 3"
+Updated memcached with PSQL data
+('Abook     ', '10')
+('Bbook     ', '20')
+('Cbook     ', '20')
+```
+```output
+ubuntu@ip-172-31-38-39:~/psql$ python3 memcached.py -db arm_test2 -k bb -q "select * from movie limit 3"
+Updated memcached with PSQL data
+('Amovie    ', '1')
+('Bmovie    ', '2')
+('Cmovie    ', '3')
+```
+
+When executed after that, it loads the data from Memcached. In the example above, the information stored in Memcached is in the form of rows from a Python DB cursor. When accessing the information (within the 120-second expiry time), the data is loaded from Memcached and dumped.
+
+The output will be:
+```output
+ubuntu@ip-172-31-38-39:~/psql$ python3 memcached.py -db arm_test1 -k aa -q "select * from book limit 3"
+Loaded data from memcached
+('Abook     ', '10')
+('Bbook     ', '20')
+('Cbook     ', '20')
+```
+
+```output
+ubuntu@ip-172-31-38-39:~/psql$ python3 memcached.py -db arm_test2 -k bb -q "select * from movie limit 3"
+Loaded data from memcached
+('Amovie    ', '1')
+('Bmovie    ', '2')
+('Cmovie    ', '3')
+```
+
+### Memcached Telnet Commands
+
+Execute the steps below to verify that the PostgreSQL query is getting stored in Memcached.
+1. Connect to the Memcached server with Telnet and start a session.
+```console
+telnet localhost 11211
+```
+2. Retrieve data from Memcached through Telnet.
+```console
+get <key>
+```
+**NOTE:-** Key is the variable in which we store the data. In the above command, we are storing the data from the tables `book` and `movie` in `AA` and `BB` respectively.
+
+The output will be:
+
+```output
+ubuntu@ip-172-31-38-39:~/psql$ telnet localhost 11211
+Trying 127.0.0.1...
+Connected to localhost.
+Escape character is '^]'.
+get aa
+VALUE aa 0 66
+[('Abook     ', '10'), ('Bbook     ', '20'), ('Cbook     ', '20')]
+END
+get bb
+VALUE bb 0 63
+[('Amovie    ', '1'), ('Bmovie    ', '2'), ('Cmovie    ', '3')]
+END
+^]
+telnet> close
+```
+
+You have successfully deployed Memcached as a cache for PostgreSQL on an AWS Arm based Instance.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```
+
+Continue the Learning Path to deploy Memcached as a cache for Postgres on an Azure Arm based Instance.

--- a/content/learning-paths/server-and-cloud/memcached_cache/memcached_psql_azure.md
+++ b/content/learning-paths/server-and-cloud/memcached_cache/memcached_psql_azure.md
@@ -1,20 +1,20 @@
 ---
 # User change
-title: "Deploy Memcached as a cache for MySQL on an Azure Arm based Instance"
+title: "Deploy Memcached as a cache for Postgres on an Azure Arm based Instance"
 
-weight: 4 # 1 is first, 2 is second, etc.
+weight: 6 # 1 is first, 2 is second, etc.
 
 # Do not modify these elements
 layout: "learningpathall"
 ---
 
-##  Deploy Memcached as a cache for MySQL on an Azure Arm based Instance
+##  Deploy Memcached as a cache for Postgres on an Azure Arm based Instance
 
-You can deploy Memcached as a cache for MySQL on Azure using Terraform and Ansible. 
+You can deploy Memcached as a cache for Postgres on Azure using Terraform and Ansible. 
 
-In this section, you will deploy Memcached as a cache for MySQL on an Azure instance. 
+In this section, you will deploy Memcached as a cache for Postgres on an Azure instance. 
 
-If you are new to Terraform, you should look at [Automate Azure instance creation using Terraform](/learning-paths/server-and-cloud/azure-terraform/terraform/) before starting this Learning Path.
+If you are new to Terraform, you should look at [Automate Azure instance creation using Terraform](/learning-paths/server-and-cloud/azure/terraform/) before starting this Learning Path.
 
 ## Before you begin
 
@@ -47,10 +47,10 @@ If you already have an SSH key-pair present in the `~/.ssh` directory, you can s
 
 ## Create Azure instances using Terraform
 
-For Azure Arm based instance deployment, the Terraform configuration is broken into three files: `providers.tf`, `variables.tf` and `main.tf`. Here you are creating 2 instances.
+For Azure Arm based instance deployment, the Terraform configuration is broken into three files: `providers.tf`, `variables.tf` and `main.tf`. Here we are creating 2 instances.
 
 Add the following code in `providers.tf` file to configure Terraform to communicate with Azure.
-    
+
 ```console
 terraform {
   required_version = ">=0.12"
@@ -145,13 +145,13 @@ resource "azurerm_network_security_group" "my_terraform_nsg" {
     destination_address_prefix = "*"
   }
   security_rule {
-    name= "MYSQL"
+    name= "PSQL"
     priority= 1002
     direction= "Inbound"
     access = "Allow"
     protocol= "Tcp"
     source_port_range= "*"
-    destination_port_range = "3306"
+    destination_port_range = "5432"
     source_address_prefix= "*"
     destination_address_prefix = "*"
   }
@@ -199,8 +199,8 @@ resource "azurerm_storage_account" "my_storage_account" {
 }
 
 # Create virtual machine
-resource "azurerm_linux_virtual_machine" "MYSQL_TEST" {
-  name= "MYSQL_TEST${format("%02d", count.index + 1)}"
+resource "azurerm_linux_virtual_machine" "PSQL_TEST" {
+  name= "PSQL_TEST${format("%02d", count.index + 1)}"
   count= 2
   location= azurerm_resource_group.rg.location
   resource_group_name= azurerm_resource_group.rg.name
@@ -234,13 +234,12 @@ resource "azurerm_linux_virtual_machine" "MYSQL_TEST" {
   }
 }
 resource "local_file" "inventory" {
-    depends_on=[azurerm_linux_virtual_machine.MYSQL_TEST]
+    depends_on=[azurerm_linux_virtual_machine.PSQL_TEST]
     filename = "/tmp/inventory"
     content = <<EOF
-[mysql1]
-${azurerm_linux_virtual_machine.MYSQL_TEST[0].public_ip_address}
-[mysql2]
-${azurerm_linux_virtual_machine.MYSQL_TEST[1].public_ip_address}
+[db_master]
+${azurerm_linux_virtual_machine.PSQL_TEST[0].public_ip_address}
+${azurerm_linux_virtual_machine.PSQL_TEST[1].public_ip_address}
 [all:vars]
 ansible_connection=ssh
 ansible_user=ubuntu
@@ -260,12 +259,11 @@ Run `terraform init` to initialize the Terraform deployment. This command downlo
 ```console
 terraform init
 ```
-    
+
 The output should be similar to:
 
 ```output
 Initializing the backend...
-
 Initializing provider plugins...
 - Reusing previous version of hashicorp/local from the dependency lock file
 - Reusing previous version of hashicorp/tls from the dependency lock file
@@ -275,13 +273,10 @@ Initializing provider plugins...
 - Using previously-installed hashicorp/tls v4.0.4
 - Using previously-installed hashicorp/azurerm v2.99.0
 - Using previously-installed hashicorp/random v3.4.3
-
 Terraform has been successfully initialized!
-
 You may now begin working with Terraform. Try running "terraform plan" to see
 any changes that are required for your infrastructure. All Terraform commands
 should now work.
-
 If you ever set or change modules or backend configuration for Terraform,
 rerun this command to reinitialize your working directory. If you forget, other
 commands will detect it and remind you to do so if necessary.
@@ -313,15 +308,15 @@ The output should be similar to:
 Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
 ```
 
-## Configure MySQL through Ansible
+## Configure Postgres through Ansible
 
-Install MySQL and the required dependencies on both the instances.
+Install Postgres and the required dependencies on both the instances.
 
-You can use the same `playbook.yaml` file used in the section, [Deploy Memcached as a cache for MySQL on an AWS Arm based Instance](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#configure-mysql-through-ansible).
+You can use the same `playbook.yaml` file used in the section, [Deploy Memcached as a cache for Postgres on an AWS Arm based Instance](/learning-paths/server-and-cloud/memcached/memcached_psql_aws#configure-postgres-through-ansible).
 
 ### Ansible Commands
 
-Substitute your private key name, and run the playbook using the  `ansible-playbook` command:
+Run the playbook using the  `ansible-playbook` command:
 
 ```console
 ansible-playbook playbook.yaml -i /tmp/inventory
@@ -334,70 +329,61 @@ Deployment may take a few minutes.
 The output should be similar to:
 
 ```output
-PLAY [mysql1, mysql2] ********************************************************************************************************************************************
-
-TASK [Gathering Facts] *******************************************************************************************************************************************
-The authenticity of host '20.114.166.37 (20.114.166.37)' can't be established.
-ED25519 key fingerprint is SHA256:AFYNvATg2zT/PQJ8I5Qr0JKO+3Jwq6lGYSex4/2gDKs.
+PLAY [all] *****************************************************************************************************************************************************
+TASK [Gathering Facts] *****************************************************************************************************************************************
+The authenticity of host '20.122.0.160 (20.122.0.160)' can't be established.
+ED25519 key fingerprint is SHA256:GhKxVqkbB/6iHm6oAWM0tI95xbUGZA/bPkcwAHPzfno.
 This key is not known by any other names
-The authenticity of host '20.114.166.67 (20.114.166.67)' can't be established.
-ED25519 key fingerprint is SHA256:0gpYKMdRIHpFxaXePtYFxs+k6JSioKcVEN6CMrCJUBA.
+The authenticity of host '20.119.220.61 (20.119.220.61)' can't be established.
+ED25519 key fingerprint is SHA256:wOq1vChpoThK8ctVUm1TeK+k73nguA+NVv6gKBMgNxw.
 This key is not known by any other names
 Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
 yes
-ok: [20.114.166.37]
-ok: [20.114.166.67]
-
-TASK [Update the Machine and Install dependencies] ***************************************************************************************************************
-changed: [20.114.166.37]
-changed: [20.114.166.67]
-
-TASK [start and enable mysql service] ****************************************************************************************************************************
-ok: [20.114.166.67]
-ok: [20.114.166.37]
-
-TASK [Change Root Password] **************************************************************************************************************************************
-changed: [20.114.166.37]
-changed: [20.114.166.67]
-
-TASK [Create database user with password and all database privileges and 'WITH GRANT OPTION'] ********************************************************************
-changed: [20.114.166.37]
-changed: [20.114.166.67]
-
-TASK [Create a new database with name 'arm_test1'] ***************************************************************************************************************
-skipping: [20.114.166.67]
-changed: [20.114.166.37]
-
-TASK [Create a new database with name 'arm_test2'] ***************************************************************************************************************
-skipping: [20.114.166.37]
-changed: [20.114.166.67]
-
-TASK [MySQL secure installation] *********************************************************************************************************************************
-changed: [20.114.166.67]
-changed: [20.114.166.37]
-
-TASK [Enable remote login by changing bind-address] **************************************************************************************************************
-changed: [20.114.166.67]
-changed: [20.114.166.37]
-
-RUNNING HANDLER [Restart mysql] **********************************************************************************************************************************
-changed: [20.114.166.67]
-changed: [20.114.166.37]
-
-PLAY RECAP *******************************************************************************************************************************************************
-20.114.166.37              : ok=9    changed=7    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
-20.114.166.67              : ok=9    changed=7    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+ok: [20.122.0.160]
+ok: [20.119.220.61]
+TASK [Update the Machine & Install PostgreSQL] *****************************************************************************************************************
+changed: [20.119.220.61]
+changed: [20.122.0.160]
+TASK [Update apt repo and cache on all Debian/Ubuntu boxes] ****************************************************************************************************
+changed: [20.122.0.160]
+changed: [20.119.220.61]
+TASK [Install PostgreSQL packages] *****************************************************************************************************************************
+changed: [20.122.0.160]
+changed: [20.119.220.61]
+TASK [Install Python pip & Python package] *********************************************************************************************************************
+changed: [20.119.220.61] => (item=python3-pip)
+changed: [20.122.0.160] => (item=python3-pip)
+TASK [Start and enable services] *******************************************************************************************************************************
+ok: [20.122.0.160] => (item=postgresql)
+ok: [20.119.220.61] => (item=postgresql)
+TASK [Utility present] *****************************************************************************************************************************************
+changed: [20.119.220.61]
+changed: [20.122.0.160]
+TASK [Replace postgresql configuration file to allow remote connection] ****************************************************************************************
+changed: [20.119.220.61] => (item=listen_addresses = '*')
+changed: [20.122.0.160] => (item=listen_addresses = '*')
+[WARNING]: Module remote_tmp /var/lib/postgresql/.ansible/tmp did not exist and was created with a mode of 0700, this may cause issues when running as another
+user. To avoid this, create the remote_tmp dir with the correct permissions manually
+TASK [Allow trust connection for the db user] ******************************************************************************************************************
+changed: [20.122.0.160]
+changed: [20.119.220.61]
+RUNNING HANDLER [restart postgres] *****************************************************************************************************************************
+changed: [20.119.220.61]
+changed: [20.122.0.160]
+PLAY RECAP *****************************************************************************************************************************************************
+20.119.220.61              : ok=10   changed=8    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+20.122.0.160               : ok=10   changed=8    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 ```
 
 ## Connect to Database from local machine
 
-Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#connect-to-database-from-local-machine) to connect to the database from local machine.
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_psql_aws#connect-to-database-from-local-machine) to connect to the database from local machine.
 
-## Deploy Memcached as a cache for MySQL using Python
+## Deploy Memcached as a cache for Postgres using Python
 
-Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_mysql_aws#deploy-memcached-as-a-cache-for-mysql-using-python) to deploy Memcached as a cache for MySQL using Python.
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_psql_aws#deploy-memcached-as-a-cache-for-postgres-using-python) to deploy Memcached as a cache for Postgres using Python.
 
-You have successfully deployed Memcached as a cache for MySQL on an Azure Arm based Instance.
+You have successfully deployed Memcached as a cache for PostgreSQL on an Azure Arm based Instance.
 
 ### Clean up resources
 
@@ -407,5 +393,4 @@ Run `terraform destroy` to delete all resources created.
 terraform destroy
 ```
 
-Continue the Learning Path to deploy Memcached as a cache for MySQL on a GCP Arm based Instance.
-
+Continue the Learning Path to deploy Memcached as a cache for Postgres on a GCP Arm based Instance.

--- a/content/learning-paths/server-and-cloud/memcached_cache/memcached_psql_gcp.md
+++ b/content/learning-paths/server-and-cloud/memcached_cache/memcached_psql_gcp.md
@@ -1,0 +1,263 @@
+---
+# User change
+title: "Deploy Memcached as a cache for Postgres on a Google Cloud Arm based Instance"
+
+weight: 7 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+##  Deploy Memcached as a cache for Postgres on a Google Cloud Arm based Instance
+
+You can deploy Memcached as a cache for Postgres on Google Cloud using Terraform and Ansible. 
+
+In this section, you will deploy Memcached as a cache for Postgres on a Google Cloud instance.
+
+If you are new to Terraform, you should look at [Automate GCP instance creation using Terraform](/learning-paths/server-and-cloud/gcp/terraform/) before starting this Learning Path.
+
+## Before you begin
+
+You should have the prerequisite tools installed before starting the Learning Path. 
+
+Any computer which has the required tools installed can be used for this section. The computer can be your desktop or laptop computer or a virtual machine with the required tools. 
+
+You will need a [Google Cloud account](https://console.cloud.google.com/?hl=en-au) to complete this Learning Path. Create an account if you don't have one.
+
+Before you begin you will also need:
+- Login to the Google Cloud CLI 
+- An SSH key pair
+
+The instructions to login to the Google Cloud CLI and create the keys are below.
+
+### Acquire GCP Access Credentials
+
+The installation of Terraform on your Desktop/Laptop needs to communicate with GCP. Thus, Terraform needs to be authenticated.
+
+To obtain GCP user credentials, follow this [guide](/install-guides/gcp_login).
+
+### Generate an SSH key-pair
+
+Generate an SSH key-pair (public key, private key) using `ssh-keygen` to use for GCP instance access. To generate the key-pair, follow this [
+guide](/install-guides/ssh#ssh-keys).
+
+{{% notice Note %}} 
+If you already have an SSH key-pair present in the `~/.ssh` directory, you can skip this step.
+{{% /notice %}}
+
+## Create GCP instances using Terraform
+
+Using a text editor, save the code below in a file called `main.tf`. Here we are creating 2 instances.
+
+```console
+provider "google" {
+  project = "{project_id}"
+  region = "us-central1"
+  zone = "us-central1-a"
+}
+
+resource "google_compute_instance" "PSQL_TEST" {
+  name         = "psqltest-${count.index+1}"
+  count        = "2"
+  machine_type = "t2a-standard-1"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts-arm64"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+  metadata = {
+     ssh-keys = "ubuntu:${file("~/.ssh/id_rsa.pub")}"
+  }
+}
+
+resource "google_compute_firewall" "rules" {
+  project     = "{project_id}"
+  name        = "my-firewall-rule"
+  network     = "default"
+  description = "Open ssh connection and psql port"
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol  = "tcp"
+    ports     = ["22", "5432"]
+  }
+}
+
+resource "google_compute_network" "default" {
+  name = "test-network1"
+}
+resource "local_file" "inventory" {
+    depends_on=[google_compute_instance.PSQL_TEST]
+    filename = "/tmp/inventory"
+    content = <<EOF
+[db_master]
+${google_compute_instance.PSQL_TEST[0].network_interface.0.access_config.0.nat_ip}
+${google_compute_instance.PSQL_TEST[1].network_interface.0.access_config.0.nat_ip}
+[all:vars]
+ansible_connection=ssh
+ansible_user=ubuntu
+                EOF
+}
+```
+In the `provider` and `google_compute_firewall` sections, update the `project_id` with your value.
+
+The inventory file is automatically generated and does not need to be changed.
+
+## Terraform Commands
+
+Use Terraform to deploy the `main.tf` file.
+
+### Initialize Terraform
+
+Run `terraform init` to initialize the Terraform deployment. This command downloads the dependencies required for GCP.
+
+```console
+terraform init
+```
+
+The output should be similar to:
+
+```output
+Initializing the backend...
+Initializing provider plugins...
+- Finding latest version of hashicorp/google...
+- Finding latest version of hashicorp/local...
+- Installing hashicorp/google v4.57.0...
+- Installed hashicorp/google v4.57.0 (signed by HashiCorp)
+- Installing hashicorp/local v2.4.0...
+- Installed hashicorp/local v2.4.0 (signed by HashiCorp)
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+Terraform has been successfully initialized!
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+### Create a Terraform execution plan
+
+Run `terraform plan` to create an execution plan.
+
+```console
+terraform plan
+```
+
+A long output of resources to be created will be printed. 
+
+### Apply a Terraform execution plan
+
+Run `terraform apply` to apply the execution plan and create all GCP resources. 
+
+```console
+terraform apply
+```      
+
+Answer `yes` to the prompt to confirm you want to create GCP resources. 
+
+The output should be similar to:
+
+```output
+Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
+```
+
+## Configure Postgres through Ansible
+
+Install Postgres and the required dependencies on both the instances. 
+
+You can use the same `playbook.yaml` file used in the section, [Deploy Memcached as a cache for Postgres on an AWS Arm based Instance](/learning-paths/server-and-cloud/memcached/memcached_psql_aws#configure-postgres-through-ansible).
+
+### Ansible Commands
+
+Run the playbook using the `ansible-playbook` command:
+
+```console
+ansible-playbook playbook.yaml -i /tmp/inventory
+```
+
+Answer `yes` when prompted for the SSH connection. 
+
+Deployment may take a few minutes. 
+
+The output should be similar to:
+
+```output
+PLAY [all] *****************************************************************************************************************************************************
+TASK [Gathering Facts] *****************************************************************************************************************************************
+The authenticity of host '34.123.220.201 (34.123.220.201)' can't be established.
+ED25519 key fingerprint is SHA256:uovagzUgma1rzZ5k4vLu2XytOB7c8zxmqwaZnCCc1fo.
+This key is not known by any other names
+The authenticity of host '34.66.63.213 (34.66.63.213)' can't be established.
+ED25519 key fingerprint is SHA256:QjI0vHnjqAI8ySD4JOzwnH6akD+UBpmHZiS0DV6xf7Q.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+yes
+ok: [34.123.220.201]
+ok: [34.66.63.213]
+TASK [Update the Machine & Install PostgreSQL] *****************************************************************************************************************
+changed: [34.123.220.201]
+changed: [34.66.63.213]
+TASK [Update apt repo and cache on all Debian/Ubuntu boxes] ****************************************************************************************************
+changed: [34.66.63.213]
+changed: [34.123.220.201]
+TASK [Install PostgreSQL packages] *****************************************************************************************************************************
+changed: [34.66.63.213]
+changed: [34.123.220.201]
+TASK [Install Python pip] **************************************************************************************************************************************
+changed: [34.66.63.213] => (item=python3-pip)
+changed: [34.123.220.201] => (item=python3-pip)
+TASK [Start and enable services] *******************************************************************************************************************************
+ok: [34.66.63.213] => (item=postgresql)
+ok: [34.123.220.201] => (item=postgresql)
+TASK [Utility present] *****************************************************************************************************************************************
+changed: [34.66.63.213]
+changed: [34.123.220.201]
+TASK [Replace postgresql configuration file to allow remote connection] ****************************************************************************************
+changed: [34.66.63.213] => (item=listen_addresses = '*')
+[WARNING]: Module remote_tmp /var/lib/postgresql/.ansible/tmp did not exist and was created with a mode of 0700, this may cause issues when running as another
+user. To avoid this, create the remote_tmp dir with the correct permissions manually
+changed: [34.123.220.201] => (item=listen_addresses = '*')
+TASK [Allow trust connection for the db user] ******************************************************************************************************************
+changed: [34.66.63.213]
+changed: [34.123.220.201]
+RUNNING HANDLER [restart postgres] *****************************************************************************************************************************
+changed: [34.66.63.213]
+changed: [34.123.220.201]
+PLAY RECAP *****************************************************************************************************************************************************
+34.123.220.201             : ok=10   changed=8    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+34.66.63.213               : ok=10   changed=8    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+## Connect to Database from local machine
+
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_psql_aws#connect-to-database-from-local-machine) to connect to the database from local machine.
+
+## Deploy Memcached as a cache for Postgres using Python
+
+Follow the instructions given in this [documentation](/learning-paths/server-and-cloud/memcached/memcached_psql_aws#deploy-memcached-as-a-cache-for-postgres-using-python) to deploy Memcached as a cache for PostgreSQL using Python.
+
+You have successfully deployed Memcached as a cache for PostgreSQL on a Google Cloud Arm based Instance.
+
+### Clean up resources
+
+Run `terraform destroy` to delete all resources created.
+
+```console
+terraform destroy
+```


### PR DESCRIPTION
- Added section to deploy Memcached as a cache for Postgres on an AWS Arm based Instance.
- Added section to deploy Memcached as a cache for Postgres on an Azure Arm based Instance.
- Added section to deploy Memcached as a cache for Postgres on a Google Cloud Arm based Instance.