### PR TITLE
Discontinue Deploying Contents to Akamai CDN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,45 +11,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_deploy_internal_existing:
-    name: Build and Deploy Internal Existing
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-        with:
-          submodules: true # Fetch Hugo Themes
-          fetch-depth: 0
-
-      # Sets Up Hugo
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: "0.130.0"
-          extended: true
-
-      # Post-CSS install and Node.js
-      - name: Install Post-CSS
-        run: npm install postcss-cli
-
-      # Builds arm-software-developer repo
-      - name: Build
-        run: |
-          hugo --minify
-          cp learn-image-sitemap.xml public/learn-image-sitemap.xml
-          bin/pagefind --site "public"
-        env:
-          HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
-
-      # Deploys website to AWS S3
-      - name: Deploy to S3
-        run: hugo deploy --force --maxDeletes -1 --invalidateCDN --target internal-existing
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
   build_and_deploy_internal:
     name: Build and Deploy Internal
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -11,61 +11,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_deploy_existing:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-        with:
-          submodules: true # Fetch Hugo Themes
-          fetch-depth: 0
-
-      # Sets Up Hugo
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: "0.130.0"
-          extended: true
-
-      # Post-CSS install
-      - name: Install Post-CSS
-        run: npm install postcss-cli
-
-      # Builds arm-learning-paths repo
-      - name: Build
-        run: |
-          hugo --minify
-          cp learn-image-sitemap.xml public/learn-image-sitemap.xml
-          bin/pagefind --site "public"
-        env:
-          HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
-
-      #  Copy SSH Key
-      - name: copy key
-        run: |
-          echo $SSH_KEY | xargs -n 1 > tmpkey
-          base64 -d < tmpkey > key
-          chmod 400 key
-        shell: bash
-        env:
-          SSH_KEY: ${{secrets.SSH_KEY}}
-
-      # SCP Site contents to netstorage
-      - name: copy site content
-        run: |
-          cd public
-          zip -r public.zip .
-          cd ..
-          scp -i key -o StrictHostKeyChecking=accept-new -oHostKeyAlgorithms=+ssh-dss -r public/public.zip $USR@$HOST:/$ID/
-        shell: bash
-        env:
-          USR: ${{secrets.SSH_USERNAME}}
-          HOST: ${{secrets.SSH_HOST}}
-          ID: ${{secrets.ID}}
-
   build_and_deploy_production:
     name: Build and Deploy Production
     uses: ./.github/workflows/deploy.yml


### PR DESCRIPTION
The Learning Paths website has been migrated to CloudFront. Therefore, remove the job to deploy to Akamai CDN. Also removed the existing job for deploying internal since this is migrated to a different account.

The following secrets could be removed (If they are not used elsewhere):
- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- SSH_KEY
- SSH_USERNAME
- SSH_HOST
- ID