### PR TITLE
Remove stories110M model and update commands for executorch android LP

### DIFF
--- a/content/learning-paths/smartphones-and-mobile/Build-Llama3-Chat-Android-App-Using-Executorch-And-XNNPACK/4-Prepare-LLaMA-models.md
+++ b/content/learning-paths/smartphones-and-mobile/Build-Llama3-Chat-Android-App-Using-Executorch-And-XNNPACK/4-Prepare-LLaMA-models.md
@@ -52,50 +52,17 @@ consolidated.00.pth  params.json  tokenizer.model
 Export model and generate `.pte` file. Run the Python command to export the model:
 
 ```bash
-python -m examples.models.llama2.export_llama --checkpoint <consolidated.00.pth> -p <params.json> -kv --use_sdpa_with_kv_cache -X -qmode 8da4w  --group_size 128 -d fp32 --metadata '{"get_bos_id":128000, "get_eos_id":128001}' --embedding-quantize 4,32 --output_name="llama3_kv_sdpa_xnn_qe_4_32.pte"
+python -m examples.models.llama2.export_llama --checkpoint llama-models/models/llama3_1/Meta-Llama-3.1-8B/consolidated.00.pth -p llama-models/models/llama3_1/Meta-Llama-3.1-8B/params.json -kv --use_sdpa_with_kv_cache -X -qmode 8da4w  --group_size 128 -d fp32 --metadata '{"get_bos_id":128000, "get_eos_id":128001}' --embedding-quantize 4,32 --output_name="llama3_kv_sdpa_xnn_qe_4_32.pte"
 ```
 
-Where `<consolidated.00.pth>` and `<params.json>` are the paths to the downloaded model files, found in llama3/Meta-Llama-3.1-8B by default.
-
 Due to the larger vocabulary size of Llama 3, you should quantize the embeddings with `--embedding-quantize 4,32` to further reduce the model size.
-
-### Download and export stories110M model
-
-Follow the steps in this section, if you want to deploy and run a smaller model for educational purposes instead of the full Llama 3 8B model.
-
-From the `executorch` root directory follow these steps:
-
-1. Download `stories110M.pt` and `tokenizer.model` from Github.
-
-    ``` bash
-    wget "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories110M.pt"
-    wget "https://raw.githubusercontent.com/karpathy/llama2.c/master/tokenizer.model"
-    ```
-
-2. Create params file.
-
-    ``` bash
-    echo '{"dim": 768, "multiple_of": 32, "n_heads": 12, "n_layers": 12, "norm_eps": 1e-05, "vocab_size": 32000}' > params.json
-    ```
-
-3. Export model and generate `.pte` file.
-
-    ``` bash
-    python -m examples.models.llama2.export_llama -c stories110M.pt -p params.json -X
-    ```
-
-4. Create tokenizer.bin.
-
-    ``` bash
-    python -m examples.models.llama2.tokenizer.tokenizer -t tokenizer.model -o tokenizer.bin
-    ```
 
 ## Optional: Evaluate Llama 3 model accuracy
 
 You can evaluate model accuracy using the same arguments as above:
 
 ``` bash
-python -m examples.models.llama2.eval_llama -c <consolidated.00.pth> -p <params.json> -t <tokenizer.model> -d fp32 --max_seq_len 2048 --limit 1000
+python -m examples.models.llama2.eval_llama -c llama-models/models/llama3_1/Meta-Llama-3.1-8B/consolidated.00.pth -p llama-models/models/llama3_1/Meta-Llama-3.1-8B/params.json -t llama-models/models/llama3_1/Meta-Llama-3.1-8B/tokenizer.model -d fp32 --max_seq_len 2048 --limit 1000
 ```
 
 {{% notice Warning %}}
@@ -134,16 +101,6 @@ Follow the steps below to build ExecuTorch and the Llama runner to run models.
 For Llama 3, add `-DEXECUTORCH_USE_TIKTOKEN=ON` option.
 {{% /notice %}}
 
-{{% notice Note %}}
-If you are building on a Mac, there is currently an [open bug](https://github.com/pytorch/executorch/issues/3600) that adds a `--gc-sections` flag to ld options. You need to remove this flag for Mac by opening `examples/models/llama2/CMakeLists.txt` and removing these lines:
-
-```
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  target_link_options(llama_main PRIVATE "LINKER:--gc-sections,-s")
-endif()
-```
-{{% /notice %}}
-
 Run cmake:
 
 ``` bash
@@ -163,9 +120,7 @@ Run cmake:
 3. Run the model:
 
     ``` bash
-    cmake-out/examples/models/llama2/llama_main --model_path=<model pte file> --tokenizer_path=<tokenizer.bin> --prompt=<prompt>
+    cmake-out/examples/models/llama2/llama_main --model_path=llama3_kv_sdpa_xnn_qe_4_32.pte --tokenizer_path=llama-models/models/llama3_1/Meta-Llama-3.1-8B/tokenizer.model --prompt=<prompt>
     ```
 
     The run options are available on [GitHub](https://github.com/pytorch/executorch/blob/main/examples/models/llama2/main.cpp#L18-L40).
-
-    For Llama 3, you can pass the original `tokenizer.model` (without converting to `.bin` file).


### PR DESCRIPTION
examples.models.llama2.tokenizer.tokenizer doesn't exist, so instead of

python -m examples.models.llama2.tokenizer.tokenizer -t tokenizer.model -o tokenizer.bin

I used

python -m extension.llm.tokenizer.tokenizer -t <tokenizer.model> -o tokenizer.bin

After doing this and building the llama runner, I got this error:

(venv) (base) ➜  executorch git:(main) ✗ cmake-out/examples/models/llama2/llama_main --model_path=xnnpack_llama2.pte --tokenizer_path=tokenizer.bin --prompt="tell me a joke."
I 00:00:00.000985 executorch:cpuinfo_utils.cpp:62] Reading file /sys/devices/soc0/image_version
I 00:00:00.001091 executorch:cpuinfo_utils.cpp:78] Failed to open midr file /sys/devices/soc0/image_version
I 00:00:00.001108 executorch:cpuinfo_utils.cpp:91] Reading file /sys/devices/system/cpu/cpu0/regs/identification/midr_el1
I 00:00:00.001120 executorch:cpuinfo_utils.cpp:100] Failed to open midr file /sys/devices/system/cpu/cpu0/regs/identification/midr_el1
I 00:00:00.001126 executorch:cpuinfo_utils.cpp:116] CPU info and manual query on # of cpus dont match.
I 00:00:00.001131 executorch:main.cpp:65] Resetting threadpool with num threads = 0
I 00:00:00.001135 executorch:runner.cpp:51] Creating LLaMa runner: model_path=xnnpack_llama2.pte, tokenizer_path=tokenizer.bin
I 00:00:00.233329 executorch:runner.cpp:66] Reading metadata from model
I 00:00:00.233375 executorch:metadata_util.h:43] get_n_bos: 1
I 00:00:00.233380 executorch:metadata_util.h:43] get_n_eos: 1
I 00:00:00.233383 executorch:metadata_util.h:43] get_max_seq_len: 128
I 00:00:00.233385 executorch:metadata_util.h:43] use_kv_cache: 0
I 00:00:00.233388 executorch:metadata_util.h:43] use_sdpa_with_kv_cache: 0
I 00:00:00.233390 executorch:metadata_util.h:43] append_eos_to_prompt: 0
I 00:00:00.233393 executorch:metadata_util.h:43] enable_dynamic_shape: 1
I 00:00:00.249155 executorch:metadata_util.h:43] get_vocab_size: 32000
I 00:00:00.249161 executorch:metadata_util.h:43] get_bos_id: 1
I 00:00:00.249163 executorch:metadata_util.h:43] get_eos_id: 2
E 00:00:00.249199 executorch:method.cpp:791] Given input index must be less than the number of inputs in method, but got 1 and 1

So I removed the stories110M model until we can figure out how to get it to run.

Also, fix https://github.com/pytorch/executorch/issues/3600 has been merged, so I removed the note discussing the workaround since it is no longer necessary.