### PR TITLE
Add note encouraging developers to use Frame Advisor and/or RenderDoc instead of Graphics Analyzer

### DIFF
--- a/content/learning-paths/mobile-graphics-and-gaming/ams/ga.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/ams/ga.md
@@ -11,6 +11,8 @@ Graphics Analyzer is a tool to help `OpenGL ES` and `Vulkan` developers get the 
 
 The tool allows you to observe API call arguments and return values, and interact with a running target application to investigate the effect of individual API calls. It highlights attempted misuse of the API, and gives recommendations for improvements.
 
+**Note:** Graphics Analyzer is no longer in active development. You can still get Graphics Analyzer as part of [Arm Performance Studio 2024.2](https://artifacts.tools.arm.com/arm-performance-studio/2024.2/), but it is no longer available in later versions of the suite. For a more lightweight tool, try [Frame Advisor](https://developer.arm.com/Tools%20and%20Software/Frame%20Advisor), which enables you to capture and analyze rendering and geometry data for a single frame. For graphics debugging, we recommend RenderDoc for Arm GPUs. Both tools are available for free as part of [Arm Performance Studio](https://developer.arm.com/Tools%20and%20Software/Arm%20Performance%20Studio).
+
 ## Prerequisites
 
 Build your application, and setup your Android device as described in [Setup tasks](/learning-paths/mobile-graphics-and-gaming/ams/setup_tasks/).


### PR DESCRIPTION
I was working through this learning path myself, and couldn't find Graphics Analyzer on my local machine, even after installing Arm Performance Studio. When I looked at [the Graphics Analyzer page on Arm's website](https://developer.arm.com/Tools%20and%20Software/Graphics%20Analyzer), I noticed this note about the app no longer being included in Arm Performance Studio. I think it makes sense to copy this note into the learning path, too, so that future readers will understand why they may not have Graphics Analyzer installed.

Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [X] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [X] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
