### PR TITLE
Revert "Ignore unformatted text blocks that are not scripts or files"

### DIFF
--- a/tools/parse.py
+++ b/tools/parse.py
@@ -212,15 +212,11 @@ def save(article, cmd, learningpath=False, img=None):
         # for other types, we're assuming source code
         # check if a file name is specified
         else:
-            # check for a file name
+            content[i_idx] = {"type": l[0]}
+            # check file name
             if "file_name" in l[0]:
-                content[i_idx] = {"type": l[0]}
                 fn = l[0].split("file_name=\"")[1].split("\"")[0]
                 content[i_idx].update({"file_name": fn })
-            else:
-                # No file name means it is some unformatted text, rather than
-                # some executable script or code. Skip it.
-                continue
 
         for j_idx,j in enumerate(l[1:]):
             content[i_idx].update({j_idx: j})


### PR DESCRIPTION
This reverts commit abbb94060bb9c852f740b733210cae1f995a6f21.

Due to causing existing learning paths to fail tests. I've opened issue #562 to discuss the larger issue here, which I did not understand when I did this change.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.
- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
