### PR TITLE
Exclude migration content from testing

### DIFF
--- a/tools/maintenance.py
+++ b/tools/maintenance.py
@@ -150,6 +150,9 @@ def main():
                     sys.exit(0)
         elif os.path.isdir(args.instructions) and "/learning-paths/" in os.path.abspath(args.instructions):
             results_dict = check_lp(args.instructions, args.link, args.debug)
+        elif "/migration" in os.path.abspath(args.instructions):
+                logging.info("Migration paths are not supported for maintenance tests yet.")
+                exit(0)
         else:
             logging.error("-i/--instructions expects a .md file, a CSV with a list of files or a Learning Path directory")
         if results_dict is not None:


### PR DESCRIPTION
Small fix to prevent a failed job when the migration page is updated