### PR TITLE
Add a shortcode to include a file and display it with syntax highligting.

### DIFF
--- a/themes/arm-design-system-hugo-theme/layouts/shortcodes/include-code.html
+++ b/themes/arm-design-system-hugo-theme/layouts/shortcodes/include-code.html
@@ -1,0 +1,4 @@
+{{- $format := ( .Get 0 ) -}}
+{{- $file := ( .Get 1 ) -}}
+
+{{- ( print "```" $format "\n" ( readFile $file ) "\n" "```" ) | markdownify -}}


### PR DESCRIPTION
The intent is to avoid duplicating information, when a file content is referred to in a learning-path.

Example usage (to include and display C++ code):

{{< include-code CPP "content/learning-paths/path/to/file.cpp" >}}


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [X] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. No AI tool can be used to generate either content or code when creating a learning path or install guide.

- [X] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
