### PR TITLE
Deploy both Internal and Production website to S3 and serve using CloudFront

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,42 +1,62 @@
-# This is a basic workflow to help you get started with Actions
+name: Deploy Hugo to S3
 
-name: content-deploy
-
-# Controls when the workflow will run
 on:
- # Triggers the workflow on push to production branch
-  push:
-    branches: [ production ]
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Choose the environment"
+        required: true
+        type: string
+      target:
+        description: "Hugo target to deploy to"
+        required: true
+        type: string
+      aws-region:
+        description: "AWS Region to use for fetching credentials"
+        required: false
+        type: string
+        default: "us-west-2"
+    secrets:
+      AWS_OIDC_ROLE:
+        required: true
+      HUGO_LLM_API:
+        required: true
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+env:
+  HUGO_VERSION: 0.130.0
+
 jobs:
-  # This workflow contains a single job called "build"
   build_and_deploy:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks-out the repository under $GITHUB_WORKSPACE, so the job can access it
       - uses: actions/checkout@v4
         with:
-          submodules: true  # Fetch Hugo Themes
-          fetch-depth: 0 
+          submodules: true # Fetch Hugo Themes
+          fetch-depth: 0
 
       # Sets Up Hugo
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-            hugo-version: '0.130.0'
-            extended: true
-            
-      # Post-CSS install
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+
+      # Installs Post-CSS
       - name: Install Post-CSS
         run: npm install postcss-cli
 
-      # Builds arm-learning-paths repo
+      - name: AWS Github OIDC Login
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
+          aws-region: ${{ inputs.aws-region }}
+
+      # Builds arm-software-developer repo
       - name: Build
         run: |
           hugo --minify
@@ -44,26 +64,7 @@ jobs:
           bin/pagefind --site "public"
         env:
           HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
-        
-      #  Copy SSH Key
-      - name: copy key
-        run: |
-            echo $SSH_KEY | xargs -n 1 > tmpkey
-            base64 -d < tmpkey > key
-            chmod 400 key
-        shell: bash
-        env:
-          SSH_KEY: ${{secrets.SSH_KEY}}
-          
-      # SCP Site contents to netstorage
-      - name: copy site content
-        run: |
-          cd public
-          zip -r public.zip .
-          cd ..
-          scp -i key -o StrictHostKeyChecking=accept-new -oHostKeyAlgorithms=+ssh-dss -r public/public.zip $USR@$HOST:/$ID/
-        shell: bash
-        env:
-          USR: ${{secrets.SSH_USERNAME}}
-          HOST: ${{secrets.SSH_HOST}}
-          ID: ${{secrets.ID}}
+
+      # Deploys website to AWS S3 and invalidate CloudFront Cache
+      - name: Deploy to S3
+        run: hugo deploy --force --maxDeletes -1 --invalidateCDN --target ${{ inputs.target }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,6 @@ name: Deploy Hugo to S3
 on:
   workflow_call:
     inputs:
-      environment:
-        description: "Choose the environment"
-        required: true
-        type: string
       target:
         description: "Hugo target to deploy to"
         required: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,16 +13,42 @@ on:
 jobs:
   build_and_deploy_internal_existing:
     name: Build and Deploy Internal Existing
-    uses: ./.github/workflows/deploy.yml
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      environment: internal
-      target: internal-existing
-    secrets:
-      AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE_INTERNAL }}
-      HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+        with:
+          submodules: true # Fetch Hugo Themes
+          fetch-depth: 0
+
+      # Sets Up Hugo
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.130.0"
+          extended: true
+
+      # Post-CSS install and Node.js
+      - name: Install Post-CSS
+        run: npm install postcss-cli
+
+      # Builds arm-software-developer repo
+      - name: Build
+        run: |
+          hugo --minify
+          cp learn-image-sitemap.xml public/learn-image-sitemap.xml
+          bin/pagefind --site "public"
+        env:
+          HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
+
+      # Deploys website to AWS S3
+      - name: Deploy to S3
+        run: hugo deploy --force --maxDeletes -1 --invalidateCDN
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   build_and_deploy_internal:
     name: Build and Deploy Internal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,6 @@ jobs:
       id-token: write
       contents: read
     with:
-      environment: internal
       target: internal
     secrets:
       AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE_INTERNAL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,56 +1,38 @@
-# This is a basic workflow to help you get started with Actions
+# This workflow will be triggered on a push to the 'main' branch automatically or when called manually.
+# Upon running this workflow, the website will be built and deployed to the internal instance.
+name: Build and Deploy Internal Website
 
-name: build-and-deploy
-
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Runs on pushes to the 'main' branch
   push:
-    branches: [ main ]
+    branches: [main]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build_and_deploy_s3:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+  build_and_deploy_internal_existing:
+    name: Build and Deploy Internal Existing
+    uses: ./.github/workflows/deploy.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      environment: internal
+      target: internal-existing
+    secrets:
+      AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE_INTERNAL }}
+      HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-        with:
-          submodules: true  # Fetch Hugo Themes
-          fetch-depth: 0 
-
-      # Sets Up Hugo
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-            hugo-version: '0.130.0'
-            extended: true
-            
-      # Post-CSS install and Node.js
-      - name: Install Post-CSS
-        run: npm install postcss-cli
-
-
-      # Builds arm-software-developer repo
-      - name: Build
-        run: |
-          hugo --minify
-          cp learn-image-sitemap.xml public/learn-image-sitemap.xml
-          bin/pagefind --site "public"
-        env:
-         HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
-
-      # Deploys website to AWS S3
-      - name: Deploy to S3
-        run: hugo deploy --force --maxDeletes -1 --invalidateCDN
-        env:
-         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          
+  build_and_deploy_internal:
+    name: Build and Deploy Internal
+    uses: ./.github/workflows/deploy.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      environment: internal
+      target: internal
+    secrets:
+      AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE_INTERNAL }}
+      HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Deploys website to AWS S3
       - name: Deploy to S3
-        run: hugo deploy --force --maxDeletes -1 --invalidateCDN
+        run: hugo deploy --force --maxDeletes -1 --invalidateCDN --target internal-existing
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -73,7 +73,6 @@ jobs:
       id-token: write
       contents: read
     with:
-      environment: production
       target: production
     secrets:
       AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE_PRODUCTION }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,80 @@
+# This workflow will be triggered on a push to the 'production' branch automatically or when called manually.
+# Upon running this workflow, the website will be built and deployed to the production instance.
+name: Build and Deploy Production Website
+
+on:
+  # Runs on pushes to the 'production' branch
+  push:
+    branches: [production]
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build_and_deploy_existing:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+        with:
+          submodules: true # Fetch Hugo Themes
+          fetch-depth: 0
+
+      # Sets Up Hugo
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.130.0"
+          extended: true
+
+      # Post-CSS install
+      - name: Install Post-CSS
+        run: npm install postcss-cli
+
+      # Builds arm-learning-paths repo
+      - name: Build
+        run: |
+          hugo --minify
+          cp learn-image-sitemap.xml public/learn-image-sitemap.xml
+          bin/pagefind --site "public"
+        env:
+          HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
+
+      #  Copy SSH Key
+      - name: copy key
+        run: |
+          echo $SSH_KEY | xargs -n 1 > tmpkey
+          base64 -d < tmpkey > key
+          chmod 400 key
+        shell: bash
+        env:
+          SSH_KEY: ${{secrets.SSH_KEY}}
+
+      # SCP Site contents to netstorage
+      - name: copy site content
+        run: |
+          cd public
+          zip -r public.zip .
+          cd ..
+          scp -i key -o StrictHostKeyChecking=accept-new -oHostKeyAlgorithms=+ssh-dss -r public/public.zip $USR@$HOST:/$ID/
+        shell: bash
+        env:
+          USR: ${{secrets.SSH_USERNAME}}
+          HOST: ${{secrets.SSH_HOST}}
+          ID: ${{secrets.ID}}
+
+  build_and_deploy_production:
+    name: Build and Deploy Production
+    uses: ./.github/workflows/deploy.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      environment: production
+      target: production
+    secrets:
+      AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE_PRODUCTION }}
+      HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}

--- a/config.toml
+++ b/config.toml
@@ -9,48 +9,54 @@ enableRobotsTXT = true
 
 [deployment]
 [[deployment.targets]]
-name = "aws"
+name = "internal-existing"
 URL = "s3://armswdev.tk?region=us-east-1"
 cloudFrontDistributionID = "E2VDQ2CYZATMO9"
 
+[[deployment.targets]]
+name = "internal"
+URL = "s3://arm-learning-paths-internal?region=us-west-2"
+cloudFrontDistributionID = "ENN4LK1IZUDIX"
 
-
+[[deployment.targets]]
+name = "production"
+URL = "s3://arm-learning-paths?region=us-west-2"
+cloudFrontDistributionID = "E2NEF61QWPFRIH"
 
 [frontmatter]
-    lastmod = [ "lastmod", ":git", "date", "publishDate" ]
+lastmod = ["lastmod", ":git", "date", "publishDate"]
 
 [taxonomies]
-    subject                 = "subjects"
-    operatingsystem         = "operatingsystems"
-    skilllevel              = "skilllevels"
-    tool_software_language  = "tools_software_languages"
-    armip                   = "armips"
-    cloud_service_provider  = "cloud_service_providers"
-
+subject = "subjects"
+operatingsystem = "operatingsystems"
+skilllevel = "skilllevels"
+tool_software_language = "tools_software_languages"
+armip = "armips"
+cloud_service_provider = "cloud_service_providers"
 
 [permalinks]
-    tools_software_languages = "/tag/:slug/"
-    operatingsystems = "/tag/:slug/"
-    subjects = "/tag/:slug/"
-    cloud_service_providers = "/tag/:slug/"
-    armips   = "/tag/:slug/"
+tools_software_languages = "/tag/:slug/"
+operatingsystems = "/tag/:slug/"
+subjects = "/tag/:slug/"
+cloud_service_providers = "/tag/:slug/"
+armips = "/tag/:slug/"
 
 [related]
-    threshold = 0 
-    includeNewer = true
-    toLower = false
+threshold = 0
+includeNewer = true
+toLower = false
 
-    [[related.indices]]
-        name = "cloud_service_providers"
-        weight = 100
+[[related.indices]]
+name = "cloud_service_providers"
+weight = 100
 
-    [[related.indices]]
-        name = "tools_software_languages"
-        weight = 80
-    
-    [[related.indices]]
-        name = "subjects"
-        weight = 50
+[[related.indices]]
+name = "tools_software_languages"
+weight = 80
+
+[[related.indices]]
+name = "subjects"
+weight = 50
 
 [params]
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
@@ -60,13 +66,12 @@ github_project_repo = "https://github.com/ArmDeveloperEcosystem/arm-learning-pat
 # location of assets
 assetsDir = "assets"
 
-
 # Specify a value here if your content directory is not in your repo's root directory
 # github_subdir = ""
 
 # Uncomment this if your GitHub repo does not have "main" as the default branch,
 # or specify a new value if you want to reference another branch in your GitHub links
-github_branch= "main"
+github_branch = "main"
 
 # For metadata posting on socials
 title = 'Arm Learning Paths'

--- a/content/error.md
+++ b/content/error.md
@@ -1,0 +1,8 @@
++++
+title = "Request Error"
+description = "We are unable to serve this request at the moment."
++++
+
+# Request cannot be served
+
+We are unable to serve this request at the moment. Try going back to our [home page](/).

--- a/themes/arm-design-system-hugo-theme/layouts/_default/single.html
+++ b/themes/arm-design-system-hugo-theme/layouts/_default/single.html
@@ -1,0 +1,5 @@
+{{ define "main"}}
+<main id="main">
+  <div>{{ .Content }}</div>
+</main>
+{{ end }}


### PR DESCRIPTION
Deploy the website to new Internal and Production S3 buckets. These can then be served using CloudFront. I have modified the workflows to allow deployment to these buckets while retaining the current deployment mechanisms. (S3 for internal and Akamai for production) My plan is to have two instances per environment so that the DNS can be switched without downtime.

_Changes_:

- Added new targets to the Hugo config to select where it should deploy to.
- Created a reusable workflow to be called from main and production workflows (To deploy to S3)
- AWS authentication uses OIDC instead of hard-coded secrets (More secure - https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers)
- Added a generic error page to return for something like 403.
- Renamed the 'deploy.yml' to 'production.yml' and 'deploy.yml' is the reusable workflow now.