### PR TITLE
Fixed: search bar width for install guide 

### DIFF
--- a/assets/css/cross-page.css
+++ b/assets/css/cross-page.css
@@ -133,8 +133,11 @@ label {
 /* Fix Search Height and pdding*/
 ads-search#search-box {
         min-height: 45px;
-        padding-left: 14px;             /*provide spacing to search field from left*/
-        padding-right: 14px;            /*provide spacing to search field from right*/
+}
+/*in install guides provide spacing to search field from left and right*/
+ads-search#search-box.install-guide{
+        padding-left: 14px;             
+        padding-right: 14px;
 }
 
 

--- a/themes/arm-design-system-hugo-theme/layouts/install-guides/list.html
+++ b/themes/arm-design-system-hugo-theme/layouts/install-guides/list.html
@@ -2,13 +2,13 @@
 A list page that shows all Tool Install Guide pages.
 
 Where it is used:
-    - /install-guides/
+- /install-guides/
 
 Called from:
-    - baseof
+- baseof
 
 Calls to:
-    - partial filter-search-sort/active-filter-and-sort-bar.html
+- partial filter-search-sort/active-filter-and-sort-bar.html
 */}}
 
 {{define "main"}}
@@ -18,40 +18,43 @@ Calls to:
 
 <!-- Filter replacement: List of additional search terms -->
 <p class="u-margin-top-1 u-margin-left-1 u-margin-bottom-1/2 u-font-size-90%">
-    Don't know a tool by name to search for? Try these common search terms:   
+    Don't know a tool by name to search for? Try these common search terms:
     {{- range $i, $e := .Params.additional_search_terms -}}
-        {{- if $i -}}
-            , 
-        {{- end -}}
-        &nbsp;<a class="common-search-term-link" href='/install-guides/?search={{$e}}'>{{$e}}</a>
+    {{- if $i -}}
+    ,
+    {{- end -}}
+    &nbsp;<a class="common-search-term-link" href='/install-guides/?search={{$e}}'>{{$e}}</a>
     {{- end -}}
     .
 </p>
 
-<ads-search class="u-margin-top-0" has-search-button id="search-box" placeholder="Search by tool name"></ads-search>
+<ads-search class="u-margin-top-0 install-guide" has-search-button id="search-box"
+    placeholder="Search by tool name"></ads-search>
 
 <!-- Bars containing Active Filter tags, how many content are displayed, and sorting info -->
-{{ partial "filter-search-sort/active-filter-and-sort-bar.html" (dict "content_to_list" $tools_to_list "page_type" "tools")}} 
+{{ partial "filter-search-sort/active-filter-and-sort-bar.html" (dict "content_to_list" $tools_to_list "page_type"
+"tools")}}
 
 
 <!-- Page wrapping row and column -->
 <div class="c-row">
     <div class="c-col">
-        <div class="u-display-grid u-gap-1 xs:u-grid-columns-1 sm:u-grid-columns-2 md:u-grid-columns-3 lg:u-grid-columns-4 xl:u-grid-columns-5 u-margin-top-1">
+        <div
+            class="u-display-grid u-gap-1 xs:u-grid-columns-1 sm:u-grid-columns-2 md:u-grid-columns-3 lg:u-grid-columns-4 xl:u-grid-columns-5 u-margin-top-1">
             {{ range $tools_to_list}}
-              <!-- div used for search hiding via additional search terms -->
-              <div class='search-div
+            <!-- div used for search hiding via additional search terms -->
+            <div class='search-div
                           {{ with .Params.additional_search_terms }}
                               {{range .}}
                                   term-{{. | urlize}}
                               {{end}}
                           {{ end }}'>
-                  <ads-card has-hover-effect class="tool-card" link="{{.Permalink}}">
-                      <ads-card-content class="tool-card-content" slot="content">
-                          <p class="search-title install-guide-title">{{.Title}}</p>
-                      </ads-card-content>   
-                  </ads-card>
-              </div>
+                <ads-card has-hover-effect class="tool-card" link="{{.Permalink}}">
+                    <ads-card-content class="tool-card-content" slot="content">
+                        <p class="search-title install-guide-title">{{.Title}}</p>
+                    </ads-card-content>
+                </ads-card>
+            </div>
             {{end}}
         </div>
     </div>

--- a/themes/arm-design-system-hugo-theme/layouts/install-guides/list.html
+++ b/themes/arm-design-system-hugo-theme/layouts/install-guides/list.html
@@ -2,13 +2,13 @@
 A list page that shows all Tool Install Guide pages.
 
 Where it is used:
-- /install-guides/
+    - /install-guides/
 
 Called from:
-- baseof
+    - baseof
 
 Calls to:
-- partial filter-search-sort/active-filter-and-sort-bar.html
+    - partial filter-search-sort/active-filter-and-sort-bar.html
 */}}
 
 {{define "main"}}
@@ -18,43 +18,40 @@ Calls to:
 
 <!-- Filter replacement: List of additional search terms -->
 <p class="u-margin-top-1 u-margin-left-1 u-margin-bottom-1/2 u-font-size-90%">
-    Searching, but don't know the name of the tool? Try these common search terms:
+    Don't know a tool by name to search for? Try these common search terms:   
     {{- range $i, $e := .Params.additional_search_terms -}}
-    {{- if $i -}}
-    ,
-    {{- end -}}
-    &nbsp;<a class="common-search-term-link" href='/install-guides/?search={{$e}}'>{{$e}}</a>
+        {{- if $i -}}
+            , 
+        {{- end -}}
+        &nbsp;<a class="common-search-term-link" href='/install-guides/?search={{$e}}'>{{$e}}</a>
     {{- end -}}
     .
 </p>
 
-<ads-search class="u-margin-top-0 install-guide" has-search-button id="search-box"
-    placeholder="Search by tool name"></ads-search>
+<ads-search class="u-margin-top-0 install-guide" has-search-button id="search-box" placeholder="Search by tool name"></ads-search>
 
 <!-- Bars containing Active Filter tags, how many content are displayed, and sorting info -->
-{{ partial "filter-search-sort/active-filter-and-sort-bar.html" (dict "content_to_list" $tools_to_list "page_type"
-"tools")}}
+{{ partial "filter-search-sort/active-filter-and-sort-bar.html" (dict "content_to_list" $tools_to_list "page_type" "tools")}} 
 
 
 <!-- Page wrapping row and column -->
 <div class="c-row">
     <div class="c-col">
-        <div
-            class="u-display-grid u-gap-1 xs:u-grid-columns-1 sm:u-grid-columns-2 md:u-grid-columns-3 lg:u-grid-columns-4 xl:u-grid-columns-5 u-margin-top-1">
+        <div class="u-display-grid u-gap-1 xs:u-grid-columns-1 sm:u-grid-columns-2 md:u-grid-columns-3 lg:u-grid-columns-4 xl:u-grid-columns-5 u-margin-top-1">
             {{ range $tools_to_list}}
-            <!-- div used for search hiding via additional search terms -->
-            <div class='search-div
+              <!-- div used for search hiding via additional search terms -->
+              <div class='search-div
                           {{ with .Params.additional_search_terms }}
                               {{range .}}
                                   term-{{. | urlize}}
                               {{end}}
                           {{ end }}'>
-                <ads-card has-hover-effect class="tool-card" link="{{.Permalink}}">
-                    <ads-card-content class="tool-card-content" slot="content">
-                        <p class="search-title install-guide-title">{{.Title}}</p>
-                    </ads-card-content>
-                </ads-card>
-            </div>
+                  <ads-card has-hover-effect class="tool-card" link="{{.Permalink}}">
+                      <ads-card-content class="tool-card-content" slot="content">
+                          <p class="search-title install-guide-title">{{.Title}}</p>
+                      </ads-card-content>   
+                  </ads-card>
+              </div>
             {{end}}
         </div>
     </div>

--- a/themes/arm-design-system-hugo-theme/layouts/install-guides/list.html
+++ b/themes/arm-design-system-hugo-theme/layouts/install-guides/list.html
@@ -18,7 +18,7 @@ Calls to:
 
 <!-- Filter replacement: List of additional search terms -->
 <p class="u-margin-top-1 u-margin-left-1 u-margin-bottom-1/2 u-font-size-90%">
-    Don't know a tool by name to search for? Try these common search terms:
+    Searching, but don't know the name of the tool? Try these common search terms:
     {{- range $i, $e := .Params.additional_search_terms -}}
     {{- if $i -}}
     ,


### PR DESCRIPTION
Fixed: search bar width for install guide only
as previously it was affecting the search bar on other pages also