### PR TITLE
Meta description field fix 

### DIFF
--- a/themes/arm-design-system-hugo-theme/layouts/partials/head/head.html
+++ b/themes/arm-design-system-hugo-theme/layouts/partials/head/head.html
@@ -27,7 +27,12 @@ Where it is used:
 <title>{{ $title }}</title>
 
 {{/* Meta description */}}
-{{- $d := .Params.description | default "" | plainify | htmlEscape | strings.TrimSpace -}}
+{{- $d := .Params.description
+    | default ""
+    | plainify
+    | replaceRE `(?s)^\s+|\s+$` ""
+    | htmlEscape
+-}}
 {{- if gt (len $d) 0 -}}
 <meta name="description" content="{{ $d }}">
 {{- end -}}


### PR DESCRIPTION
Fixes an issue where <meta name="description"> tags were emitted with only whitespace due to incomplete whitespace trimming in the head template.

The template now fully normalizes and trims the description front matter value and only emits the meta tag when a non-empty value remains.

Testing: Verified locally by rebuilding with Hugo and inspecting generated HTML. Pages with a description field now emit a correct meta description, and no whitespace-only tags are generated.
