### PR TITLE
Remove broken image sitemap reference from robots.txt

### DIFF
--- a/themes/arm-design-system-hugo-theme/layouts/robots.txt
+++ b/themes/arm-design-system-hugo-theme/layouts/robots.txt
@@ -23,6 +23,5 @@ Allow: /
 User-agent: CCBot
 Allow: /
 
-# Sitemaps help AI discovery
+# Sitemap for page discovery
 Sitemap: https://learn.arm.com/sitemap.xml
-Sitemap: https://learn.arm.com/learn-image-sitemap.xml


### PR DESCRIPTION
This PR cleans up the robots.txt configuration for Learn by removing the reference to learn-image-sitemap.xml.

