### PR TITLE
Fix canonical URL generation to prevent malformed double-host URLs

### DIFF
--- a/themes/arm-design-system-hugo-theme/layouts/partials/head/head.html
+++ b/themes/arm-design-system-hugo-theme/layouts/partials/head/head.html
@@ -23,7 +23,7 @@ Where it is used:
     <!-- verify site ownership for Google -->
 <meta name="google-site-verification" content="BTfVb1OscFD-pN_bYZaTGmfx2_K3S1EbzvdKPepntvk" />
     <!-- add cannonical link to reinforce this page's validity for search engines, with a trailing / on the URL name-->
-<link rel="canonical" href="https://learn.arm.com{{ .Permalink }}" />
+<link rel="canonical" href="{{ .Permalink }}" />
 <title>{{ $title }}</title>
 
 {{/* Meta description: short, task-oriented summary for SERP and AI selection.


### PR DESCRIPTION
This PR fixes how canonical URLs are generated in the shared Hugo head template.

The template previously concatenated a hard-coded host with .Permalink, which can produce malformed canonical URLs in production builds (double host), causing search engines to ignore our declared canonical.

