### PR TITLE
Editorial review - Multi-architecture applications on Amazon EKS

### DIFF
--- a/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_index.md
@@ -8,7 +8,6 @@ who_is_this_for: This is an advanced topic for software developers who want to u
 learning_objectives: 
     - Build x86/amd64 and arm64 container images with docker buildx and docker manifest
     - Understand the nuances of building a multi-architecture container image
-    - Learn how to add taints and tolerations to Amazon EKS clusters to schedule application pods on architecture specific nodes
     - Deploy a multi-arch container application across multiple architectures in a single Amazon EKS cluster
 
 prerequisites:

--- a/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_index.md
@@ -3,7 +3,7 @@ title: Learn how to build and deploy a multi-architecture application on Amazon 
 
 minutes_to_complete: 60
 
-who_is_this_for: This is an advanced topic for software developers who are looking to understand how to build and deploy a multi-architecture application with x86/amd64 and arm64 based container images on Amazon EKS
+who_is_this_for: This is an advanced topic for software developers who want to understand how to build and deploy a multi-architecture application with x86/amd64 and arm64-based container images on Amazon EKS
 
 learning_objectives: 
     - Build x86/amd64 and arm64 container images with docker buildx and docker manifest

--- a/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_next-steps.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_next-steps.md
@@ -1,5 +1,5 @@
 ---
-next_step_guidance: We recommend you to continue learning about deploying multi-architecture applications.
+next_step_guidance: We recommend you continue learning about deploying multi-architecture applications.
 
 recommended_path: "/learning-paths/servers-and-cloud-computing/migration"
 

--- a/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_review.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_review.md
@@ -8,7 +8,7 @@ review:
             - "False"
         correct_answer: 1                    
         explanation: >
-            Taints and tolerations work together to make sure that application pods are not scheduled on wrong architecture nodes.
+            Taints and tolerations work together to ensure that application pods are not scheduled on the wrong architecture nodes.
 
     - questions:
         question: >

--- a/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/go-multi-arch-eks.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/go-multi-arch-eks.md
@@ -8,7 +8,7 @@ layout: learningpathall
 
 ## Multi-architecture Amazon EKS cluster with x86 and Arm-based (Graviton) nodes
 
-A multi-architecture Kubernetes cluster runs workloads on multiple hardware architectures, typically arm64 and amd64. To learn more about multi-architecture Kubernetes you can create a hybrid cluster in Amazon EKS and gain some practical experience with arm64 and amd64 nodes. This will also help you understand multi-architecture container images.
+A multi-architecture Kubernetes cluster runs workloads on multiple hardware architectures, typically arm64 and amd64. To learn more about multi-architecture Kubernetes, you can create a hybrid cluster in Amazon EKS and gain some practical experience with arm64 and amd64 nodes. This will also help you understand multi-architecture container images.
 
 ## Before you begin
 
@@ -20,7 +20,7 @@ Three tools are required on your local machine. Follow the links to install the 
 * [Amazon eksctl CLI](/install-guides/eksctl)
 * [Docker](/install-guides/docker)
 
-## Create a Multi-architecture Amazon EKS Cluster
+## Create a multi-architecture Amazon EKS Cluster
 
 Use `eksctl` to create a multi-architecture Amazon EKS cluster. Create a file named `cluster.yaml` with the contents below using a file editor of your choice.
 
@@ -153,7 +153,7 @@ You should now see the docker image in your repository.
 
 ## Build multi-architecture docker images with Docker manifest
 
-You can also use docker manifest to create a multi-architecture image from two single-architecture images. This is an alternative way to to build the multi-architecture image. 
+You can also use docker manifest to create a multi-architecture image from two single-architecture images. This is an alternative way to build the multi-architecture image. 
 Create another repository in Amazon ECR with the name `multi-arch-demo`. Use the following command to build an amd64 image:
 
 ```console
@@ -202,7 +202,7 @@ spec:
     tier: web
 ```
 
-Deploy the service. Run the following command:
+Deploy the service and run the following command:
 
 ```console
 kubectl apply -f hello-service.yaml
@@ -271,7 +271,7 @@ Use the `external-ip` from the command output and execute the following command.
 ```console
 curl -w '\n' http://<external_ip>
 ```
-You should see output similar to what is shown below:
+You should now see an output similar to what's shown below:
 
 ```output
 Hello from image NODE:ip-192-168-32-244.ec2.internal, POD:amd-deployment-7d4d44889d-vzhpd, CPU PLATFORM:linux/amd64
@@ -333,9 +333,9 @@ Execute the following command to check the running pods
 ```console
 kubectl get pods
 ```
-You should see two pods running in the cluster. One for amd64 and another one for arm64.
+You should see two pods running in the cluster, one for amd64 and another one for arm64.
 
-Execute the curl command a few times to see output from both the pods. You should see responses from both the arm64 and amd64 pods.
+Execute the curl command a few times to see output from both the pods; you should see responses from both the arm64 and amd64 pods.
 
 ```console
 curl -w '\n' http://<external_ip>

--- a/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/go-multi-arch-eks.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/go-multi-arch-eks.md
@@ -139,7 +139,7 @@ CMD [ "/hello" ]
 
 ## Build multi-architecture docker images with docker buildx
 
-With these files you can build your docker image. Login to Amazon ECR and create a repository named `multi-arch-app`.
+With these files you can build your docker image. Log in to Amazon ECR and create a repository named `multi-arch-app`.
 
 Run the following command to build and push the docker image to the repository:
 
@@ -151,9 +151,9 @@ Replace `<your-docker-repo-path>` in the command above to the location of your r
 
 You should now see the docker image in your repository.
 
-## Build multi-architecture docker images with Docker manifest
+## Build multi-architecture docker images with docker manifest
 
-You can also use docker manifest to create a multi-architecture image from two single-architecture images. This is an alternative way to build the multi-architecture image. 
+You can also use docker manifest to create a multi-architecture image from two single-architecture images. 
 Create another repository in Amazon ECR with the name `multi-arch-demo`. Use the following command to build an amd64 image:
 
 ```console
@@ -266,7 +266,7 @@ Get the external IP assigned to the service you deployed earlier, by executing t
 ```console
 kubectl get svc
 ```
-Use the `external-ip` from the command output and execute the following command. This IP belongs to the Load Balancer provisioned in your cluster.
+Use the `external-ip` from the command output and execute the following command (this IP belongs to the Load Balancer provisioned in your cluster):
 
 ```console
 curl -w '\n' http://<external_ip>
@@ -279,7 +279,7 @@ Hello from image NODE:ip-192-168-32-244.ec2.internal, POD:amd-deployment-7d4d448
 
 ## Deploy arm64 application
 
-Create a text file named `arm64-deployment.yaml` with the contents below. Notice that the value of `nodeSelector` is now arm64.
+Create a text file named `arm64-deployment.yaml` with the contents below. Note that the value of `nodeSelector` is now arm64.
 
 ```yaml
 apiVersion: apps/v1
@@ -328,12 +328,12 @@ Deploy the arm64 application by using the command below:
 kubectl apply -f arm64-deployment.yaml
 ```
 
-Execute the following command to check the running pods
+Execute the following command to check the running pods:
 
 ```console
 kubectl get pods
 ```
-You should see two pods running in the cluster, one for amd64 and another one for arm64.
+You should now see two pods running in the cluster, one for amd64 and another one for arm64.
 
 Execute the curl command a few times to see output from both the pods; you should see responses from both the arm64 and amd64 pods.
 
@@ -343,7 +343,7 @@ curl -w '\n' http://<external_ip>
 
 ## Deploy multi-architecture application in EKS cluster
 
-You can now deploy the multi-architecture version of the application in our EKS cluster. Create a text file named `multi-arch-deployment.yaml` with the contents below. The image is the multi-architecture image created with docker buildx and 6 replicas are specified.
+You can now deploy the multi-architecture version of the application in EKS cluster. Create a text file named `multi-arch-deployment.yaml` with the contents below. The image is the multi-architecture image created with docker buildx and 6 replicas are specified.
 
 ```yaml
 apiVersion: apps/v1


### PR DESCRIPTION
There is one LO (Learn how to add taints and tolerations to Amazon EKS clusters to schedule application pods on architecture specific nodes) that needs to be amended. There is no specific mention of taints and tolerations in the body of the learning path. It might be implicit in the content but it's not explicit and therefore shouldn't be a specific LO. I suggest that this LO is removed.

Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [x ] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.
- [x ] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
