### PR TITLE
Updated migrating to arm servers

### DIFF
--- a/content/learning-paths/servers-and-cloud-computing/migration/c-c++.md
+++ b/content/learning-paths/servers-and-cloud-computing/migration/c-c++.md
@@ -10,32 +10,11 @@ layout: "learningpathall"
 
 ## C/C++ on Arm Neoverse processors
 
-### Enabling Architecture Specific Features
-
-You can use the table below to build C/C++ applications with the optimal processor features.
-
-Select Neoverse-N1 if you want to run your application on both Neoverse-N1 and Neoverse-V1 processors. 
-
-Applications compiled for Neoverse-V1 will not run on Neoverse-N1. 
-
-Use `-mcpu=` to specify the architecture and tuning. Using `-mcpu=` is generally better than using `-march=`. 
-
-CPU       | Flag    | GCC version      | LLVM version
-----------|---------|-------------------|-------------
-Neoverse-N1 | `-mcpu=neoverse-n1` | GCC-9+ | Clang/LLVM 10+
-Neoverse-V1 | `-mcpu=neoverse-512tvb` | GCC-11+ | Clang/LLVM 14+
-
-If your compiler doesn't support `-mcpu=neoverse-512tvb`, use `-mcpu=neoverse-n1` instead. 
-
-If your compiler doesn't support `-mcpu=neoverse-n1`, use `-mcpu=cortex-a72` instead.
-
-The Neoverse-N1 option `-mcpu=neoverse-n1` is available in GCC-7 on Amazon Linux2.
-
 ### Compilers
 
 Newer compilers provide better support and optimizations for Arm Neoverse processors. You should use the latest compiler available for the operating system you are using.
 
-The table below shows GCC and LLVM compiler versions available in Linux distributions. The starred version is the default compiler for the Linux distribution.
+The table below shows GCC and LLVM compiler versions available in Linux distributions. The starred version is the default compiler version for the Linux distribution. If a newer version is available over the default, it's recommended to install that version.
 
 Linux Distribution      | GCC                  | Clang/LLVM
 ------------------------|----------------------|-------------
@@ -48,6 +27,69 @@ Debian10                | 7, 8*                | 6, 7, 8
 Red Hat EL8             | 8*, 9, 10            | 10
 SUSE Linux ES15         | 7*, 9, 10            | 7
 
+### GCC Neoverse CPU targets
+
+If the application will be executed on the same processor it is being compiled on, then simply use `-mcpu=native`. GCC will produce the most optimized binary.
+
+If the application will be executed on a different processor from the one it is being compiled on, don't use `-mcpu=native`. In that case, you can reference the table below.
+
+CPU       | Flag    | GCC version      | LLVM version
+----------|---------|-------------------|-------------
+Any | `-mcpu=native` | All | All
+Neoverse-N1 | `-mcpu=neoverse-n1` | GCC-9+ | Clang/LLVM 10+
+Neoverse-V1 | `-mcpu=neoverse-v1` | GCC-11+ | Clang/LLVM 12+
+Neoverse-N2 | `-mcpu=neoverse-n2` | GCC-11+ | Clang/LLVM 12+
+
+The Neoverse-N1 option `-mcpu=neoverse-n1` is available in GCC-7 on Amazon Linux2.
+
+There are other options like `-march` (ISA version) and `-mtune` (specific processor implementation). These are discussed in the [GCC Arm options documentation](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html). However, in general, only `-mcpu` should be used. `-mcpu` is basically a single option that combines `-march` and `-mcpu` together. Last, keep in mind that if an application targets an older processor, it will likely be able to execute on a newer processor (less some optimizations for the newer processor). However, if the application targets a newer processor, it might not execute on an older processor. This is true for any processor architecture, not just Arm.
+
+If `-mcpu` (and `-march` and `-mtune` for that matter) are not used, GCC will use a default value for `-march` (ISA version). This default for a given version of GCC can be viewed by running the following command.
+
+```console
+gcc -Q --help=target
+```
+
+Below is an example output for GCC 11.3.0
+
+``` output
+The following options are target specific:
+  -mabi=                                lp64
+  -march=                               armv8-a
+  -mbig-endian                          [disabled]
+  -mbionic                              [disabled]
+  -mbranch-protection=
+  -mcmodel=                             small
+  -mcpu=                                generic
+  -mfix-cortex-a53-835769               [enabled]
+  -mfix-cortex-a53-843419               [enabled]
+  -mgeneral-regs-only                   [disabled]
+  -mglibc                               [enabled]
+  -mharden-sls=
+  -mlittle-endian                       [enabled]
+  -mlow-precision-div                   [disabled]
+  -mlow-precision-recip-sqrt            [disabled]
+  -mlow-precision-sqrt                  [disabled]
+  -mmusl                                [disabled]
+  -momit-leaf-frame-pointer             [enabled]
+  -moutline-atomics                     [enabled]
+  -moverride=<string>
+  -mpc-relative-literal-loads           [enabled]
+  -msign-return-address=                none
+  -mstack-protector-guard-offset=
+  -mstack-protector-guard-reg=
+  -mstack-protector-guard=              global
+  -mstrict-align                        [disabled]
+  -msve-vector-bits=<number>            scalable
+  -mtls-dialect=                        desc
+  -mtls-size=                           24
+  -mtrack-speculation                   [disabled]
+  -mtune=                               generic
+  -muclibc                              [disabled]
+  -mverbose-cost-dump                   [disabled]
+```
+
+Notice that this version of GCC defaults `-march` to Arm ISA version ARMv8.A (v8.0). This could be under optimized if the application will run an on ISA version that is newer than ARMv8.A (8.0). However, it will result in a binary that can execute across a wider spectrum of Arm processors. This is precisely why the default is ARMv8.A and not something newer like ARMv8.3-A (or ARMv9.0-A). If you know the minimum ISA version of CPU your application will execute on, you could also consider selecting the ISA. This can be done with either the `-mcpu` (recommended) or `-march` switches. Valid values for the ISA version can be found in the [GCC Arm options documentation](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
 
 ### Large-System Extensions
 


### PR DESCRIPTION
- Swapped the order of the compilier and GCC options section. This makes more logical sense to go from general (compiliers) to specifics (compilier options)
- Added that general recommendation of just using -mcpu=native when possible. Also added additional information on compiler options


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.
- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
