### PR TITLE
MCP Content Fixes

### DIFF
--- a/content/learning-paths/servers-and-cloud-computing/arm-mcp-server/2-docker-check.md
+++ b/content/learning-paths/servers-and-cloud-computing/arm-mcp-server/2-docker-check.md
@@ -82,10 +82,10 @@ CMD ["./start.sh"]
 With the Arm MCP Server connected to your AI assistant, you can quickly verify base image compatibility using a simple natural language prompt:
 
 ```text
-Check this base image for Arm compatibility
+Check if this Dockerfile supports Arm
 ```
 
-The AI assistant will use the `check_image` or `skopeo` tool to inspect the image and return a report. For `centos:6`, you'd discover that this legacy image doesn't support `arm64` architecture.
+The AI assistant uses the `check_image` or `skopeo` tool to inspect the base image and return a compatibility report. For `centos:6`, you'd discover that this legacy image doesn't support `arm64` architecture.
 
 ## What you've accomplished and what's next
 

--- a/content/learning-paths/servers-and-cloud-computing/arm-mcp-server/3-simd-migration.md
+++ b/content/learning-paths/servers-and-cloud-computing/arm-mcp-server/3-simd-migration.md
@@ -5,8 +5,9 @@ weight: 4
 ### FIXED, DO NOT MODIFY
 layout: learningpathall
 ---
-
 ## Migrating SIMD code with AI assistance
+
+{{% notice Note %}} This section uses Visual Studio Code with GitHub Copilot Chat or Copilot Edits. If you're using a different AI assistant, skip to the next section, where you'll configure the same migration workflow using other agentic systems.{{% /notice %}}
 
 When migrating applications from x86 to Arm, you might encounter SIMD (Single Instruction, Multiple Data) code that is written using architecture-specific intrinsics. On x86 platforms, SIMD is commonly implemented with SSE, AVX, or AVX2 intrinsics, while Arm platforms use NEON and SVE intrinsics to provide similar vectorized capabilities. Updating this code manually can be time-consuming and challenging. By combining the Arm MCP Server with a well-defined prompt file, you can automate much of this work and guide an AI assistant through a structured, architecture-aware migration of your codebase.
 

--- a/content/learning-paths/servers-and-cloud-computing/arm-mcp-server/4-agentic-systems.md
+++ b/content/learning-paths/servers-and-cloud-computing/arm-mcp-server/4-agentic-systems.md
@@ -12,9 +12,7 @@ Different AI coding tools provide different mechanisms for defining persistent i
 
 This section shows how to set up Arm migration workflows in popular agentic AI systems. You'll see that the core migration logic stays consistent across platforms, but each tool has its own format for defining these instructions.
 
-{{% notice Note %}}
-The migration instructions below are the same workflow you used in the previous section. Each AI tool simply wraps those instructions in a different format.
-{{% /notice %}}
+{{% notice Note %}}The migration instructions below implement the same workflow shown in the previous section. If you skipped that section, you can start here directly. Each AI tool simply wraps the same core instructions in a different format.{{% /notice %}}
 
 ## Set up Kiro steering documents
 

--- a/content/learning-paths/servers-and-cloud-computing/arm-mcp-server/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/arm-mcp-server/_index.md
@@ -13,10 +13,9 @@ learning_objectives:
   - Configure AI agents to reuse the same migration workflow across different tools
 
 prerequisites:
-    - An AI-powered IDE such as VS Code with agentic tools like GitHub Copilot, Claude Code, Cursor, or similar
+    - An AI-powered IDE such as VS Code, Copilot in VS Code, Kiro (IDE or CLI) or Codex
     - Basic familiarity with Docker and C/C++ development
-    - Access to an Arm-based cloud instance or local Arm computer for testing
-
+    - Access to an Arm-based cloud instance or local Arm computer running Linux or macOS
 author: Joe Stech
 
 ### Tags


### PR DESCRIPTION
I’ve clarified the Docker compatibility prompt, made the VS Code + Copilot dependency explicit, and adjusted the flow so users can safely skip to alternative agentic tools without losing context.