### PR TITLE
Virtual FAE for internal.learn.arm.com

### DIFF
--- a/themes/arm-design-system-hugo-theme/static/js/authentication.js
+++ b/themes/arm-design-system-hugo-theme/static/js/authentication.js
@@ -47,19 +47,10 @@ if (!window.msalInstance) {
 const msalInstance = window.msalInstance;
 
 function ensureChatAiLoaded() {
-  const host = (window.location.hostname || "").toLowerCase();
-  const allowedHosts = new Set([
-    "localhost",
-    "127.0.0.1",
-    "internal.learn.arm.com",
-    "learn.arm.com",
-    "d3lutzu1kzwmb3.cloudfront.net"
-  ]);
-  const isAllowedHost = allowedHosts.has(host);
   const signedIn = isUserSignedIn();
   const existingWidget = document.querySelector("chat-ai");
 
-  if (!isAllowedHost || !signedIn) {
+  if (!signedIn) {
     if (existingWidget) {
       existingWidget.remove();
     }
@@ -255,5 +246,4 @@ document.addEventListener("arm-top-navigation-ready", function (e) {
   await initAuth();   // IMPORTANT: await this before user clicks anything
 
 })();
-
 


### PR DESCRIPTION
- Virtual FAE comes up only on successful sign in.
- Virtual FAE gets removed once logged out.

We need to test this functionality on internal.learn.arm.com. Once we confirm it works fine there, we can work on enabling it for learn.arm.com. 

**Important Note**: We do not want to push this to production right now. We need to revert this code before production push. We only need to test this on internal.learn.arm.com.
