### PR TITLE
Patch 1

### DIFF
--- a/content/learning-paths/cross-platform/sme-executorch-profiling/02-setup-and-pipeline.md
+++ b/content/learning-paths/cross-platform/sme-executorch-profiling/02-setup-and-pipeline.md
@@ -193,7 +193,7 @@ Each experiment is defined in a JSON configuration file. These configs specify:
   * Logging level: Timing-only mode vs full ETDump trace mode (trace mode impacts timing, use for kernel-level insights)
   * Analysis comparisons: Which experiment pairs to compare (for example, SME2-on vs SME2-off)
 
-This approach enables repeatable, systematic performance analysis across multiple configurations without modifying pipeline code. Example templates can be found in the [`model_profiling/config`] directory after the setup workspace has completed. 
+This approach enables repeatable, systematic performance analysis across multiple configurations without modifying pipeline code. Example templates can be found in the `model_profiling/config` directory after the setup workspace has completed. 
 
 ### Pipeline scripts
 


### PR DESCRIPTION
## Suggested Changes
I have added a line earlier in the path to clearly highlight where the config examples can be found.

Setting up the config.json is a key step in the workflow, but the config examples are currently referenced quite late in the learning path under “Configure profiling experiments with JSON”, which itself sits within “Export PyTorch Models and analyse performance.” This is a fairly dense section, and although there is a reference under “Organize your profiling workspace,” it’s easy to miss.

More broadly, the learning path would benefit from being simplified and structured more clearly for developers new to this space. It could be organized around the major pipeline components:

1. Execute the model under defined configurations
2. Collect timing data and ETDump traces
3. Analyse traces into operator-level and category-level summaries

At present, information is introduced at different points without clearly guiding developers through the end-to-end pipeline.

My recent change is small and minimally disruptive, but I believe restructuring the content around the pipeline stages above would have a much greater impact for new users.

Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
