### PR TITLE
Link directly to GitHub's Pull Request documentation

### DIFF
--- a/content/learning-paths/cross-platform/_example-learning-path/contribute.md
+++ b/content/learning-paths/cross-platform/_example-learning-path/contribute.md
@@ -55,7 +55,8 @@ After you have reviewed the new material using `hugo server` and there are no is
 You can now submit a GitHub pull request. 
 
 {{% notice Note%}}
-If you are new to GitHub, find a tutorial about how to create a pull request from a GitHub fork.
+If you are new to GitHub, please go to [GitHub's documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
+to learn how to create a pull request from a GitHub fork.
 {{% /notice %}}
 
 Optionally, if you would like to add your new Learning Path content to the automated testing framework, follow the guidelines in the [Appendix: How to test your code](/learning-paths/cross-platform/_example-learning-path/appendix-3-test).


### PR DESCRIPTION
This is likely (and was for me) the first result of searching Google for the same thing. Removes a small amount of friction if we just link to it directly since it is the official page.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.
- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
