### PR TITLE
Remove partial prefix as of hugo v0.146.1

### DIFF
--- a/.github/workflows/test-lp.yml
+++ b/.github/workflows/test-lp.yml
@@ -8,6 +8,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.vars.outputs.branch-name }}
+      - name: Run hugo command to test site builds
+        run: |
+          sudo apt-get install -y hugo
+          hugo
       - name: Get all changed markdown files
         id: changed-markdown-files
         uses: step-security/changed-files@v45

--- a/themes/arm-design-system-hugo-theme/layouts/partials/general-formatting/metadata-table.html
+++ b/themes/arm-design-system-hugo-theme/layouts/partials/general-formatting/metadata-table.html
@@ -97,14 +97,6 @@ Called from:
 
 
 
-
-
-
-
-
-
-
-
  <!-- Markdown metadata table -->
  <div class="content-box">
     {{- $page_h2 := printf "About this %s" $table_name -}}

--- a/themes/arm-design-system-hugo-theme/layouts/partials/general-formatting/metadata-table.html
+++ b/themes/arm-design-system-hugo-theme/layouts/partials/general-formatting/metadata-table.html
@@ -44,8 +44,8 @@ Called from:
 {{/* Populate dictionary with author metadata */}}
 {{ range $index, $row := $csv_content }}
     {{ $name := index $row 0 }}
-    
-    {{ $metadata := dict 
+
+    {{ $metadata := dict
         "company"   (cond (and (gt (len $row) 1) (ne (index $row 1) "")) (index $row 1) nil)
         "github"    (cond (and (gt (len $row) 2) (ne (index $row 2) "")) (printf "https://github.com/%s" (index $row 2)) nil)
         "linkedin"  (cond (and (gt (len $row) 3) (ne (index $row 3) "")) (printf "https://linkedin.com/in/%s" (index $row 3)) nil)
@@ -85,7 +85,7 @@ Called from:
             {{end}}
         {{ end }}
     {{end}}
-{{end}}  
+{{end}}
 
 <!-- Check if there are any matching learning paths to this tool (or the main tool) -->
 {{ if in $tools_software_languages (.Title | urlize)}}
@@ -135,22 +135,22 @@ Called from:
                             Reading time:
                         </td>
                         <td id="reading-time" class="td-metadata-value" >
-                            <span><i class="fa-light fa-clock fa-sm"></i></span>&nbsp; <span class="time-to-complete-string" name="{{.Params.minutes_to_complete}}">{{partial "partials/server-side-processing/time-beautifier.html" .Params.minutes_to_complete}}</span>
+                            <span><i class="fa-light fa-clock fa-sm"></i></span>&nbsp; <span class="time-to-complete-string" name="{{.Params.minutes_to_complete}}">{{partial "server-side-processing/time-beautifier.html" .Params.minutes_to_complete}}</span>
                         </td>
                     </tr>
                     <tr>
                         <td class="td-metadata-key">
                             Last updated:
                         </td>
-                        <td id="last-updated" class="td-metadata-value">                    
+                        <td id="last-updated" class="td-metadata-value">
                             <span><i class="fa-light fa-calendar-days fa-sm"></i></span>&nbsp;
-                            {{/* If learning path, obtain last modified date from any LP file; install guide just display from this file. */}} 
+                            {{/* If learning path, obtain last modified date from any LP file; install guide just display from this file. */}}
                             {{ if $is_learning_path}}
                                 {{- $true_last_mod_date := partial "server-side-processing/calculate-last-update.html" . }}
                                 {{$true_last_mod_date.Format "02 Jan 2006"}}
                             {{else}}
                                 {{ .Lastmod.UTC.Format "2 Jan 2006" }}
-                            {{end}} 
+                            {{end}}
                         </td>
                     </tr>
                 {{ if .Params.test_maintenance}}
@@ -163,8 +163,8 @@ Called from:
                         </td>
                     </tr>
                 {{end}}
-                </table>     
-            </div>     
+                </table>
+            </div>
             <!-- RIGHT TABLE, mobile -->
             <div class="md:u-hide u-display-block">
                 <table class="width-max-content">
@@ -187,7 +187,7 @@ Called from:
                     </tr>
                     <tr>
                         <td id="reading-time" class="td-metadata-value margin-l-24" >
-                            <span><i class="fa-light fa-clock fa-sm"></i></span>&nbsp; <span class="time-to-complete-string" name="{{.Params.minutes_to_complete}}">{{partial "partials/server-side-processing/time-beautifier.html" .Params.minutes_to_complete}}</span>
+                            <span><i class="fa-light fa-clock fa-sm"></i></span>&nbsp; <span class="time-to-complete-string" name="{{.Params.minutes_to_complete}}">{{partial "server-side-processing/time-beautifier.html" .Params.minutes_to_complete}}</span>
                         </td>
                     </tr>
                     <tr>
@@ -196,15 +196,15 @@ Called from:
                         </td>
                     </tr>
                     <tr>
-                        <td id="last-updated" class="td-metadata-value margin-l-24">                    
+                        <td id="last-updated" class="td-metadata-value margin-l-24">
                             <span><i class="fa-light fa-calendar-days fa-sm"></i></span>&nbsp;
-                            {{/* If learning path, obtain last modified date from any LP file; install guide just display from this file. */}} 
+                            {{/* If learning path, obtain last modified date from any LP file; install guide just display from this file. */}}
                             {{ if $is_learning_path}}
                                 {{- $true_last_mod_date := partial "server-side-processing/calculate-last-update.html" . }}
                                 {{$true_last_mod_date.Format "02 Jan 2006"}}
                             {{else}}
                                 {{ .Lastmod.UTC.Format "2 Jan 2006" }}
-                            {{end}} 
+                            {{end}}
                         </td>
                     </tr>
                 {{ if .Params.test_maintenance}}
@@ -219,7 +219,7 @@ Called from:
                         </td>
                     </tr>
                 {{end}}
-                </table>   
+                </table>
             </div>
         </div>
         <!-- Second column table-->
@@ -258,7 +258,7 @@ Called from:
                                 </span>
                                 <br>
                             {{- end -}}
-                        </td>                        
+                        </td>
                     </tr>
                     <!-- Arm IP if learning path. Official Docs if tool -->
                     {{if $is_learning_path}}
@@ -267,7 +267,7 @@ Called from:
                                 Arm IP:
                             </td>
                             <td class="td-metadata-value">
-                                {{- range .Params.armips -}}<a href="https://developer.arm.com/Processors#q={{.}}" target="_blank" style="margin-right: 16px;">{{.}}{{ partial "general-formatting/external-link.html"}}</a>{{- end -}}    
+                                {{- range .Params.armips -}}<a href="https://developer.arm.com/Processors#q={{.}}" target="_blank" style="margin-right: 16px;">{{.}}{{ partial "general-formatting/external-link.html"}}</a>{{- end -}}
                             </td>
                         </tr>
                     {{else}}
@@ -298,7 +298,7 @@ Called from:
                                         <span class="u-flex u-flex-row u-align-items-center u-gap-1/2">
                                         <span class="fa-solid fa-tag"></span>
                                         {{ .Params.subjects }}
-                                    </ads-tag> 
+                                    </ads-tag>
                                 {{end}}
                                 {{ if .Params.cloud_service_providers }}
                                     <ads-tag    href='{{ "/" | relLangURL}}tag/{{.Params.cloud_service_providers | urlize}}' style="margin-bottom: 4px;">
@@ -321,7 +321,7 @@ Called from:
                                         {{ . }}
                                     </ads-tag>
                                 {{ end }}
-                            </span>  
+                            </span>
                         </td>
                     </tr>
                     <!-- tool tags, if present in learning paths -->
@@ -336,14 +336,14 @@ Called from:
                                     <span class="u-flex u-flex-row u-align-items-center u-gap-1/2">
                                     <span class="fa-solid fa-tag"></span>
                                     {{$active_tag}}
-                                </ads-tag></span>                             
+                                </ads-tag></span>
                             </td>
                         </tr>
                         {{end}}
                     {{end}}
-                </table>   
+                </table>
             </div>
-            <!-- Table mobile-sized windows only -->   
+            <!-- Table mobile-sized windows only -->
             <div class="md:u-hide u-display-block">
                 <table>
                     <tr>
@@ -393,7 +393,7 @@ Called from:
                             <td class="td-metadata-value margin-l-24">
                                 {{- range .Params.armips -}}
                                     <a href="https://developer.arm.com/Processors#q={{.}}" target="_blank" style="margin-right: 16px;">{{.}}{{ partial "general-formatting/external-link.html"}}</a>
-                                {{- end -}}    
+                                {{- end -}}
                             </td>
                         </tr>
                     {{else}}
@@ -450,7 +450,7 @@ Called from:
                                         {{ . }}
                                     </ads-tag>
                                 {{ end }}
-                                </span>  
+                                </span>
                             </td>
                         </tr>
                     <!-- Tool tag, if present in learning paths -->
@@ -467,18 +467,18 @@ Called from:
                                     <span class="u-flex u-flex-row u-align-items-center u-gap-1/2">
                                     <span class="fa-solid fa-tag"></span>
                                     {{$active_tag}}
-                                </ads-tag></span>                             
+                                </ads-tag></span>
                             </td>
                         </tr>
                         {{end}}
                     {{end}}
 
-                </table>   
+                </table>
 
-            </div>                
+            </div>
         </div>
         {{if not $is_learning_path}}
             <p style="margin-top: 24px;">This guide is intended to get you up and running with this tool quickly with the most common settings. For a thorough review of all options, refer to the official documentation.</p>
         {{end}}
-    </div>            
+    </div>
 </div>

--- a/themes/arm-design-system-hugo-theme/layouts/partials/general-formatting/path-ads-card.html
+++ b/themes/arm-design-system-hugo-theme/layouts/partials/general-formatting/path-ads-card.html
@@ -32,9 +32,9 @@ Called from:
             &nbsp; {{.calculated_date.Format "02 Jan 2006"}}
 
             &nbsp;&nbsp;&nbsp;&nbsp;
-            
+
             <span><i class="fa-light fa-clock"></i></span>
-            &nbsp;<span class="time-to-complete-string" name="{{.learning_path.Params.minutes_to_complete}}">{{partial "partials/server-side-processing/time-beautifier.html" .learning_path.Params.minutes_to_complete}}</span>
+            &nbsp;<span class="time-to-complete-string" name="{{.learning_path.Params.minutes_to_complete}}">{{partial "server-side-processing/time-beautifier.html" .learning_path.Params.minutes_to_complete}}</span>
         </p>
-    </ads-card-content>   
+    </ads-card-content>
 </ads-card>


### PR DESCRIPTION
- The following warning started showing after updating hugo: 
```WARN  Partial name "partials/server-side-processing/time-beautifier.html" starting with 'partials/' (as in {{ partial "partials/server-side-processing/time-beautifier.html"}}) is most likely not what you want. Before 0.146.0 we did a double lookup in this situation.```
- With v0.146.1 it seems we assume the partials directory, removing the need to explicitly call it out in the path


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
