### PR TITLE
De-duplicate container setup by adding a function to "docker exec"

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -74,7 +74,6 @@ def patch(article, results, lk):
             f.write(i)
         f.close()
 
-
 '''
 Read json file and run commands in Docker
 '''
@@ -91,50 +90,33 @@ def check(json_file, start, stop):
             logging.debug(cmd)
             subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
+            # Docker exec a command in the container named test_{i}
+            def exec(cmd):
+                docker_cmd = ["docker exec test_{} {}".format(i, cmd)]
+                logging.debug(docker_cmd)
+                subprocess.run(docker_cmd, shell=True, stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT)
+
             # Create user and configure
             if  "arm-tools" in img:
                 # These images already have a 'ubunutu' user account set up.
-                cmd = ["docker exec test_{} apt update".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+                exec("apt update")
             elif "ubuntu" in img or "mongo" in img:
-                cmd = ["docker exec test_{} apt update".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
-                cmd = ["docker exec test_{} apt install -y sudo wget curl git".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
-                cmd = ["docker exec test_{} useradd user -m -G sudo".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
-                cmd = ["docker exec test_{} bash -c \"cat << EOF > /etc/sudoers.d/user\n user ALL=(ALL) NOPASSWD:ALL\nEOF\"".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+                exec("apt update")
+                exec("apt install -y sudo wget curl git")
+                exec("useradd user -m -G sudo")
+                exec("bash -c \"cat << EOF > /etc/sudoers.d/user\n user ALL=(ALL) NOPASSWD:ALL\nEOF\"")
                 # The default .bashrc on Ubuntu returns when not interactive so removing it
-                cmd = ["docker exec test_{} rm /home/user/.bashrc".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+                exec("rm /home/user/.bashrc")
                 # Allow write permissions on shared folder
-                cmd = ["docker exec test_{} chmod ugo+rw /shared".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+                exec("chmod ugo+rw /shared")
             elif "fedora" in img:
-                cmd = ["docker exec test_{} yum update".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
-                cmd = ["docker exec test_{} yum install -y sudo wget curl git".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
-                cmd = ["docker exec test_{} useradd user -m -G wheel".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
-                cmd = ["docker exec test_{} bash -c \"cat << EOF > /etc/sudoers.d/user\n user ALL=(ALL) NOPASSWD:ALL\nEOF\"".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+                exec("yum update")
+                exec("yum install -y sudo wget curl git")
+                exec("useradd user -m -G wheel")
+                exec("bash -c \"cat << EOF > /etc/sudoers.d/user\n user ALL=(ALL) NOPASSWD:ALL\nEOF\"")
                 # Allow write permissions on shared folder
-                cmd = ["docker exec test_{} chmod ugo+rw /shared".format(i)]
-                logging.debug(cmd)
-                subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+                exec("chmod ugo+rw /shared")
 
         logging.info("Container(s) initialization completed")
     else:


### PR DESCRIPTION
This function just does the 3 lines that were done before, make a cmd, log it, run it. We just don't have to write it out each time, and can't forget one of the lines.

By declaring it each time around the for loop, `i` is recaptured each time and we don't have to pass it to the function every time.

Simplified example:
```
>>> for i in range(3):
...     def foo():
...             return i
...     print(foo())
...
0
1
2
```


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.
- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
