### PR TITLE
Fix malloc title formatting in dynamic memory allocator path

### DIFF
--- a/content/learning-paths/cross-platform/dynamic-memory-allocator/1_dynamic_memory_allocation.md
+++ b/content/learning-paths/cross-platform/dynamic-memory-allocator/1_dynamic_memory_allocation.md
@@ -43,7 +43,7 @@ int main(...) {
 
 The arguments passed to the program determine if memory is allocated or not. 
 
-## The C library `malloc` function
+## The C library malloc function
 
 The C standard library provides a special function
 [`malloc`](https://en.cppreference.com/w/c/memory/malloc) (`m` for "memory",


### PR DESCRIPTION
The plain text ends up looking very small next to the title font size, so just remove the formatting.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.
- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
