### PR TITLE
fix(kleidiai-llm-chatbot): add command to install specific httpx vers…

### DIFF
--- a/content/learning-paths/servers-and-cloud-computing/pytorch-llama/pytorch-llama-frontend.md
+++ b/content/learning-paths/servers-and-cloud-computing/pytorch-llama/pytorch-llama-frontend.md
@@ -22,6 +22,11 @@ Install the additional packages:
 pip3 install openai==1.45.0
 ```
 
+Roll back httpx to a version before 0.28 to prevent a "proxies" error with Streamlit
+```sh
+pip3 install httpx==0.27.2
+```
+
 ### Running LLM Inference Backend Server
 Start the LLM Inference Backend Server in a new terminal window:
 


### PR DESCRIPTION
I added a command to roll the httpx version to 0.27.2.

I noticed there is an issue when planning a workshop that is based on the following Learning Path: https://learn.arm.com/learning-paths/servers-and-cloud-computing/pytorch-llama/. If the httpx isn't rolled back to an version prior to 0.28 the Streamlit frontend will throw a "proxies" error when you try to send a message to the chatbot.

I know this is probably a band-aid fix, but because I will be sending people to try this Learning Path after they complete the workshop I wanted them to be able to successfully complete all the steps.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com//learning-paths/cross-platform/_example-learning-path/)
- [x ] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [x ] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
