### PR TITLE
Add a line numbering start attribute.

### DIFF
--- a/content/learning-paths/cross-platform/_example-learning-path/appendix-1-formatting.md
+++ b/content/learning-paths/cross-platform/_example-learning-path/appendix-1-formatting.md
@@ -83,12 +83,26 @@ Specify that line_numbers are true in the following way:
 \`\`\`bash { line_numbers = "true" } \
 echo 'hello world' \
 echo ‘I am line two’ \
-\`\`\` 
+\`\`\`
 
-```bash { line_numbers = "true" } 
-echo ‘hello world’ 
-echo ‘I am line two’ 
-``` 
+```bash { line_numbers = "true" }
+echo ‘hello world’
+echo ‘I am line two’
+```
+
+In some cases, the line numbering should not start from one but from another
+value, e.g. if the code excerpt is extracted from a larger file. Use the
+`line_start` attribute to achieve this:
+
+\`\`\`bash { line_numbers = "true" line_start = "10" } \
+echo 'hello world' \
+echo ‘I am line two’ \
+\`\`\`
+
+```bash { line_numbers = "true" line_start = "10" }
+echo ‘hello world’
+echo ‘I am line eleven’
+```
 
 ### Output Lines
 

--- a/themes/arm-design-system-hugo-theme/layouts/_default/_markup/render-codeblock.html
+++ b/themes/arm-design-system-hugo-theme/layouts/_default/_markup/render-codeblock.html
@@ -6,5 +6,5 @@ consistent with tabpane shortcode.
 ```
 */}}
 {{partial "general-formatting/prismjs-codeblock.html" (dict "input_from" "normal" "code" .Inner "language" .Type
-"line_numbers" .Attributes.line_numbers "output_lines" .Attributes.output_lines "command_line" .Attributes.command_line)
+"line_numbers" .Attributes.line_numbers "output_lines" .Attributes.output_lines "command_line" .Attributes.command_line "line_start" .Attributes.line_start)
 }}

--- a/themes/arm-design-system-hugo-theme/layouts/partials/general-formatting/prismjs-codeblock.html
+++ b/themes/arm-design-system-hugo-theme/layouts/partials/general-formatting/prismjs-codeblock.html
@@ -14,6 +14,7 @@ Called from:
         code                Str:  echo('Hello world')....
         language            Str:  python
         line_numbers        Bool: true or false
+        line_start          Str:  123
         output_lines        Str:  5 or 1-4, 9
         command_line        Str:  "root@localhost"
 */}}
@@ -42,14 +43,24 @@ Called from:
     {{$output_present = true}}
 {{end}}
 
-
 <!-- Start with the 'pre' element, then 'code' element, then the code content -->
 <pre
-    {{if .command_line}}
-        class="command-line"
-        data-user= {{ trim (index (split (index (split .command_line "|") 0) "@") 0 ) " "}}
-        data-host= {{ trim (index (split (index (split .command_line "|") 0) "@") 1 ) " "}}
-        data-output={{ trim (index (split .command_line "|") 1) " "}}
+    {{if or (.command_line) (.line_start)}}
+      {{if and (.command_line) (.line_start)}}
+          class="command-line line-numbers"
+      {{else if .command_line}}
+          class="command-line"
+      {{else if .line_start}}
+          class="line-numbers"
+      {{end}}
+      {{if .command_line}}
+          data-user= {{ trim (index (split (index (split .command_line "|") 0) "@") 0 ) " "}}
+          data-host= {{ trim (index (split (index (split .command_line "|") 0) "@") 1 ) " "}}
+          data-output={{ trim (index (split .command_line "|") 1) " "}}
+      {{end}}
+      {{if .line_start}}
+          data-start="{{.line_start}}"
+      {{end}}
     {{end}}
 >
     <code class='language-{{.language}}

--- a/themes/arm-design-system-hugo-theme/layouts/shortcodes/tab.html
+++ b/themes/arm-design-system-hugo-theme/layouts/shortcodes/tab.html
@@ -27,6 +27,7 @@ Only used by 'tabpane' shortcode to process code in tabs.
 {{ else }}
 {{ with $.Get "language" }}        {{ $tab = merge $tab (dict "language" ($.Get "language")) }}               {{ end }}
 {{ with $.Get "line_numbers" }}    {{ $tab = merge $tab (dict "line_numbers" ($.Get "line_numbers")) }}       {{ end }}
+{{ with $.Get "line_start" }}      {{ $tab = merge $tab (dict "line_start" ($.Get "line_start")) }}           {{ end }}
 {{ with $.Get "output_lines" }}    {{ $tab = merge $tab (dict "output_lines" ($.Get "output_lines")) }}       {{ end }}
 {{ with $.Get "command_line" }}    {{ $tab = merge $tab (dict "command_line" ($.Get "command_line")) }}       {{ end }}
 {{ with $.Inner }}

--- a/themes/arm-design-system-hugo-theme/layouts/shortcodes/tabpane.html
+++ b/themes/arm-design-system-hugo-theme/layouts/shortcodes/tabpane.html
@@ -23,6 +23,7 @@ Create code panes via horizontal tabs. Uses the 'prismjs-codeblock.html' partial
                                                                     "code" $element.content
                                                                     "language" $element.language
                                                                     "line_numbers" $element.line_numbers 
+                                                                    "line_start" $element.line_start
                                                                     "output_lines" $element.output_lines
                                                                     "command_line" $element.command_line) }}
         {{- end -}}


### PR DESCRIPTION
When line numbering is enabled, this enables to start the line numbering from a specific value. This feature is useful when refering to large files for which a learning path would comment some excerpts. We want the line numbering to match the one from the file.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [X] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [X] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
