### PR TITLE
Changing the C++ tag to CPP for URL correctness.

### DIFF
--- a/content/learning-paths/cross-platform/cpp-loop-size-context/_index.md
+++ b/content/learning-paths/cross-platform/cpp-loop-size-context/_index.md
@@ -23,7 +23,7 @@ armips:
     - Neoverse
     - Cortex-A
 tools_software_languages:
-    - C++
+    - CPP
     - Runbook
 operatingsystems:
     - Linux

--- a/content/learning-paths/cross-platform/ernie_moe_v9/_index.md
+++ b/content/learning-paths/cross-platform/ernie_moe_v9/_index.md
@@ -28,7 +28,7 @@ operatingsystems:
     - Linux
 tools_software_languages:
     - Python
-    - C++
+    - CPP
     - Bash
     - llama.cpp
 

--- a/content/learning-paths/cross-platform/floating-point-behavior/_index.md
+++ b/content/learning-paths/cross-platform/floating-point-behavior/_index.md
@@ -25,7 +25,7 @@ armips:
     - Cortex-A
     - Neoverse
 tools_software_languages:
-    - C++
+    - CPP
 operatingsystems:
     - Linux
 shared_path: true

--- a/content/learning-paths/cross-platform/function-multiversioning/_index.md
+++ b/content/learning-paths/cross-platform/function-multiversioning/_index.md
@@ -29,7 +29,7 @@ armips:
     - Neoverse
 tools_software_languages:
     - C
-    - C++
+    - CPP
     - Runbook
 operatingsystems:
     - Linux

--- a/content/learning-paths/cross-platform/kleidiai-explainer/_index.md
+++ b/content/learning-paths/cross-platform/kleidiai-explainer/_index.md
@@ -22,7 +22,7 @@ armips:
     - Cortex-A
     - Neoverse
 tools_software_languages:
-    - C++
+    - CPP
     - Generative AI
     - NEON
     - Runbook

--- a/content/learning-paths/cross-platform/matrix/_index.md
+++ b/content/learning-paths/cross-platform/matrix/_index.md
@@ -28,7 +28,7 @@ armips:
     - Neoverse
     - Cortex-A
 tools_software_languages:
-    - C++
+    - CPP
     - GCC
     - Clang
     - CMake

--- a/content/learning-paths/cross-platform/simd-loops/_index.md
+++ b/content/learning-paths/cross-platform/simd-loops/_index.md
@@ -31,7 +31,7 @@ operatingsystems:
     - macOS
 tools_software_languages:
   - C
-  - C++
+  - CPP
   - GCC
   - Clang
 

--- a/content/learning-paths/laptops-and-desktops/win-opencv/_index.md
+++ b/content/learning-paths/laptops-and-desktops/win-opencv/_index.md
@@ -23,7 +23,7 @@ tools_software_languages:
     - Visual Studio
     - Clang
     - OpenCV
-    - C++
+    - CPP
 operatingsystems:
     - Windows
 

--- a/content/learning-paths/laptops-and-desktops/win_arm64ec_porting/_index.md
+++ b/content/learning-paths/laptops-and-desktops/win_arm64ec_porting/_index.md
@@ -26,7 +26,7 @@ operatingsystems:
     - Windows
 tools_software_languages:
     - C
-    - C++
+    - CPP
     - Qt    
 
 further_reading:

--- a/content/learning-paths/laptops-and-desktops/win_arm_qt/_index.md
+++ b/content/learning-paths/laptops-and-desktops/win_arm_qt/_index.md
@@ -24,7 +24,7 @@ operatingsystems:
     - Windows
 tools_software_languages:
     - C
-    - C++
+    - CPP
     - Qt    
 
 further_reading:

--- a/content/learning-paths/laptops-and-desktops/win_cef/_index.md
+++ b/content/learning-paths/laptops-and-desktops/win_cef/_index.md
@@ -23,7 +23,7 @@ armips:
 operatingsystems:
     - Windows
 tools_software_languages:
-    - C++
+    - CPP
     - CMake 
     - HTML
     - JavaScript

--- a/content/learning-paths/laptops-and-desktops/win_on_arm_build_onnxruntime/_index.md
+++ b/content/learning-paths/laptops-and-desktops/win_on_arm_build_onnxruntime/_index.md
@@ -20,7 +20,7 @@ armips:
     - Cortex-A
 tools_software_languages:
     - Visual Studio
-    - C++
+    - CPP
     - Python
     - Git
     - CMake

--- a/content/learning-paths/laptops-and-desktops/win_win32_dll_porting/_index.md
+++ b/content/learning-paths/laptops-and-desktops/win_win32_dll_porting/_index.md
@@ -25,7 +25,7 @@ operatingsystems:
     - Windows
 tools_software_languages:
     - C
-    - C++     
+    - CPP     
 
 further_reading:
     - resource:

--- a/content/learning-paths/mobile-graphics-and-gaming/ai-camera-pipelines/_index.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/ai-camera-pipelines/_index.md
@@ -24,7 +24,7 @@ subjects: Performance and Architecture
 armips:
     - Cortex-A
 tools_software_languages:
-    - C++
+    - CPP
     - Docker
 operatingsystems:
     - Linux

--- a/content/learning-paths/mobile-graphics-and-gaming/android_halide/_index.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/android_halide/_index.md
@@ -28,7 +28,7 @@ operatingsystems:
 tools_software_languages:
     - Android Studio
     - Halide
-    - C++
+    - CPP
     - Kotlin
     - Android Studio
     - CMake

--- a/content/learning-paths/mobile-graphics-and-gaming/android_webgpu_dawn/_index.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/android_webgpu_dawn/_index.md
@@ -36,7 +36,7 @@ armips:
 tools_software_languages:
     - Java
     - Kotlin
-    - C++
+    - CPP
     - Python
 operatingsystems:
     - macOS

--- a/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/_index.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/build-android-chat-app-using-onnxruntime/_index.md
@@ -22,7 +22,7 @@ armips:
     - Cortex-A
 tools_software_languages:
     - Kotlin
-    - C++
+    - CPP
     - ONNX Runtime
     - Android
     - Hugging Face

--- a/content/learning-paths/mobile-graphics-and-gaming/build-llama3-chat-android-app-using-executorch-and-xnnpack/_index.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/build-llama3-chat-android-app-using-executorch-and-xnnpack/_index.md
@@ -32,7 +32,7 @@ armips:
     - Cortex-A
 tools_software_languages:
     - Java
-    - C++
+    - CPP
     - Python
     - Hugging Face
     - ExecuTorch

--- a/content/learning-paths/mobile-graphics-and-gaming/optimizing-vertex-efficiency/_index.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/optimizing-vertex-efficiency/_index.md
@@ -25,7 +25,7 @@ armips:
     - Mali
 tools_software_languages:
     - C
-    - C++
+    - CPP
 operatingsystems:
     - Android
 

--- a/content/learning-paths/mobile-graphics-and-gaming/run-stable-audio-open-small-with-lite-rt/_index.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/run-stable-audio-open-small-with-lite-rt/_index.md
@@ -32,7 +32,7 @@ armips:
     - Cortex-X
 
 tools_software_languages:
-    - C++
+    - CPP
     - Python
     - Hugging Face
 

--- a/content/learning-paths/mobile-graphics-and-gaming/voice-assistant/_index.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/voice-assistant/_index.md
@@ -26,7 +26,7 @@ armips:
 tools_software_languages:
     - Java
     - Kotlin
-    - C++
+    - CPP
 operatingsystems:
     - Android
     - Linux

--- a/content/learning-paths/servers-and-cloud-computing/arm-cpp-memory-model/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/arm-cpp-memory-model/_index.md
@@ -22,7 +22,7 @@ subjects: Performance and Architecture
 armips:
     - Neoverse
 tools_software_languages:
-    - C++
+    - CPP
     - TSan
     - Runbook
 operatingsystems:

--- a/content/learning-paths/servers-and-cloud-computing/arm-mcp-server/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/arm-mcp-server/_index.md
@@ -27,7 +27,7 @@ armips:
 tools_software_languages:
     - MCP
     - Docker
-    - C++
+    - CPP
     - GitHub Copilot
 operatingsystems:
     - Linux

--- a/content/learning-paths/servers-and-cloud-computing/cplusplus_compilers_flags/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/cplusplus_compilers_flags/_index.md
@@ -21,7 +21,7 @@ subjects: Performance and Architecture
 armips:
     - Neoverse
 tools_software_languages:
-    - C++
+    - CPP
     - Runbook
 operatingsystems:
     - Linux

--- a/content/learning-paths/servers-and-cloud-computing/fexpa/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/fexpa/_index.md
@@ -46,7 +46,7 @@ operatingsystems:
     - macOS
 tools_software_languages:
     - C
-    - C++
+    - CPP
 
 ### FIXED, DO NOT MODIFY
 # ================================================================================

--- a/content/learning-paths/servers-and-cloud-computing/llama_cpp_streamline/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/llama_cpp_streamline/_index.md
@@ -30,7 +30,7 @@ armips:
     - Neoverse
 tools_software_languages:
     - Arm Streamline
-    - C++
+    - CPP
     - llama.cpp
     - Profiling
 operatingsystems:

--- a/content/learning-paths/servers-and-cloud-computing/pmuv3_plugin_learning_path/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/pmuv3_plugin_learning_path/_index.md
@@ -25,7 +25,7 @@ armips:
     - Neoverse
 tools_software_languages:
     - C
-    - C++
+    - CPP
     - Python
     - Runbook
 

--- a/content/learning-paths/servers-and-cloud-computing/processwatch/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/processwatch/_index.md
@@ -26,7 +26,7 @@ tools_software_languages:
     - libbpf
     - Capstone
     - C
-    - C++
+    - CPP
     - Runbook
 
 operatingsystems:

--- a/content/learning-paths/servers-and-cloud-computing/using-and-porting-performance-libs/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/using-and-porting-performance-libs/_index.md
@@ -22,7 +22,7 @@ armips:
     - Neoverse
 tools_software_languages:
     - Arm Compiler for Linux
-    - C++
+    - CPP
     - Runbook
 operatingsystems:
     - Linux


### PR DESCRIPTION
In some learning paths, the C++ tag throws a 404 error as the URL does not handle the "+" character correctly.
This change updates the tag to "CPP" so the URL works correctly.