### PR TITLE
Example learning path: hugo server must be run from repo root

### DIFF
--- a/content/learning-paths/cross-platform/_example-learning-path/setup.md
+++ b/content/learning-paths/cross-platform/_example-learning-path/setup.md
@@ -85,9 +85,12 @@ Check Hugo is installed correctly and check the version by running this command:
 ```bash
 hugo version
 ```
-Run hugo to launch a development version of website on your machine.
+
+Navigate into the `arm-learning-paths` folder and run hugo to launch a
+development version of website on your machine.
 
 ```bash
+cd arm-learning-paths
 hugo server
 ```
 
@@ -158,9 +161,11 @@ There are a number of good options for text editors if you don't have a full Lin
 
 To use Visual Studio Code in the browser on your remote Linux server check the install information for [OpenVSCode Server](/install-guides/openvscode-server/) and [VS Code Tunnels](/install-guides/vscode-tunnels/)
 
-Run hugo to launch a development version of website on your machine.
+Navigate into the `arm-learning-paths` folder and run hugo to launch a
+development version of website on your machine.
 
 ```bash
+cd arm-learning-paths
 hugo server
 ```
 


### PR DESCRIPTION
If one takes the instructions literally they get:
```
Error: command error: Unable to locate config file or config directory. Perhaps you need to create a new site.
```

All that's missing is changing into the git checkout dir before running hugo.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [ ] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.
- [ ] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
