### PR TITLE
Update hugo baseURL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 title = 'Arm Learning Paths'
 
-baseURL = '/'
+baseURL = 'https://localhost:1313/'
 languageCode = 'en-us'
 theme = "arm-design-system-hugo-theme"
 


### PR DESCRIPTION
Have the `hugo_server.sh` link be clickable by configuring the baseURL as advised in: https://github.com/gohugoio/hugo/issues/10765 