### PR TITLE
Added learning path on thread syncing

### DIFF
--- a/content/learning-paths/servers-and-cloud-computing/memory_consistency/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/memory_consistency/_index.md
@@ -1,0 +1,60 @@
+---
+title: Explore The Arm Memory Model & Thread Synchronization
+
+minutes_to_complete: 150
+
+who_is_this_for: This is an advanced topic for engineers looking for a practical way to test different thread synchronization approaches within the context of the Arm memory model.
+
+learning_objectives:
+    - Test snippets of thread synchronization assembly against the formal definition of the Arm Memory Model
+    - Test snippets of thread synchronization assembly on Arm hardware to compare against the formal Arm Memory Model
+
+prerequisites:
+    - An understanding of different memory consistency models like Sequential Consistency, Weak Ordering, Relaxed Consistency, Processor Consistency, etc.
+    - An understanding of thread synchronization.
+    - An understanding of Arm assembly, general-purpose registers, and how to find information on Arm assembly instructions.
+    - An understanding of memory barriers including acquire-release semantics.
+
+author: Julio Suarez
+
+skilllevels: Advanced
+subjects: Performance and Architecture
+cloud_service_providers:
+armips:
+    - Neoverse
+operatingsystems:
+    - Linux
+tools_software_languages:
+    - Herd7
+    - Litmus7
+    - Arm ISA
+
+test_images:
+    - ubuntu:latest
+test_link: null
+test_maintenance: false
+test_status:
+    - passed
+
+further_reading:
+    - resource:
+        title: Arm Architecture Reference Manual for A-profile architecture
+        link: https://developer.arm.com/documentation/ddi0487/la
+        type: documentation
+    - resource:
+        title: Armv8 Barriers
+        link: https://developer.arm.com/documentation/100941/0101/Barriers
+        type: documentation
+    - resource:
+        title: Barrier Litmus Tests and Cookbook
+        link: https://developer.arm.com/documentation/100941/0101/Barriers
+        type: documentation
+    - resource:
+        title: diy7 documentation
+        link: https://diy.inria.fr/doc/index.html
+        type: documentation
+
+weight: 1
+layout: learningpathall
+learning_path_main_page: 'yes'
+---

--- a/content/learning-paths/servers-and-cloud-computing/memory_consistency/_next-steps.md
+++ b/content/learning-paths/servers-and-cloud-computing/memory_consistency/_next-steps.md
@@ -1,0 +1,8 @@
+---
+# ================================================================================
+#       FIXED, DO NOT MODIFY THIS FILE
+# ================================================================================
+weight: 21                  # Set to always be larger than the content in this path to be at the end of the navigation.
+title: "Next Steps"         # Always the same, html page title.
+layout: "learningpathall"   # All files under learning paths have this same wrapper for Hugo processing.
+---

--- a/content/learning-paths/servers-and-cloud-computing/memory_consistency/arm_mem_model.md
+++ b/content/learning-paths/servers-and-cloud-computing/memory_consistency/arm_mem_model.md
@@ -1,0 +1,73 @@
+---
+title: "Thread Synchronization, Arm Memory Model, and Tools"
+weight: 2
+layout: "learningpathall"
+---
+
+## CPU Memory Model vs Language/Runtime Memory Models
+
+It's important to understand that the majority of developers will not need to concern themselves with the memory consistency model of the CPU their code will execute on. This is because programming languages and runtime engines abstract away the CPUs memory model by presenting the programmer with a language/runtime memory model. This abstraction is achieved by providing developers with a set of language/runtime specific memory ordering rules, synchronization constructs, and supporting libraries. So long as the developer uses these correctly, language compilers and runtime engines will make sure the code executes correctly on any CPU regardless of how strong or weakly ordered it is.
+
+That said, developers may want to dig deeper into this topic for various reasons including:
+
+- Extract more performance from weakly ordered CPUs (like Arm).
+  - Keep in mind that compilers and runtimes will do a good job of maximizing performance. Only in well understood niche cases will there be a potential for performance gain by going beyond what the compiler/runtime would do to higher level code. For most cases, all it takes to get more performance is to use the latest compilers, compiler switches, and runtimes.
+- Develop confidence in the correctness of synchronization constructs.
+- Develop an understanding of how compilers and runtimes select different machine instructions while still honoring the memory ordering rules of the language/runtime and CPU.
+- General learning.
+
+## What We Will Do
+
+In this Learning Path, we will use publicly available tools to explore thread synchronization on Arm CPUs. This will provide the reader with enough working knowledge of the tools to be able to explore on their own. At the end of this Learning Path, we will provide more information on where readers can find a more formal (and complex) treatment of this subject.
+
+##  The Formal Definition of the Arm Memory Model
+
+The formal definition of the Arm memory model is in the [Arm Architecture Reference Manual for A-profile architecture](https://developer.arm.com/documentation/ddi0487/la) (Arm ARM) under the section called `The AArch64 Application Level Memory Model`. The ordering requirements defined in the Arm ARM is a transliteration of the `aarch64.cat` file hosted on the Arm [herd7 simulator tool](https://developer.arm.com/herd7). In fact, this `aarch64.cat` file is the authoritative definition of the Arm memory model. Since it is a formal definition, it is complex.
+
+##  Herd7 Simulator & Litmus7 Tool
+
+The herd7 simulator provides a way to test snippets of Arm assembly against the formal definition of the Arm memory model (the `aarch64.cat` file mentioned above). The litmus7 tool can take the same snippets of assembly that run on herd7 and run them on actual Arm HW. This allows for comparing the formal memory model to the memory model of an actual Arm CPU. These snippets of assembly are called litmus tests.
+
+It's important to understand that it is possible for an implementation of an Arm CPU to be more strongly ordered than the formally defined Arm memory model. This case is not a violation of the memory model because it will still execute code in a way that is compliant with the memory ordering rules.
+
+## Installing the Tools
+
+Herd7 and Litmus7 are part of the [diy7](http://diy.inria.fr/) tool suite. The diy7 tool suite can be installed by following the [installation instructions](http://diy.inria.fr/sources/index.html). We suggest installing this on an Arm system so that both herd7 and litmus7 can be compared side by side on the same system.
+
+
+## Running Herd7 and Litmus7 Example Commands
+
+The test file is assumed to be called `test.litmus` and is in the current directory.
+
+The help menu shows all options.
+```
+herd7 --help
+```
+```
+litmus7 --help
+```
+
+Example of running herd7.
+```
+herd7 ./test.litmus
+```
+
+Example of running litmus7.
+```
+litmus7 ./test.litmus
+```
+
+Example of running litmus7 with 5,000,000 test iterations (default is 1,000,000).
+```
+litmus7 ./test.litmus -s 5000000
+```
+
+Example of running a litmus7 tests in parallel on 8 CPUs.
+```
+litmus7 ./test.litmus -a 8
+```
+
+Example of running litmus7 and asking GCC to emit atomic instructions as required by the litmus test (the possible need for this is explained later).
+```
+litmus7 ./test.litmus -ccopts="-mcpu=native"
+```

--- a/content/learning-paths/servers-and-cloud-computing/memory_consistency/examples.md
+++ b/content/learning-paths/servers-and-cloud-computing/memory_consistency/examples.md
@@ -1,0 +1,261 @@
+---
+# User change
+title: "Thread Synchronization Examples"
+
+weight: 4 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+## Arm Instructions with Acquire-Release Ordering
+
+Most of the examples below use the instructions `LDAR` and `STLR` which are load-acquire and store-release respectively. However, there are other instructions that support acquire-release ordering. More specifically, the various atomic instructions that were made mandatory as of Armv8.1. These include Compare and Swap (`CAS`), Swap (`SWP`), Load-Add (`LDADD`), Store-ADD (`STADD`), and more. We leave it as an exercise for the reader to explore these.
+
+## Litmus7 Switches
+
+Since `litmus7` executes code on the machine, it needs to build the assembly snippets into executable code. `litmus7` compiles with GCC, however, GCC uses default options. If running on an Arm Neoverse platform, we strongly recommend using the `-ccopts="-mcpu=native"` switch. This is the easiest way to avoid all possible run time failures. For example, if the Compare and Swap example below is executed without this switch, it will fail to run because by default, GCC will not emit the Compare and Swap instruction (`CAS`). This instruction is supported in Armv8.1, but GCC by default builds for Armv8.0. If in the future, the GCC default is updated to build for a newer version of the Arm architecture (e.g. Armv9.0). The `-ccopts` switch will not be needed to run tests that use atomic instructions like Compare and Swap (`CAS`).
+
+## Example 1: Message passing without barriers
+
+The first example highlights one of the pitfalls that may occur under a relaxed memory model.
+
+```
+AArch64 MP+Loop
+{
+0:X1=x; 0:X3=y;
+1:X1=y; 1:X3=x;
+}
+  P0                 |  P1               ;
+   MOV    W0,  #1    |L1:                ;
+   STR    W0,  [X1]  |  LDR    W0,  [X1] ;
+   MOV    W2,  #1    |  CBZ    W0,  L1   ;
+   STR    W2,  [X3]  |  LDR    W2,  [X3] ;
+exists
+(1:X0=1 /\ 1:X2=0)
+```
+This example is similar to what we saw in the previous section, except this time we've added a loop to check for the message ready flag. If we think about this assembly in a Sequentially Consistent way, we can convince ourselves that the only valid outcome of these two threads executing will be `(1,1)`. Below is the output of this test with `herd7`.
+
+```
+Test MP+Loop Allowed
+States 2
+1:X0=1; 1:X2=0;
+1:X0=1; 1:X2=1;
+```
+We see the outcome of `(1,0)`. Let's try `litmus7` on a Neoverse platform to see if it shows us the same outcomes.
+
+```
+Test MP+Loop Allowed
+Histogram (2 states)
+458   *>1:X0=1; 1:X2=0;
+999542:>1:X0=1; 1:X2=1;
+```
+`litmus7` shows that most of the time we see the outcome `(1,1)`, but occasionally we see `(1,0)`. This result also highlights why we might want to increase the number of test iterations with `litmus7`. Notice that the `(1,0)` result is rare relative to the result of `(1,1)`. Increasing the number of test iterations will increase the probability that we see all outcomes, including those that are rare.
+
+We see the outcome of `(1,0)` because `LDR` and `STR` are ordinary memory accesses. This means that if there are no dependencies between them (there aren't in this case), they can be reordered by the CPU. Both `herd7` and `litmus7` confirm that this can and will happen. The result of `(1,0)` is not desired because it represents reading the payload of a message before the ready flag is set. This is likely not what the programmer intended.
+
+## Example 2: Message passing with two-way barriers
+
+Let's fix the message passing by adding two-way barriers. Namely, the instruction `DMB` which is a data memory barrier.
+```
+AArch64 MP+Loop+DMB
+{
+0:X1=x; 0:X3=y;
+1:X1=y; 1:X3=x;
+}
+  P0                 |  P1               ;
+   MOV    W0,  #1    |L1:                ;
+   STR    W0,  [X1]  |  LDR    W0,  [X1] ;
+   DMB    ISH        |  CBZ    W0,  L1   ;
+   MOV    W2,  #1    |  DMB    ISH       ;
+   STR    W2,  [X3]  |  LDR    W2,  [X3] ;
+exists
+(1:X0=1 /\ 1:X2=0)
+```
+In this example we add the `DMB` instruction between the `STR` instructions in `P0`, and between the `LDR` instructions in `P1`. The `DMB` prevents the reordering of memory accesses across it. Note that non-memory access instructions can still be reordered across the `DMB`. For example, it's possible for the second `MOV` in `P0` to be executed before the `DMB` because it's not a memory access instruction. Also, on Arm, `DMB` instructions are Sequentially Consistent with respect to other `DMB` instructions.
+
+Below is the `herd7` output of this test.
+
+```
+Test MP+Loop+DMB Allowed
+States 1
+1:X0=1; 1:X2=1;
+...
+Warning: File "test.litmus": unrolling limit exceeded at L1, legal outcomes may be missing.
+```
+Now that we have the memory barriers in place, we only see the outcome `(1,1)` which is what is desired for message passing between threads. When we run tests that contain loops with `herd7`, a warning will be shown. This warning appears because `herd7` is a simulator that interleaves instructions to figure out all possible outcomes. A consequence of it working this way means that it will unroll loops first, then test against the unrolled loops. By default, it unrolls loops two times. It is possible to increase this with with `-unroll` switch. That said, it doesn't seem useful to increase the number of unrolls unless there is some very specific and unusual sequencing occurring between the threads being tested. Overall, we strongly recommend that complex scenarios be broken into smaller and more primitive tests.
+
+Below is the `litmus7` output of this test on a Neoverse platform.
+
+```
+Test MP+Loop+DMB Allowed
+Histogram (1 states)
+1000000:>1:X0=1; 1:X2=1;
+```
+100% of the test runs observed `(1,1)`. This builds confidence that our barriers are working.
+
+A last point is that the `DMB` in `P1` can be relaxed by changing it to `DMB ISHLD`. This relaxation could potentially yield performance improvements in real applications. However, doing the same relaxation to the `DMB` in `P0` will break the message passing. We encourage readers to try this experiment and also read the Arm documentation on the differences between `DMB ISH`, `DMB ISHLD`, and `DMB ISHST`.
+
+## Example 3: Message passing with One-Way Barriers
+
+Let's test message passing with one-way barriers next. This is done by using instructions that support acquire-release ordering.
+
+```
+AArch64 MP+Loop+ACQ_REL
+{
+0:X1=x; 0:X3=y;
+1:X1=y; 1:X3=x;
+}
+  P0                 |  P1               ;
+   MOV    W0,  #1    |L1:                ;
+   STR    W0,  [X1]  |  LDAR   W0,  [X1] ;
+   MOV    W2,  #1    |  CBZ    W0,  L1   ;
+   STLR   W2,  [X3]  |  LDR    W2,  [X3] ;
+exists
+(1:X0=1 /\ 1:X2=0)
+```
+
+In this example, we drop the `DMB` instructions and instead use a properly placed `STLR` in `P0` and `LDAR` in `P1`. `STLR` is a store-release instruction and `LDAR` is a load-acquire instruction. These are synchronizing memory accesses (as opposed to ordinary memory accesses). The `STLR` prevents earlier memory accesses from reordering after it, while the `LDAR` prevents later memory accesses from reordering before it. This is why these are also called one-way barriers; they block reordering only in one direction. `LDAR` and `STLR` instructions are Sequentially Consistent with respect to other `LDAR` and `STLR` instructions, while ordinary `LDR` and `STR` are not. There is also a more relaxed version of `LDAR` called `LDAPR`, this is a Load-Acquire with Processor Consistency. The Arm documentation on [Load-Acquire and Store-Release instructions](https://developer.arm.com/documentation/102336/0100/Load-Acquire-and-Store-Release-instructions) has more information on this.
+
+Below is the `herd7` output of this test.
+
+```
+Test MP+Loop+ACQ_REL Allowed
+States 1
+1:X0=1; 1:X2=1;
+```
+
+We see the result we want. Only an outcome of `(1,1)` is possible.
+
+Below is the `litmus7` output of this test on a Neoverse platform.
+```\
+Test MP+Loop+ACQ_REL Allowed
+Histogram (1 states)
+1000000:>1:X0=1; 1:X2=1;
+```
+
+`litmus7` shows us the same as `herd7`.
+
+## Example 4: Compare and Swap with One-Way Barriers
+
+Atomic instructions support acquire-release semantics. In this example we look at Compare and Swap with acquire ordering (`CASA`).
+
+```
+AArch64 Lock+Loop+CAS+ACQ_REL
+{
+y = 1;
+0:X1=x; 0:X3=y;
+1:X1=y; 1:X3=x;
+}
+  P0                 |  P1                    ;
+   MOV    W0,  #1    |  MOV    W0,  #0        ;
+   STR    W0,  [X1]  |  MOV    W4,  #1        ;
+   MOV    W2,  #0    |L1:                     ;
+   STLR   W2,  [X3]  |  CASA   W0,  W4,  [X1] ;
+                     |  CBNZ   W0,  L1        ;
+                     |  MOV    W0,  W4        ;
+                     |  LDR    W2,  [X3]      ;
+exists
+(1:X0=1 /\ 1:X2=0)
+```
+
+This test is a representation of a basic spin lock. The lock variable is in address `y`. When it is set to 1, it's locked, when it's set to 0, it's available. This test starts with the lock variable at address `y` set to 1, which means it's locked. `P0` is assumed to be the owner of the lock at the start of the test. `P0` will write to address `x` (the payload), then release the lock by writing a 0 to address `y`. The store to address `y` is a `STLR` (store-release), this ensures that the write to the payload is visible before the release of the lock at address `y`. On `P1`, we spin on address `y` (the lock) with a `CASA`. At each loop iteration, `CASA` checks the value at address `y`. If it's 0 (available), then it will write a 1 to take ownership. If it's 1, the `CASA` fails and loops back to try the `CASA` again. It will continue to loop until it successfully takes the lock. The `CASA` instruction does this operation atomically, and with acquire ordering to ensure that the later `LDR` of address `x` (the payload) is not ordered before the `CASA`.
+
+Below is the `herd7` output of this test.
+```
+Test Lock+Loop+CAS+ACQ_REL Allowed
+States 1
+1:X0=1; 1:X2=1;
+```
+We see the result we want. Only an outcome of `(1,1)` is possible.
+
+Below is the `litmus7` output of this test on a Neoverse platform. Note that when we ran this, we used the switch `-ccopts="-mcpu=native"`. If we didn't, `litmus7` would fail with a message saying that the `CASA` instruction cannot be emitted by the compiler.
+```
+Test Lock+Loop+CAS+ACQ_REL Allowed
+Histogram (1 states)
+1000000:>1:X0=1; 1:X2=1;
+```
+Only an outcome of `(1,1)` has been observed. More test iterations can be executed to build confidence that this is the only possible result.
+
+Try changing the `CASA` to a `CAS` (Compare and Swap with no ordering) to see what happens.
+
+## Example 5: Dependency as a Barrier
+
+It is possible to create barriers that are more relaxed than acquire-releases. This is done by creating dependencies between instructions that block the CPU's scheduler from reordering them. This is what the C/C++ ordering of `memory_order::consume` aims to achieve. However, over the years, it has been challenging for compilers to support this dependency based barrier concept. Thus,`memory_order::consume` gets upgraded to `memory_order::acquire` in practice. In fact, this ordering is in discussion to be dropped from the C/C++ standard. Still, it makes for an interesting example to show here.
+
+To be able to show the difference, we first need to look at the one-way barrier example from before but with a modification. That modification is that we add a second payload memory address. We'll call it `w`. The new test with this additional memory location is shown below.
+
+```
+AArch64 MP+Loop+ACQ_REL2
+{
+0:X1=x; 0:X3=y; 0:X4=w;
+1:X1=y; 1:X3=x; 1:X4=w;
+}
+  P0                 |  P1               ;
+   MOV    W5,  #1    |L1:                ;
+   STR    W5,  [X4]  |  LDAR   W0,  [X1] ;
+   MOV    W0,  #1    |  CBZ    W0,  L1   ;
+   STR    W0,  [X1]  |  LDR    W2,  [X3] ;
+   MOV    W2,  #1    |  LDR    W5,  [X4] ;
+   STLR   W2,  [X3]  |                   ;
+exists
+(1:X0=1 /\ (1:X2=0 \/ 1:X5=0))
+```
+On `P0`, we are writing to both `w` and `x` before we do the store-release on address `y`. This ensures that the writes to both `x` and `w` (the payloads) will be ordered before the write to address `y` (the flag). On `P1`, we loop with a load-acquire on address `y` (the flag). Once it is observed to be set, we load the two payload addresses. The load-acquire ensures that we do not read the payload addresses `w` and `x` until the flag is observe to be set. The condition at the bottom has been updated to check for any cases where either `w` or `x` are 0. Either of these being observed as 0 will be an indication of reading the payload before the ready flag is observed to be set (not what we want). Overall, this code should result in only the outcome `(1,1,1)`.
+
+Below is the `herd7` output of this test.
+```
+Test MP+Loop+ACQ_REL2 Allowed
+States 1
+1:X0=1; 1:X2=1; 1:X5=1;
+```
+
+Below is the `litmus7` output of this test on a Neoverse platform.
+```
+Test MP+Loop+ACQ_REL2 Allowed
+Histogram (1 states)
+1000000:>1:X0=1; 1:X2=1; 1:X5=1;
+```
+
+Both `herd7` and `litmus7` show us the expected result. It might be worth increasing the number of iterations on `litmus7` to build more confidence in the result.
+
+Now let's remove the load-acquire in `P1` and use a dependency as a barrier.
+```
+AArch64 MP+Loop+Dep
+{
+0:X1=x; 0:X3=y; 0:X4=w;
+1:X1=y; 1:X3=x; 1:X4=w;
+}
+  P0                 |  P1                    ;
+   MOV    W5,  #1    |L1:                     ;
+   STR    W5,  [X4]  |  LDR    W0,  [X1]      ;
+   MOV    W0,  #1    |  CBZ    W0,  L1        ;
+   STR    W0,  [X1]  |  AND    W6,  W0,  WZR  ;
+   MOV    W2,  #1    |  LDR    W2,  [X3, X6]  ;
+   STLR   W2,  [X3]  |  LDR    W5,  [X4]      ;
+exists
+(1:X0=1 /\ (1:X2=0 \/ 1:X5=0))
+```
+What we've done to `P1` is create a dependency between the first `LDR` which is in the loop, and the second `LDR` which appears after the loop. Register `X6` (which is the same as `W6`) doesn't change the address loaded in the second `LDR` because the previous `AND` instruction zeros the offset. The point of the `AND` is to create a dependency between the first and second `LDR` instructions so that they execute in order. The net effect is that we have a barrier for the address `x` between the two `LDR` instructions. However, we do not have a barrier for the address `y`. In this way, it is a more relaxed barrier than using `LDAR`, because `LDAR` applies to all memory accesses that appear after it in program order.
+
+Below is the `herd7` output of this test.
+```
+Test MP+Loop+Dep Allowed
+States 2
+1:X0=1; 1:X2=1; 1:X5=0;
+1:X0=1; 1:X2=1; 1:X5=1;
+```
+The possible outcome of `(1,1,0)` makes sense because the dependency we've added doesn't cover the read of address `w`.
+
+Below is the `litmus7` output of this test on a Neoverse platform.
+```
+Test MP+Loop+Dep Allowed
+Histogram (2 states)
+1     *>1:X0=1; 1:X2=1; 1:X5=0;
+49999999:>1:X0=1; 1:X2=1; 1:X5=1;
+```
+We have the same result here too. However, notice that we had to execute the test 50 million times just to observe the reorder of the `LDR` of address `w` just one time. Again, if we don't do enough test iterations, we might miss the observation of a possible outcome.
+
+## Experimentation Ideas
+
+We encourage readers to modify and experiment with the example tests shared here. Readers can also create their own examples by using the assembly code generated from higher level languages. Last, there are also other litmus tests posted in the [herd7 online simulator](https://developer.arm.com/herd7)

--- a/content/learning-paths/servers-and-cloud-computing/memory_consistency/explore_deeper.md
+++ b/content/learning-paths/servers-and-cloud-computing/memory_consistency/explore_deeper.md
@@ -1,0 +1,30 @@
+---
+# User change
+title: "Exploring More Deeply"
+
+weight: 5
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+## Exploring the Memory Model More Deeply
+
+In this Learning Path we took a practical approach to exploring the Arm memory model and thread synchronization. If the reader would like to explore this topic more deeply and more formally, we recommend reading through the following blog series.
+
+- [A working example of how to use the herd7 Memory Model Tool](https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/how-to-use-the-memory-model-tool)
+- [How to generate litmus tests automatically with the diy7 tool](https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/generate-litmus-tests-automatically-diy7-tool)
+- [Running litmus tests on hardware using litmus7](https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/running-litmus-tests-on-hardware-litmus7)
+- [Expanding the Memory Model Tools to System-level architecture](https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/expanding-memory-model-tools-system-level-architecture)
+
+Also, the [diy7 documentation](https://diy.inria.fr/doc/index.html) links to a few papers that explore memory models more formally.
+
+## Docs on Barriers
+
+- [Barriers on Armv8](https://developer.arm.com/documentation/100941/0101/Barriers).
+- [Load-Acquire and Store-Release on Armv8](https://developer.arm.com/documentation/102336/0100/Load-Acquire-and-Store-Release-instructions).
+- [Barrier Litmus Tests and Cookbook](https://developer.arm.com/documentation/genc007826/latest). This was written during the Armv7 days, but it still has relevance.
+
+## More Tests to Explore
+
+There are many more tests that can be explored in the [herd7 simulator tool](https://developer.arm.com/herd7).

--- a/content/learning-paths/servers-and-cloud-computing/memory_consistency/litmus_syntax.md
+++ b/content/learning-paths/servers-and-cloud-computing/memory_consistency/litmus_syntax.md
@@ -1,0 +1,140 @@
+---
+# User change
+title: "Herd7 & Litmus7 Test Primer"
+
+weight: 3 # 1 is first, 2 is second, etc.
+
+# Do not modify these elements
+layout: "learningpathall"
+---
+
+## Herd7 & Litmus7 Test Primer
+
+In this section we will give just enough information to understand the syntax of litmus tests and how to run them. More comprehensive information on developing and runing litmus tests can be found in the [diy7 documentation](https://diy.inria.fr/doc/index.html)
+
+We will use an abbreviated version of the `MP.litmus` test included in the [herd7 online simulator](https://developer.arm.com/herd7).
+```
+AArch64 MP
+{
+0:X1=x; 0:X3=y;
+1:X1=y; 1:X3=x;
+}
+  P0               |  P1               ;
+  MOV    W0,  #1   |  LDR    W0,  [X1] ;
+  STR    W0,  [X1] |  LDR    W2,  [X3] ;
+  MOV    W2,  #1   |                   ;
+  STR    W2,  [X3] |                   ;
+exists
+(1:X0=1 /\ 1:X2=0)
+```
+
+- The first line sets the target architecture of this test which is `AArch64`. This is required because the diy7 tool supports other architectures that are not Arm. After the architecture label we have `MP` which is a label that gives this test its name. `MP` stands for "Message Passing".
+  - In short, the first line say's "This is a test for AAarch64 called `MP`"
+- This test defines two threads `P0` and `P1`. It is possible to define more threads than just two, but in this Learning Path we will only work with two threads to keep things manageable.
+- The lines between the brackets ( `{..}` ) determines the initial state of the CPU registers for this test.
+  - `0:X1=x; 0:X3=y;` defines the initial state for `P0`.
+    - Register X1 holds memory address `x`.
+    - Register X3 holds memory address `y`.
+  - `1:X1=y; 1:X3=x;` defines the initial state for `P1`.
+    - Register X1 holds memory address `y`.
+    - Register X3 holds memory address `x`.
+  - Any registers and memory addresses not listed in between these brackets are initialized to 0.
+  - The memory address `x` contains the message to pass, while the memory address `y` is the message ready flag.
+- Below the brackets we see the assembly snippets for `P0` and `P1`.
+  - `P0`.
+    - The first `MOV` and `STR` writes a `1` into memory address `x` (the payload).
+    - The second `MOV` and `STR` writes a `1` into memory address `y` (the flag).
+  - `P1`.
+    - The first `LDR` reads the address `y` (the flag). The value of the flag is stored in register `W0`.
+    - The second `LDR` reads the address `x` (the payload). The value of the payload is stored in register `W2`.
+    - Notice that we are not looping on the flag like what would normally be done in a message passing scenario. We explore loops in the next section.
+- The last two lines shows a test condition. This test condition asks the question:
+  - "On `P1`, is it possible for us to observe register `W0` (the flag) set to 1 **AND** register `W2` (the payload) set to 0?"
+    - Wait...but the condition uses register names `X0` and `X2`, not `W0` and `W2`. See the note below for more.
+  - In this condition check syntax, `/\` is a logical **AND**, while `\/` is a logical **OR**
+- A note on `X` and `W` registers.
+  - Notice we are using `X` registers for storing addresses and for doing the condition check, but `W` registers for everything else.
+    - Addresses need to be stored as 64-bit values, hence the need to use `X` registers for the addresses because they are 64-bit. `W` registers are 32-bit. In fact, register `Wn` is the lower 32-bits of register `Xn`.
+    - Writing the litmus tests this way is cleaner than if we use all `X` registers. If all `X` registers are used, the data type of each register needs to be declared on additional lines. For this reason, most tests are written as shown above. The way this is done may be changed in the future to reduce potential confusion around the mixed use of `W` and `X` registers, but all of this is functionally correct.
+
+Before we run this test with `herd7` and `litmus7`, let's hypothesize on what might be observed in registers `X0` (flag) and `X2` (payload) on thread `P1`. Even though we know Arm machines are not Sequentially Consistent (modern machines usually aren't), let's start by assuming this to be the case anyway. To reason on the execution of these threads in a Sequentially Consistent way, means to imagine the instructions on `P0` and `P1` are executed in some interleaved order. Further, if we interleave these instructions in all possible permutations, we can figure out all of the possible valid outcomes of registers `X0` (flag) and `X2` (payload) on `P1`. For the example test above, the possible valid outcomes of `(X0,X2)` (or `(flag,data)`) are `(0,0)`, `(0,1)`, & `(1,1)`. Below we show some permutations that result in these valid outcomes. These are not all the possible instruction permutations for this test. Listing them all would make this section needlessly long.
+
+A permutation that results in `(0,0)`:
+```
+(P1)  LDR  W0,  [X1]  # P1 reads flag, gets 0
+(P1)  LDR  W2,  [X3]  # P1 reads payload, gets 0
+(P0)  MOV  W0,  #1
+(P0)  STR  W0,  [X1]  # P2 writes payload, sets 1
+(P0)  MOV  W2,  #1
+(P0)  STR  W2,  [X3]  # P2 writes flag, sets 1
+```
+In this permutation of the test execution, `P1` runs to completion before `P0` even starts its execution. For this reason, `P1` observes the initial values of 0 for both the flag and payload.
+
+A permutation that results in `(0,1)`:
+```
+(P1)  LDR  W0,  [X1]  # P1 reads flag, gets 0
+(P0)  MOV  W0,  #1
+(P0)  STR  W0,  [X1]  # P2 writes payload, sets 1
+(P1)  LDR  W2,  [X3]  # P1 reads payload, gets 1
+(P0)  MOV  W2,  #1
+(P0)  STR  W2,  [X3]  # P2 writes flag, sets 1
+```
+In this permutation of the test execution, `P1` reads the initial value of the flag (the first line) because this instruction is executed before `P0` writes the flag (the last list). However `P1` reads the payload value of 1 because it executes after `P0` writes the payload to 1 (third and forth lines).
+
+A permutation that results in `(1,1)`:
+```
+(P0)  MOV  W0,  #1
+(P0)  STR  W0,  [X1]  # P2 writes payload, sets 1
+(P0)  MOV  W2,  #1
+(P0)  STR  W2,  [X3]  # P2 writes flag, sets 1
+(P1)  LDR  W0,  [X1]  # P1 reads flag, gets 1
+(P1)  LDR  W2,  [X3]  # P1 reads payload, gets 1
+```
+In this permutation of the test execution, `P2` runs to completion before `P1` starts. Thus `P1` observes both the flag and payload set to 1.
+
+Result `(1,0)` is not possible in a Sequentially Consistent execution of this test. This is because the instructions in `P0` and `P1` must execute in program order (a requirement for Sequential Consistency). It is only possible to get the result `(1,0)` if the machine is not Sequentially Consistent. Not being Sequentially Consistent means that the memory access instructions (`STR` and `LDR`) can be executed out of program order if there are no dependencies between them.
+
+Now that we've developed a hypothesis on what we should see assuming a Sequentially Consistent machine, let's try running the test with `herd7`. `herd7` will simulate all the possible instruction permutations to see which outcomes are possible. Below is the output of the test on `herd7`.
+
+```
+Test MP Allowed
+States 4
+1:X0=0; 1:X2=0;
+1:X0=0; 1:X2=1;
+1:X0=1; 1:X2=0;
+1:X0=1; 1:X2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+```
+
+It turns out that we do see outcome `(1,0)` when testing against the Arm memory model. This point is also signaled by the positive witness on our test condition. This tells us that the Arm memory model violates Sequential Consistency. As mentioned earlier, we know this already. The Arm memory model tends to be a Relaxed Consistency model. We are saying Arm "tends to" be a Relaxed Consistency model because it is possible for an Arm CPU in the real world to use ordering rules that are stronger than Relaxed Consistency. Going stronger on the memory model will not violate the Arm ordering rules. A stronger memory model means that there might be less opportunity for HW based optimizations, it will not affect the correctness of code execution (assuming no bugs in the code). That said, all Arm Neoverse CPUs in the market can be thought of as following a Relaxed Consistency model (i.e. acquire-release ordering is supported).
+
+In a Release Consistency model, ordinary memory accesses like `STR` and `LDR` do not need to follow program order. This relaxation in the ordering rules expands the list of instruction permutations in the litmus test above. It is in these additional instruction permutations allowed by the Relaxed Consistency model that yields at least one permutation that results in `(1,0)`. Below is one such example of a permutation. For this permutation, we reordered the `LDR` instructions in `P1`.
+
+One possible permutation resulting in `(1,0)`:
+```
+(P1)  LDR  W2,  [X3]  # P1 reads payload, gets 0
+(P0)  MOV  W0,  #1
+(P0)  STR  W0,  [X1]  # P2 writes payload, sets 1
+(P0)  MOV  W2,  #1
+(P0)  STR  W2,  [X3]  # P2 writes flag, sets 1
+(P1)  LDR  W0,  [X1]  # P1 reads flag, gets 1
+```
+There are more possible permutations of instructions, including some that reorder the `STR` instructions in `P0`. We will not explore those here, this is what `herd7` tests for us anyway.
+
+Now that we see the results against the formal Arm memory model, we can try testing on actual hardware with `litmus7`. Since `litmus7` runs the test against actual HW, it can't guarantee that all instruction permutations are tested. This is because there isn't a way to manipulate the CPUs dynamic instruction scheduler (this is "hardwired" in the CPU design). Instead, we have to run numerous iterations of the test to increase the probability that we see all possible outcomes. Thus, `litmus7` can't formally verify/confirm the memory model of the CPU, it can only provide empirical evidence to support a claim on the CPU's memory model. That said, it can be used to disprove that the CPU does not follow a specific memory model. For example, we can prove that Arm is **not** Sequentially Consistent by finding at least one outcome that would not be allowed by Sequential Consistency.
+
+Below we run the test 1,000,000 times with `litmus7`. 1,000,000 is the default number of iterations, this can be adjusted with the `-s` switch. It is also possible to run the test on more than one CPU in parallel with the `-a` switch. The more test iterations we run, the more confidence there can be that we've capture all possible outcomes. Below is the result of running the test on an Arm Neoverse system.
+
+```
+Test MP Allowed
+Histogram (4 states)
+553396:>1:X0=0; 1:X2=0;
+53040 *>1:X0=1; 1:X2=0;
+96641 :>1:X0=0; 1:X2=1;
+296923:>1:X0=1; 1:X2=1;
+```
+`litmus7` reports the same 4 outcomes we saw in the `herd7` simulation. The outcome with the asterisk signals the positive witness of the condition check. It also reports the number of times each outcome was observed. This result suggests that this CPU is in agreement with the formal memory model (tested with `herd7`), at least for this test. To build more confidence, more tests and more test iterations with `litmus7` would be needed. The [herd7 online simulator](https://developer.arm.com/herd7) contains additional tests that can be executed. Additional tests can also be created by the reader.
+
+Let's move on to exploring thread synchronization.


### PR DESCRIPTION
New learning path on using herd7 and litmus7 tools to explore the Arm memory model and thread synchronization. The idea is to enable people to explore their thread sync constructs within the context of the Arm memory model.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
