### PR TITLE
Added Directory of Academic Offers available from Arm CSPs

### DIFF
--- a/content/learning-paths/servers-and-cloud-computing/intro/find-hardware.md
+++ b/content/learning-paths/servers-and-cloud-computing/intro/find-hardware.md
@@ -34,6 +34,17 @@ The [Works on Arm](https://www.arm.com/markets/computing-infrastructure/works-on
 
 Consider [applying for Arm resources on an Equinix Cluster](https://github.com/WorksOnArm/equinix-metal-arm64-cluster).
 
+## Academic offers from Arm Cloud Service Providers
+
+This is a non-exhaustive list of Arm cloud partners that have existing academic offers for students and teaching staff who wish to use Arm-based instances. 
+
+- [Microsoft Azure Student Offer](https://azure.microsoft.com/en-us/free/students)
+- [Google Cloud for Faculty](https://cloud.google.com/edu/faculty?hl=en)
+- [Google Cloud for Researchers](https://cloud.google.com/edu/researchers?hl=en)
+- [Alibaba Cloud Academic Empowerment Program](https://edu.alibabacloud.com/campus/index?spm=a3c0i.11593861.4363105600.24.6d326d84ZWObih)
+- [NVIDIA Higher Education Research](https://www.nvidia.com/en-gb/industries/higher-education-research/academic-grant-program/)
+- [Oracle Cloud Education](https://www.oracle.com/uk/government/education/)
+
 ##  Arm SystemReady Certified hardware
 
 [Arm SystemReady](https://www.arm.com/architecture/system-architectures/systemready-certification-program) is a program that certifies that systems meet the SystemReady standards, giving confidence that operating systems (OS) and subsequent layers of software just work.


### PR DESCRIPTION
For students and teaching staff wanting to get started with Arm cloud instances, I added a directory of CSPs that have existing offers that include Arm-based instances. This is a non-exhaustive list and has no priority. Worth noting that naturally some academic offers also include x86 platforms. I ran this through hugo with no errors. 

 In the future on the [Arm education website](https://www.arm.com/resources/education), we may link to this learning path for those looking to get started.  

- [x] I have reviewed Create a Learning Path

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
