### PR TITLE
Ignore unformatted text blocks that are not scripts or files

### DIFF
--- a/tools/parse.py
+++ b/tools/parse.py
@@ -212,11 +212,15 @@ def save(article, cmd, learningpath=False, img=None):
         # for other types, we're assuming source code
         # check if a file name is specified
         else:
-            content[i_idx] = {"type": l[0]}
-            # check file name
+            # check for a file name
             if "file_name" in l[0]:
+                content[i_idx] = {"type": l[0]}
                 fn = l[0].split("file_name=\"")[1].split("\"")[0]
                 content[i_idx].update({"file_name": fn })
+            else:
+                # No file name means it is some unformatted text, rather than
+                # some executable script or code. Skip it.
+                continue
 
         for j_idx,j in enumerate(l[1:]):
             content[i_idx].update({j_idx: j})


### PR DESCRIPTION
While testing a learning path I had one page that used the triple backtick blocks just to show some plain text diagrams, but nothing else.

The test runner thought these were tests, but then didn't set any commands for them, as there's nothing it can do with them.

```
Traceback (most recent call last):
  File "./tools/maintenance.py", line 171, in <module>
    main()
  File "./tools/maintenance.py", line 148, in main
    check_lp(args.instructions, args.link, args.debug)
  File "./tools/maintenance.py", line 60, in check_lp
    res.append(check.check(lp_path + "/" + i[0], start=launch, stop=terminate))
  File "/home/davspi01/work/open_source/arm-learning-paths/tools/check.py", line 196, in check
    for j in range(0, t["ncmd"]):
KeyError: 'ncmd'
```

What we should do is not treat these blocks as tests at all, so that "ntests" is 0 by the time we get to check.py.

check.py is already handling "ntests" being not present or set to 0 so it all works out.

If you had a mix of triple backtick blocks, we'd skip the non-executable ones and the executable ones will still become tests and commands.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.
- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
