### PR TITLE
Add link to RenderDoc reference guide to Next Steps in Getting Started with Arm Performance Studio for mobile.

### DIFF
--- a/content/learning-paths/mobile-graphics-and-gaming/ams/_index.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/ams/_index.md
@@ -71,6 +71,10 @@ further_reading:
         title: Integrate Arm Performance Studio into a CI workflow
         link: https://developer.arm.com/documentation/102543
         type: documentation
+    - resource:
+        title: RenderDoc Reference Guide
+        link: https://renderdoc.org/docs/index.html
+        type: documentation
 
 
 ### FIXED, DO NOT MODIFY


### PR DESCRIPTION
This PR is a follow-up to #1685
Feedback was provided on the change that we should also link to the RenderDoc reference guide from the 'Next Steps' section of this learning path.

Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [X] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [X] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
