### PR TITLE
Update ACfL and ArmPL install guides for 24.10 releases

### DIFF
--- a/content/install-guides/acfl.md
+++ b/content/install-guides/acfl.md
@@ -101,11 +101,11 @@ Fetch the `ACfL` installers:
 #### Ubuntu Linux:
 
 ```bash { target="ubuntu:latest" }
-wget  https://developer.arm.com/-/cdn-downloads/permalink/Arm-Compiler-for-Linux/Version_24.04/arm-compiler-for-linux_24.04_Ubuntu-22.04_aarch64.tar
+wget  https://developer.arm.com/-/cdn-downloads/permalink/Arm-Compiler-for-Linux/Version_24.10/arm-compiler-for-linux_24.10_Ubuntu-22.04_aarch64.tar
 ```
 #### Red Hat Linux:
 ```bash { target="fedora:latest" }
-wget https://developer.arm.com/-/cdn-downloads/permalink/Arm-Compiler-for-Linux/Version_24.04/arm-compiler-for-linux_24.04_RHEL-8_aarch64.tar
+wget https://developer.arm.com/-/cdn-downloads/permalink/Arm-Compiler-for-Linux/Version_24.10/arm-compiler-for-linux_24.10_RHEL-9_aarch64.tar
 ```
 
 ### Install
@@ -118,19 +118,26 @@ Each command sequence includes accepting the license agreement to automate the i
 
 ```bash { target="ubuntu:latest", env="DEBIAN_FRONTEND=noninteractive" }
 sudo -E apt-get -y install environment-modules python3 libc6-dev
-tar -xvf arm-compiler-for-linux_24.04_Ubuntu-22.04_aarch64.tar
-cd ./arm-compiler-for-linux_24.04_Ubuntu-22.04
-sudo ./arm-compiler-for-linux_24.04_Ubuntu-22.04.sh --accept
+tar -xvf arm-compiler-for-linux_24.10_Ubuntu-22.04_aarch64.tar
+cd ./arm-compiler-for-linux_24.10_Ubuntu-22.04
+sudo ./arm-compiler-for-linux_24.10_Ubuntu-22.04.sh --accept
 ```
 
 #### Red Hat Linux:
 
 ```bash { target="fedora:latest" }
 sudo yum -y install environment-modules python3 glibc-devel
-tar -xvf arm-compiler-for-linux_24.04_RHEL-8_aarch64.tar
-cd arm-compiler-for-linux_24.04_RHEL-8
-sudo ./arm-compiler-for-linux_24.04_RHEL-8.sh --accept
+tar -xvf arm-compiler-for-linux_24.10_RHEL-9_aarch64.tar
+cd arm-compiler-for-linux_24.10_RHEL-9
+sudo ./arm-compiler-for-linux_24.10_RHEL-9.sh --accept
 ```
+
+⚠️ **Compatability with Non-ACfL GCC:** On RPM based (Red Hat) systems, if an
+alternative version of GCC (not the GCC bundled with ACfL) is installed
+**after** ACfL, you will not be able to uninstall ACfL fully. For example, a GDB
+(GNU Project Debugger) installation will install the native system GCC.  If this
+install takes place **after** ACfL, you will no longer be able to fully
+uninstall ACfL.
 
 ### Set up environment
 
@@ -163,13 +170,13 @@ module avail
 To configure Arm Compiler for Linux:
 
 ```bash { env_source="~/.bashrc" }
-module load acfl/24.04
+module load acfl/24.10
 ```
 
 To configure GCC:
 
 ```bash { env_source="~/.bashrc" }
-module load gnu/13.2.0
+module load gnu/14.2.0
 ```
 `ACfL` is now [ready to use](#armclang).
 
@@ -226,7 +233,7 @@ spack compiler find
 To get started with the Arm C/C++ Compiler and compile a simple application follow the steps below.
 
 Check that the correct compiler version is being used:
-```bash { env_source="~/.bashrc", pre_cmd="module load acfl/24.04" }
+```bash { env_source="~/.bashrc", pre_cmd="module load acfl/24.10" }
 armclang --version
 ```
 
@@ -244,13 +251,13 @@ int main()
 
 Build the application with:
 
-```console { env_source="~/.bashrc", pre_cmd="module load acfl/24.04" }
+```console { env_source="~/.bashrc", pre_cmd="module load acfl/24.10" }
 armclang hello.c -o hello
 ```
 
 Run the application with:
 
-```bash { env_source="~/.bashrc", pre_cmd="module load acfl/24.04" }
+```bash { env_source="~/.bashrc", pre_cmd="module load acfl/24.10" }
 ./hello
 ```
 
@@ -264,7 +271,7 @@ Hello, C World!
 To get started with the Arm Fortran Compiler and compile a simple application follow the steps below.
 
 Check that the correct compiler version is being used:
-```bash { env_source="~/.bashrc", pre_cmd="module load acfl/24.04" }
+```bash { env_source="~/.bashrc", pre_cmd="module load acfl/24.10" }
 armflang --version
 ```
 
@@ -278,12 +285,12 @@ end program hello
 ```
 
 Build the application with:
-```bash { env_source="~/.bashrc", pre_cmd="module load acfl/24.04" }
+```bash { env_source="~/.bashrc", pre_cmd="module load acfl/24.10" }
 armflang hello.f90 -o hello
 ```
 
 Run the application with:
-```bash { env_source="~/.bashrc", pre_cmd="module load acfl/24.04" }
+```bash { env_source="~/.bashrc", pre_cmd="module load acfl/24.10" }
 ./hello
 ```
 

--- a/content/install-guides/acfl.md
+++ b/content/install-guides/acfl.md
@@ -188,7 +188,7 @@ See the [Arm Compiler for Linux and Arm PL now available in Spack](https://commu
 
 ### Setup Spack
 
-Clone the `Spack` repostitory and add `bin` directory to the path:
+Clone the `Spack` repository and add `bin` directory to the path:
 
 ```console
 git clone -c feature.manyFiles=true https://github.com/spack/spack.git

--- a/content/install-guides/armpl.md
+++ b/content/install-guides/armpl.md
@@ -70,28 +70,28 @@ For more information refer to [Get started with Arm Performance Libraries](https
 
 In a terminal, run the command shown below to download the macOS package:
 ```console
-wget https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries/24-04/macos/arm-performance-libraries_24.04_macOS.tgz
+wget https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries/24-10/macos/arm-performance-libraries_24.10_macOS.tgz
 ```
 
 Use tar to extract the file:
 ```console
-tar zxvf arm-performance-libraries_24.04_macOS.tgz
+tar zxvf arm-performance-libraries_24.10_macOS.tgz
 ```
 
 Output of above command:
 ```console
-armpl_24.04_flang-new_clang_18.dmg
+armpl_24.10_flang-new_clang_19.dmg
 ```
 
 Mount the disk image by running from a terminal:
 ```console
-hdiutil attach armpl_24.04_flang-new_clang_18.dmg
+hdiutil attach armpl_24.10_flang-new_clang_19.dmg
 ```
 
 Now run the installation script as a superuser:
 
 ```console
-/Volumes/armpl_24.04_flang-new_clang_18_installer/armpl_24.04_flang-new_clang_18_install.sh -y
+/Volumes/armpl_24.10_flang-new_clang_19_installer/armpl_24.10_flang-new_clang_19_install.sh -y
 ```
 
 Using this command you automatically accept the End User License Agreement and the packages are installed to the `/opt/arm` directory. If you want to change the installation directory location use the `--install_dir` option with the script and provide the desired directory location.
@@ -103,33 +103,33 @@ For more information refer to [Get started with Arm Performance Libraries](https
 
 ## Linux {#linux}
 
-Arm Performance Libraries are supported on most Linux Distributions like Ubuntu, RHEL, SLES and Amazon Linux on an `AArch64` host and compatible with various versions of GCC and NVHPC. The GCC compatible releases are built with GCC 13 and tested with GCC versions 7 to 13. The NVHPC compatible releases are built and tested with NVHPC 24.1.
+Arm Performance Libraries are supported on most Linux Distributions like Ubuntu, RHEL, SLES and Amazon Linux on an `AArch64` host and compatible with various versions of GCC and NVHPC. The GCC compatible releases are built with GCC 14 and tested with GCC versions 7 to 14. The NVHPC compatible releases are built and tested with NVHPC 24.7.
 
 [Download](https://developer.arm.com/downloads/-/arm-performance-libraries) the appropriate package for your Linux distribution. The deb based installers can be used on Ubuntu 20 and Ubuntu 22. The RPM based installers can be used on the following supported distributions:
 
 - Amazon Linux 2, Amazon Linux 2023
-- RHEL-7, RHEL-8, RHEL-9
-- SLES-15
+- RHEL-8, RHEL-9
+- SLES-15 Service Packs 5 and 6
 
 The instructions shown below are for deb based installers for GCC users.
 
 In a terminal, run the command shown below to download the debian package:
 
 ```console
-wget https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries/24-04/linux/arm-performance-libraries_24.04_deb_gcc.tar
+wget https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries/24-10/linux/arm-performance-libraries_24.10_deb_gcc.tar
 ```
 
 Use `tar` to extract the file and then change directory:
 
 ```console
-tar -xf arm-performance-libraries_24.04_deb_gcc.tar
-cd arm-performance-libraries_24.04_deb/
+tar -xf arm-performance-libraries_24.10_deb_gcc.tar
+cd arm-performance-libraries_24.10_deb/
 ```
 
 Run the installation script as a super user:
 
 ```console
-sudo ./arm-performance-libraries_24.04_deb.sh --accept
+sudo ./arm-performance-libraries_24.10_deb.sh --accept
 ```
 
 Using the `--accept` switch you automatically accept the End User License Agreement and the packages are installed to the `/opt/arm` directory.
@@ -165,13 +165,13 @@ module avail
 The output should be similar to:
 
 ```output
-armpl/24.04.0_gcc
+armpl/24.10.0_gcc
 ```
 
 Load the appropriate module:
 
 ```console
-module load armpl/24.04.0_gcc
+module load armpl/24.10.0_gcc
 ```
 
 You can now compile and test the examples included in the `/opt/arm/<armpl_dir>/examples/`, or `<install_dir>/<armpl_dir>/examples/` directory, if you have installed to a different location than the default.


### PR DESCRIPTION
Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [X] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. No AI tool can be used to generate either content or code when creating a learning path or install guide.

- [X] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 

--- 

This PR updates the install guides for both ACfL and ArmPL with the information on installing the latest version (24.10). 

This also addresses a spelling error in the ACfL install guide.
