### PR TITLE
Updated AWS,Azure,GCP learning paths

### DIFF
--- a/content/learning-paths/servers-and-cloud-computing/aws-terraform/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/aws-terraform/_index.md
@@ -8,7 +8,7 @@ who_is_this_for: This is an introductory topic for software developers who are n
 learning_objectives: 
     - Automate AWS EC2 instance creation using Terraform
     - Deploy Arm instances on AWS and provide access via Jump Server
-    - Give you Infrastructure as Code knowledge and files that could help with future learning paths
+    - Provide infrastructure basics, code knowledge and files that could help with future learning paths
 
 prerequisites:
     - An Amazon Web Services (AWS) [account](https://aws.amazon.com/)

--- a/content/learning-paths/servers-and-cloud-computing/aws-terraform/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/aws-terraform/_index.md
@@ -8,6 +8,7 @@ who_is_this_for: This is an introductory topic for software developers who are n
 learning_objectives: 
     - Automate AWS EC2 instance creation using Terraform
     - Deploy Arm instances on AWS and provide access via Jump Server
+    - Give you Infrastructure as Code knowledge and files that could help with future learning paths
 
 prerequisites:
     - An Amazon Web Services (AWS) [account](https://aws.amazon.com/)

--- a/content/learning-paths/servers-and-cloud-computing/aws-terraform/jump_server_aws.md
+++ b/content/learning-paths/servers-and-cloud-computing/aws-terraform/jump_server_aws.md
@@ -7,9 +7,17 @@ weight: 3 # 1 is first, 2 is second, etc.
 # Do not modify these elements
 layout: "learningpathall"
 ---
+## Infrastructure automation for other Learning Paths
+
+Some learning paths may require one or more server nodes to complete. The Terraform files shown here can be used as a platform to work on those learning paths. The intent is for you to modify these as needed to support other learning path activities.
+
 ## Introduction to Jump Server
 
 A Jump Server (also known as a bastion host) is an intermediary device responsible for funneling traffic through firewalls using a supervised secure channel. By creating a barrier between networks, jump servers create an added layer of security against outsiders wanting to maliciously access sensitive company data. Only those with the right credentials can log into a jump server and obtain authorization to proceed to a different security zone.
+
+{{% notice Note %}}
+An alternative to setting up a Jump server like below is to use [Linux Bastion Hosts](https://aws.amazon.com/solutions/implementations/linux-bastion/) or [AWS Systems Manager service](https://aws.amazon.com/systems-manager/).
+{{% /notice %}}
 
 ## Deploying Arm instances on AWS and providing access via Jump Server
 

--- a/content/learning-paths/servers-and-cloud-computing/azure-terraform/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/azure-terraform/_index.md
@@ -10,7 +10,7 @@ who_is_this_for: This is an introductory topic for software developers who are n
 learning_objectives: 
     - Automate Arm virtual machine creation using Terraform
     - Deploy Arm VMs on Azure and provide access via Jump Server
-    - Give you Infrastructure as Code knowledge and files that could help with future learning paths
+    - Provide infrastructure basics, code knowledge and files that could help with future learning paths
 
 prerequisites:
     - An Azure account

--- a/content/learning-paths/servers-and-cloud-computing/azure-terraform/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/azure-terraform/_index.md
@@ -10,6 +10,7 @@ who_is_this_for: This is an introductory topic for software developers who are n
 learning_objectives: 
     - Automate Arm virtual machine creation using Terraform
     - Deploy Arm VMs on Azure and provide access via Jump Server
+    - Give you Infrastructure as Code knowledge and files that could help with future learning paths
 
 prerequisites:
     - An Azure account

--- a/content/learning-paths/servers-and-cloud-computing/azure-terraform/jump_server.md
+++ b/content/learning-paths/servers-and-cloud-computing/azure-terraform/jump_server.md
@@ -7,6 +7,9 @@ weight: 3 # 1 is first, 2 is second, etc.
 # Do not modify these elements
 layout: "learningpathall"
 ---
+## Infrastructure automation for other Learning Paths
+
+Some learning paths may require one or more server nodes to complete. The Terraform files shown here can be used as a platform to work on those learning paths. The intent is for you to modify these as needed to support other learning path activities.
 
 ## Introduction to Jump Server
 

--- a/content/learning-paths/servers-and-cloud-computing/gcp/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/gcp/_index.md
@@ -8,7 +8,7 @@ who_is_this_for: This is an introductory topic for anyone new to using Arm virtu
 learning_objectives:
     - Automate Arm virtual machine creation using Terraform
     - Deploy Arm instances on GCP and provide access via Jump Server
-    - Give you Infrastructure as Code knowledge and files that could help with future learning paths
+    - Provide infrastructure basics, code knowledge and files that could help with future learning paths
 
 prerequisites:
     - A [Google Cloud account](https://console.cloud.google.com/). Create an account if needed.

--- a/content/learning-paths/servers-and-cloud-computing/gcp/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/gcp/_index.md
@@ -8,6 +8,7 @@ who_is_this_for: This is an introductory topic for anyone new to using Arm virtu
 learning_objectives:
     - Automate Arm virtual machine creation using Terraform
     - Deploy Arm instances on GCP and provide access via Jump Server
+    - Give you Infrastructure as Code knowledge and files that could help with future learning paths
 
 prerequisites:
     - A [Google Cloud account](https://console.cloud.google.com/). Create an account if needed.

--- a/content/learning-paths/servers-and-cloud-computing/gcp/jump_server.md
+++ b/content/learning-paths/servers-and-cloud-computing/gcp/jump_server.md
@@ -7,11 +7,18 @@ weight: 3 # 1 is first, 2 is second, etc.
 # Do not modify these elements
 layout: "learningpathall"
 ---
+## Infrastructure automation for other Learning Paths
+
+Some learning paths may require one or more server nodes to complete. The Terraform files shown here can be used as a platform to work on those learning paths. The intent is for you to modify these as needed to support other learning path activities.
 
 ## Deploy Arm instances on GCP and provide access via Jump Server
 
 ### Introduction to Jump Server
 A Jump Server (also known as a bastion host) is an intermediary device responsible for funneling traffic through firewalls using a supervised secure channel. By creating a barrier between networks, jump servers create an added layer of security against outsiders wanting to maliciously access sensitive company data. Only those with the right credentials can log into a jump server and obtain authorization to proceed to a different security zone.
+
+{{% notice Note %}}
+An alternative to setting up a Jump server like below is to use [IAP](https://cloud.google.com/compute/docs/connect/ssh-using-iap).
+{{% /notice %}}
 
 ### Generate an SSH key pair
 


### PR DESCRIPTION
- Added a note about how the different terraform deployment learning paths can be a used as a platform for completing other learning paths. The intent is to have other learning paths point back to these if users do not already have their own infrastructure to work with.
- Added notes about alternatives to doing a manual jump server.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [X] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.
- [X] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
