### PR TITLE
Update to ALP "Build and run an Android chat app"

### DIFF
--- a/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/1-dev-env-setup.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/1-dev-env-setup.md
@@ -13,10 +13,10 @@ In this learning path, you will learn how to build and deploy a simple LLM-based
 Your first task is to prepare a development environment with the required software:
 
 - Android Studio (latest version recommended)
-- Android NDK (tested with version 27.0.12077973)
-- Python 3.11
-- CMake (tested with version 3.28.1)
-- Ninja (tested with version 1.11.1)
+- Android NDK (tested with version 27.3.13750724)
+- Python 3.13
+- CMake (tested with version 4.1.0)
+- Ninja (tested with version 1.12.1)
 
 The following instructions were tested on an x86 Windows machine with at least 16GB of RAM.
 
@@ -34,9 +34,9 @@ Follow these steps to install and configure Android Studio:
 
 5. Click **OK** and **Apply**.
 
-## Install Python 3.11
+## Install Python 3.15
 
-Download and install [Python version 3.11](https://www.python.org/downloads/release/python-3110/)
+Download and install [Python version 3.13](https://www.python.org/downloads/release/python-3135/)
 
 ## Install CMake
 
@@ -45,7 +45,7 @@ CMake is an open-source tool that automates the build process for software proje
 [Download and install CMake](https://cmake.org/download/)
 
 {{% notice Note %}}
-The instructions were tested with version 3.28.1
+The instructions were tested with version 4.1.0
 {{% /notice %}}
 
 ## Install Ninja
@@ -55,7 +55,7 @@ Ninja is a minimalistic build system designed to efficiently handle incremental 
 [Download and install Ninja]( https://github.com/ninja-build/ninja/releases)
 
 {{% notice Note %}}
-The instructions were tested with version 1.11.1
+The instructions were tested with version 1.12.1
 {{% /notice %}}
 
 You now have the required development tools installed to follow this learning path.

--- a/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/2-build-onnxruntime.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/2-build-onnxruntime.md
@@ -21,26 +21,26 @@ Open up a Windows PowerShell and checkout the source tree:
 cd C:\Users\$env:USERNAME
 git clone --recursive https://github.com/Microsoft/onnxruntime.git
 cd onnxruntime
-git checkout 9b37b3ea4467b3aab9110e0d259d0cf27478697d
+git checkout 5630b081cd25e4eccc7516a652ff956e51676794
 ```
 
 {{% notice Note %}}
-You might be able to use a later commit. These steps have been tested with the commit `9b37b3ea4467b3aab9110e0d259d0cf27478697d`.
+You might be able to use a later commit. These steps have been tested with the commit `5630b081cd25e4eccc7516a652ff956e51676794`. This corresponds to ORT 1.22.2
 {{% /notice %}}
 
 ### Build for Android CPU
 
-You use the Ninja generator to build on Windows for Android. First, set JAVA_HOME to the path to your JDK install. You can point to the JDK from Android Studio, or a standalone JDK install.
+You use the Ninja generator to build on Windows for Android. First, set JAVA_HOME to the path to your JDK install. ONNX Runtime compiles well with JDK 17. If you face issuses with compilation it would be a good time to check the JDK version.
 
 ```bash
-$env:JAVA_HOME="C:\Program Files\Android\Android Studio\jbr"
+$env:JAVA_HOME="C:\Program Files\Microsoft\jdk-17.0.16.8-hotspot\"
 ```
 
 Now run the following command:
 
 ```bash
 
-./build.bat --config Release --build_shared_lib --android --android_sdk_path C:\Users\$env:USERNAME\AppData\Local\Android\Sdk --android_ndk_path C:\Users\$env:USERNAME\AppData\Local\Android\Sdk\ndk\27.0.12077973 --android_abi arm64-v8a --android_api 27 --cmake_generator Ninja --build_java
+./build.bat --config Release --build_shared_lib --android --android_sdk_path C:\Users\$env:USERNAME\AppData\Local\Android\Sdk --android_ndk_path C:\Users\$env:USERNAME\AppData\Local\Android\Sdk\ndk\27.3.13750724 --android_abi arm64-v8a --android_api 27 --cmake_generator Ninja --build_java
 
 ```
 
@@ -49,7 +49,7 @@ An Android Archive (AAR) file, which can be imported directly in Android Studio,
 When the build is complete, confirm the shared library and the AAR file have been created:
 
 ```
-ls build\Windows\Release\onnxruntime.so
+ls build\Windows\Release\libonnxruntime.so
 ls build\Windows\Release\java\build\android\outputs\aar\onnxruntime-release.aar
 ```
 

--- a/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/2-build-onnxruntime.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/2-build-onnxruntime.md
@@ -30,7 +30,7 @@ You might be able to use a later commit. These steps have been tested with the c
 
 ### Build for Android CPU
 
-You use the Ninja generator to build on Windows for Android. First, set JAVA_HOME to the path to your JDK install. ONNX Runtime compiles well with JDK 17. If you face issuses with compilation it would be a good time to check the JDK version.
+You use the Ninja generator to build on Windows for Android. First, set JAVA_HOME to the path to your JDK install. ONNX Runtime compiles well with JDK 17. If you face issuses with compilation please check your JDK version.
 
 ```bash
 $env:JAVA_HOME="C:\Program Files\Microsoft\jdk-17.0.16.8-hotspot\"

--- a/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/3-build-onnxruntime-generate-api.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/3-build-onnxruntime-generate-api.md
@@ -24,11 +24,11 @@ Within your Windows PowerShell prompt, checkout the source repo:
 C:\Users\$env:USERNAME
 git clone https://github.com/microsoft/onnxruntime-genai
 cd onnxruntime-genai
-git checkout 1e4d289502a61265c3b07efb17d8796225bb0b7f
+git checkout 5ba9fce5b52452a82b12ac343d941765c430d996
 ```
 
 {{% notice Note %}}
-You might be able to use later commits. These steps have been tested with the commit `1e4d289502a61265c3b07efb17d8796225bb0b7f`.
+You might be able to use later commits. These steps have been tested with the commit `5ba9fce5b52452a82b12ac343d941765c430d996`. This corresponds to ORT Gen API 0.9.0
 {{% /notice %}}
 
 ### Build for Android CPU
@@ -37,11 +37,12 @@ Ninja generator is used to build on Windows for Android. Make sure you have set 
 
 ```bash
 python -m pip install requests 
-python3.11 build.py --build_java --android --android_home C:\Users\$env:USERNAME\AppData\Local\Android\Sdk --android_ndk_path C:\Users\$env:USERNAME\AppData\Local\Android\Sdk\ndk\27.0.12077973 --android_abi arm64-v8a --config Release
+python3.13 build.py --skip_wheel --build_java --android --android_home C:\Users\$env:USERNAME\AppData\Local\Android\Sdk --android_ndk_path C:\Users\$env:USERNAME\AppData\Local\Android\Sdk\ndk\27.3.13750724 --android_abi arm64-v8a --config Release
 ```
 
 When the build is complete, confirm the shared library has been created:
 
 ```output
-ls build\Android\Release\onnxruntime-genai.so
+ls build\Android\Release\libonnxruntime-genai.so
+ls build\Android\Release\src\java\build\android\outputs\aar\onnxruntime-genai-release.aar
 ```

--- a/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/4-run-benchmark-on-android.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/4-run-benchmark-on-android.md
@@ -19,17 +19,16 @@ cd onnxruntime-genai
 copy src\ort_genai.h examples\c\include\
 copy src\ort_genai_c.h examples\c\include\
 cd examples\c
-mkdir build
-cd build
 ```
 Run the `cmake` command as shown:
 
 ```bash
-cmake -DCMAKE_TOOLCHAIN_FILE=C:\Users\$env:USERNAME\AppData\Local\Android\Sdk\ndk\27.0.12077973\build\cmake\android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-27 -DCMAKE_BUILD_TYPE=Release -G "Ninja" ..
-ninja
+cmake -G "Ninja" -S . -B build -DMODEL_QA=ON -DCMAKE_TOOLCHAIN_FILE=C:\Users\$env:USERNAME\AppData\Local\Android\Sdk\ndk\27.3.13750724\build\cmake\android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-27 -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-L../lib"
+cmake --build build --parallel --config Release 
+cd build
 ```
 
-After successful build, a binary program called `phi3` will be created.
+After successful build, a binary program called `model_qa` will be created.
 
 ### Prepare Phi-3-mini model
 
@@ -63,7 +62,7 @@ You should see your device listed to confirm it is connected.
 
 ``` bash
 adb push cpu-int4-rtn-block-32-acc-level-4 /data/local/tmp
-adb push .\phi3 /data/local/tmp
+adb push .\model_qa /data/local/tmp
 adb push onnxruntime-genai\build\Android\Release\libonnxruntime-genai.so /data/local/tmp
 adb push onnxruntime\build\Windows\Release\libonnxruntime.so /data/local/tmp
 ```
@@ -75,9 +74,9 @@ Use the runner to execute the model on the phone with the `adb` command:
 ``` bash
 adb shell
 cd /data/local/tmp
-chmod 777 phi3
+chmod 777 model_qa
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/data/local/tmp
-./phi3 cpu-int4-rtn-block-32-acc-level-4
+./model_qa cpu-int4-rtn-block-32-acc-level-4
 ```
 
 This will allow the runner program to load the model. It will then prompt you to input the text prompt to the model. After you enter your input prompt, the text output by the model will be displayed. On completion, performance metrics similar to those shown below should be displayed:

--- a/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/5-build-android-chat-app.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/5-build-android-chat-app.md
@@ -16,11 +16,11 @@ You can use the Android demo application included in the [onnxruntime-inference-
 ``` bash
 git clone https://github.com/microsoft/onnxruntime-inference-examples
 cd onnxruntime-inference-examples
-git checkout 009920df0136d7dfa53944d06af01002fb63e2f5
+git checkout 7a635daae48450ff142e5c0848a564b245f04112
 ```
 
 {{% notice Note %}}
-You could probably use a later commit but these steps have been tested with the commit `009920df0136d7dfa53944d06af01002fb63e2f5`.
+You could probably use a later commit but these steps have been tested with the commit `7a635daae48450ff142e5c0848a564b245f04112`.
 {{% /notice %}}
 
 ### Build the app using Android Studio
@@ -29,10 +29,11 @@ Open the `mobile\examples\phi-3\android` directory with Android Studio.
 
 #### (Optional) In case you want to use the ONNX Runtime AAR you built
 
-Copy ONNX Runtime AAR you built earlier in this learning path:
+Copy ONNX Runtime AAR and ONNX Runtime GenAI AAR you built earlier in this learning path:
 
 ```bash
-Copy onnxruntime\build\Windows\Release\java\build\android\outputs\aar\onnxruntime-release.aar mobile\examples\phi-3\android\app\libs
+Copy onnxruntime\build\Windows\Release\java\build\android\outputs\aar\onnxruntime-release.aar onnxruntime-inference-examples\mobile\examples\phi-3\android\app\libs\
+Copy onnxruntime-genai\build\Android\Release\src\java\build\android\outputs\aar\onnxruntime-genai-release.aar onnxruntime-inference-examples\mobile\examples\phi-3\android\app\libs\
 ```
 
 Update `build.gradle.kts (:app)` as below:
@@ -41,6 +42,8 @@ Update `build.gradle.kts (:app)` as below:
 // ONNX Runtime with GenAI
 //implementation("com.microsoft.onnxruntime:onnxruntime-android:latest.release")
 implementation(files("libs/onnxruntime-release.aar"))
+//implementation(files("libs/onnxruntime-genai-android-0.8.1.aar"))
+implementation(files("libs/onnxruntime-genai-release.aar"))
 ```
 
 Finally, click **File > Sync Project with Gradle**


### PR DESCRIPTION
	1. Support for ONNX Runtime 1.22.1
	2. Support for ONNX Runtime GenAI 0.9.0
	3. Updated dependencies a. Python 3.11 -> 3.13 b. Cmake 3.28.1 -> 4.1.0 c. Ninja 1.11.1 -> 1.12.1 d. Android NDK 27.0.12077973 -> 27.3.13750724
	4. Updated typos with libraries built
	5. Added missing steps when building test


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
