### PR TITLE
windowsperf: fix missing double-dash operator in record command

### DIFF
--- a/content/learning-paths/laptops-and-desktops/windowsperf_sampling_cpython/windowsperf_sampling_cpython_example_2.md
+++ b/content/learning-paths/laptops-and-desktops/windowsperf_sampling_cpython/windowsperf_sampling_cpython_example_2.md
@@ -6,7 +6,7 @@ weight: 4
 
 ## Example 2: Using the `record` command to simplify things
 
-The `record` command spawns the process and pins it to the core specified by the `-c` option. You can either use --pe_file to let WindowsPerf know which process to spawn or simply add the process to spawn at the very end of the `wperf` command. 
+The `record` command spawns the process and pins it to the core specified by the `-c` option. You can either use `--pe_file` to let WindowsPerf know which process to spawn or simply add the process to spawn at the very end of the `wperf` command. 
 
 This simplifies the steps presented in the previous example.
 
@@ -14,11 +14,11 @@ If you want to pass command line arguments to your application, you can call the
 verbatim to the program that is being spawned. If you want to execute the CPython example above using this approach, you could just type:
 
 ```command
-wperf record -e ld_spec:100000 -c 1 --timeout 30 python_d.exe -c 10**10**100
+wperf record -e ld_spec:100000 -c 1 --timeout 30 -- python_d.exe -c 10**10**100
 ```
 
 {{% notice  Note%}}
-This command will automatically spawn the process `python_d.exe -c 10**10**100` (and pass command line options to it), sample for 30 seconds with --timeout 30 event ld_spec with sample frequency of 100000.
+This command will automatically spawn the process `python_d.exe -c 10**10**100` (and pass command line options to it), sample for 30 seconds with `--timeout 30` event `ld_spec` with sample frequency of `100000`.
 {{% /notice %}}
 
 You should see the same output from this command as in the previous section.


### PR DESCRIPTION
Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [X] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. No AI tool can be used to generate either content or code when creating a learning path or install guide.

- [X] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 

--- 

Minor changes to LP.
- Added missing escape characters and added `--` operator to `wperf record` command.