### PR TITLE
Fix UnboundLocalError for username when testing multiple learning path pages

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -92,8 +92,8 @@ def check(json_file, start, stop):
             subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
             # Create user and configure
-            username="user"
             if  "arm-tools" in img:
+                # These images already have a user account set up.
                 username="ubuntu"
                 cmd = ["docker exec test_{} apt update".format(i)]
                 logging.debug(cmd)
@@ -157,6 +157,7 @@ def check(json_file, start, stop):
 
     # Run bash commands
     for i in range(0, data["ntests"]):
+        username = "ubuntu" if "arm-tools" in data["image"][0] else "user"
         t = data["{}".format(i)]
 
         # Check if file name is specified

--- a/tools/check.py
+++ b/tools/check.py
@@ -93,8 +93,7 @@ def check(json_file, start, stop):
 
             # Create user and configure
             if  "arm-tools" in img:
-                # These images already have a user account set up.
-                username="ubuntu"
+                # These images already have a 'ubunutu' user account set up.
                 cmd = ["docker exec test_{} apt update".format(i)]
                 logging.debug(cmd)
                 subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
@@ -157,7 +156,6 @@ def check(json_file, start, stop):
 
     # Run bash commands
     for i in range(0, data["ntests"]):
-        username = "ubuntu" if "arm-tools" in data["image"][0] else "user"
         t = data["{}".format(i)]
 
         # Check if file name is specified
@@ -211,6 +209,7 @@ def check(json_file, start, stop):
         else:
             inst = range(0, len(data["image"]))
 
+        username = "ubuntu" if "arm-tools" in data["image"][0] else "user"
         for k in inst:
             # Copy over the file with commands
             cmd = ["docker cp {} test_{}:/home/{}/".format(fn, k, username)]


### PR DESCRIPTION
Prior to this change, when I tested a learning path that had >1 page using `ubuntu:latest` I got:
```
Traceback (most recent call last):
  File "./tools/maintenance.py", line 171, in <module>
    main()
  File "./tools/maintenance.py", line 148, in main
    check_lp(args.instructions, args.link, args.debug)
  File "./tools/maintenance.py", line 60, in check_lp
    res.append(check.check(lp_path + "/" + i[0], start=launch, stop=terminate))
  File "/home/davspi01/work/open_source/arm-learning-paths/tools/check.py", line 215, in check
    cmd = ["docker cp {} test_{}:/home/{}/".format(fn, k, username)]
UnboundLocalError: local variable 'username' referenced before assignment
```

This happened because username is only set when `start` is true and this only happens for the first page.

```
[INFO]	Checking how-to-1.md
> /home/davspi01/work/open_source/arm-learning-paths/tools/check.py(83)check()
-> with open(json_file) as jf:
(Pdb) print(start, stop)
True False
(Pdb) c
[INFO]	Checking how-to-3.md
> /home/davspi01/work/open_source/arm-learning-paths/tools/check.py(83)check()
-> with open(json_file) as jf:
(Pdb) print(start, stop)
False False
(Pdb) c
[INFO]	Checking how-to-2.md
> /home/davspi01/work/open_source/arm-learning-paths/tools/check.py(83)check()
-> with open(json_file) as jf:
(Pdb) print(start, stop)
False True
(Pdb) c
```

Where it was, `username` didn't really need to be a variable because it was hardcoded into the docker commands for each branch of the if.

So I've moved the username lookup later where we check the image we're going to run on (which happens regardless of whether we start a new image).


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.
- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
