### PR TITLE
Update from JNI to AAR to reflect updated Executorch example

### DIFF
--- a/content/learning-paths/smartphones-and-mobile/Build-Llama3-Chat-Android-App-Using-Executorch-And-XNNPACK/6-Build-Android-Chat-App.md
+++ b/content/learning-paths/smartphones-and-mobile/Build-Llama3-Chat-Android-App-Using-Executorch-And-XNNPACK/6-Build-Android-Chat-App.md
@@ -6,7 +6,7 @@ weight: 7
 layout: learningpathall
 ---
 
-## Build the JNI library
+## Build the Android Archive (AAR)
 {{% notice Note %}}
 You can use the Android demo application included in ExecuTorch repository [LlamaDemo](https://github.com/pytorch/executorch/tree/main/examples/demo-apps/android/LlamaDemo) to demonstrate local inference with ExecuTorch.
 {{% /notice %}}
@@ -33,6 +33,9 @@ You can use the Android demo application included in ExecuTorch repository [Llam
 4. Run the following commands to set up the required JNI library:
 
     ``` bash
+    pushd extension/android
+    ./gradlew build
+    popd
     pushd examples/demo-apps/android/LlamaDemo
     ./gradlew :app:setup
     popd


### PR DESCRIPTION
Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [ X] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. No AI tool can be used to generate either content or code when creating a learning path or install guide.

- [ X] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 


Executorch example was recently updated to use AAR instead of JNI, updating learning path to reflect the same

