### PR TITLE
WindowsPerf: align docs with release 3.2.1

### DIFF
--- a/content/install-guides/wperf.md
+++ b/content/install-guides/wperf.md
@@ -93,7 +93,7 @@ devcon install wperf-driver.inf Root\WPERFDRIVER
 ```
 You will see output similar to:
 
-```output
+```console
 Device node created. Install is complete when drivers are installed...
 Updating drivers for Root\WPERFDRIVER from <path>\wperf-driver.inf.
 Drivers installed successfully.
@@ -111,7 +111,7 @@ cd wperf-driver
 wperf-devgen install
 ```
 You will see output similar to:
-```output
+```console
 Executing command: install.
 Install requested.
 Waiting for device creation...

--- a/content/install-guides/wperf.md
+++ b/content/install-guides/wperf.md
@@ -57,15 +57,15 @@ https://gitlab.com/Linaro/WindowsPerf/windowsperf/-/releases
 To download directly from command prompt, use:
 
 ```console
-mkdir windowsperf-bin-3.2.0
-cd windowsperf-bin-3.2.0
-curl https://gitlab.com/api/v4/projects/40381146/packages/generic/windowsperf/3.2.0/windowsperf-bin-3.2.0.zip --output windowsperf-bin-3.2.0.zip
+mkdir windowsperf-bin-3.2.1
+cd windowsperf-bin-3.2.1
+curl https://gitlab.com/api/v4/projects/40381146/packages/generic/windowsperf/3.2.1/windowsperf-bin-3.2.1.zip --output windowsperf-bin-3.2.1.zip
 ```
 
 Unzip the package:
 
 ```console
-tar -xmf windowsperf-bin-3.2.0.zip
+tar -xmf windowsperf-bin-3.2.1.zip
 ```
 
 ## Install wperf driver
@@ -80,7 +80,7 @@ Open a `Windows Command Prompt` terminal with `Run as administrator` enabled.
 
 Navigate to the `windowsperf-bin-<version>` directory.
 ```command
-cd windowsperf-bin-3.2.0
+cd windowsperf-bin-3.2.1
 ```
 
 ### Install with devcon {#devcon}
@@ -133,11 +133,11 @@ cd ..
 wperf --version
 ```
 You should see output similar to:
-```output
+```console
 Component     Version  GitVer
 =========     =======  ======
-wperf         3.2.0    a947eed8
-wperf-driver  3.2.0    a947eed8
+wperf         3.2.1    c831cfc2
+wperf-driver  3.2.1    c831cfc2
 ```
 ## Further reading
 

--- a/content/install-guides/wperf.md
+++ b/content/install-guides/wperf.md
@@ -93,7 +93,7 @@ devcon install wperf-driver.inf Root\WPERFDRIVER
 ```
 You will see output similar to:
 
-```console
+```output
 Device node created. Install is complete when drivers are installed...
 Updating drivers for Root\WPERFDRIVER from <path>\wperf-driver.inf.
 Drivers installed successfully.
@@ -111,7 +111,7 @@ cd wperf-driver
 wperf-devgen install
 ```
 You will see output similar to:
-```console
+```output
 Executing command: install.
 Install requested.
 Waiting for device creation...
@@ -133,7 +133,7 @@ cd ..
 wperf --version
 ```
 You should see output similar to:
-```console
+```output
 Component     Version  GitVer
 =========     =======  ======
 wperf         3.2.1    c831cfc2
@@ -156,7 +156,7 @@ Below command removes the device from the device tree and deletes the device sta
 devcon remove wperf-driver.inf Root\WPERFDRIVER
 ```
 You should see output similar to:
-```console
+```output
 ROOT\SYSTEM\0001                                            : Removed
 1 device(s) were removed.
 ```

--- a/content/install-guides/wperf.md
+++ b/content/install-guides/wperf.md
@@ -139,6 +139,43 @@ Component     Version  GitVer
 wperf         3.2.1    c831cfc2
 wperf-driver  3.2.1    c831cfc2
 ```
+
+## Uninstall wperf driver
+
+You can uninstall (aka "remove") the kernel driver using either the Visual Studio [devcon](#devcon) utility or the supplied [installer](#devgen).
+
+{{% notice  Note%}}
+You must uninstall the driver as `Administrator`.
+{{% /notice %}}
+
+### Uninstall with devcon {#devcon}
+
+Below command removes the device from the device tree and deletes the device stack for the device. As a result of these actions, child devices are removed from the device tree and the drivers that support the device are unloaded. See [DevCon Remove](https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/devcon-remove) article for more details.
+
+```command
+devcon remove wperf-driver.inf Root\WPERFDRIVER
+```
+You should see output similar to:
+```console
+ROOT\SYSTEM\0001                                            : Removed
+1 device(s) were removed.
+```
+
+### Uninstall with wperf-devgen {#devgen}
+
+```command
+wperf-devgen uninstall
+```
+You should see output similar to:
+```console
+Executing command: uninstall.
+Uninstall requested.
+Waiting for device creation...
+Device uninstalled successfully.
+Trying to remove driver <path>\wperf-driver.inf.
+Driver removed successfully.
+```
+
 ## Further reading
 
 [Announcing WindowsPerf: Open-source performance analysis tool for Windows on Arm](https://community.arm.com/arm-community-blogs/b/infrastructure-solutions-blog/posts/announcing-windowsperf)


### PR DESCRIPTION
Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [X] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.
- [X] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 

--- 

In this PR:

* I've updated docs to match latest release 3.2.1. This release is [here](https://gitlab.com/Linaro/WindowsPerf/windowsperf/-/releases/3.2.1).
* I've added "uninstall WindowsPerf kernel driver" to compliment already existing "install learning path".