### PR TITLE
Fix: Exclude deleted files from capital letter check

### DIFF
--- a/.github/workflows/test-lp.yml
+++ b/.github/workflows/test-lp.yml
@@ -31,7 +31,7 @@ jobs:
 
           tmpfile=$(mktemp)
 
-          git diff --name-only origin/${{ github.base_ref }}...HEAD |
+          git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD |
             grep '^content/' |
             while read -r path; do
               name=$(basename "$path")


### PR DESCRIPTION
- Added --diff-filter=d to git diff command in test-lp.yml
- Prevents false positives when deleting files with capital letters or spaces
- Deleted files are now excluded from filename validation


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [ ] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [ ] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
