### PR TITLE
Add device-connect-d2d learning path

### DIFF
--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/_index.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/_index.md
@@ -3,6 +3,10 @@ title: Device-to-Device communication with Device Connect
 
 minutes_to_complete: 25
 
+draft: true
+cascade:
+    draft: true
+
 who_is_this_for: This is an introductory topic for developers wiring up heterogeneous edge fleets, where devices need a shared way to find each other and a shared way to be controlled by agents. Device Connect provides this communication protocol between agents and devices, and standardizes how devices from different vendors advertise themselves and exchange structured messages, so both peer devices and AI agents can discover and invoke them through the same driver model. You'll use it to stand up peer-to-peer communication between two devices, with no broker or cloud service in between.
 
 learning_objectives:

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/_index.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/_index.md
@@ -1,0 +1,52 @@
+---
+title: Device-to-Device communication with Device Connect
+
+minutes_to_complete: 25
+
+who_is_this_for: This is an introductory topic for developers wiring up heterogeneous edge fleets, where devices need a shared way to find each other and a shared way to be controlled by agents. Device Connect provides this communication protocol between agents and devices, and standardizes how devices from different vendors advertise themselves and exchange structured messages, so both peer devices and AI agents can discover and invoke them through the same driver model. You'll use it to stand up peer-to-peer communication between two devices, with no broker or cloud service in between.
+
+learning_objectives:
+    - Understand Device Connect Edge SDK primitives and use them to build a device driver that exposes capabilities like discovery, RPC, events, and status to other peers on the mesh
+    - Set up a Python environment for Device Connect with no hardware required
+    - Build two cooperating drivers, a simulated sensor that exposes an RPC method and emits readings on a schedule, and a threshold monitor that subscribes to those events with `@on` and emits its own alerts in response
+    - Run both devices as independent runtimes and watch them discover and invoke each other on the same network
+    - Use the Device Connect agent tools to discover both devices on the mesh and invoke their RPCs
+
+prerequisites:
+    - Basic familiarity with Python and the command line
+
+author:
+    - Kavya Sri Chennoju
+    - Annie Tallund
+
+### Tags
+skilllevels: Introductory
+subjects: Libraries
+armips:
+    - Cortex-A
+operatingsystems:
+    - Linux
+    - macOS
+tools_software_languages:
+    - Python
+
+further_reading:
+    - resource:
+        title: Device Connect repository
+        link: https://github.com/arm/device-connect
+        type: website
+    - resource:
+        title: device-connect-edge package
+        link: https://github.com/arm/device-connect/tree/main/packages/device-connect-edge
+        type: documentation
+    - resource:
+        title: Zenoh
+        link: https://zenoh.io/
+        type: website
+
+### FIXED, DO NOT MODIFY
+# ================================================================================
+weight: 1
+layout: "learningpathall"
+learning_path_main_page: "yes"
+---

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/_next-steps.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/_next-steps.md
@@ -1,0 +1,16 @@
+---
+# ================================================================================
+#       FIXED, DO NOT MODIFY THIS FILE
+# ================================================================================
+weight: 21
+title: "Next Steps"
+layout: "learningpathall"
+---
+
+## Where to go next
+
+From here, you can extend the example in a few useful directions:
+
+- add a second custom driver that subscribes to emitted sensor events
+- move one runtime to another machine on the same LAN and repeat the discovery test
+- replace the simulated values with a real sensor-backed driver

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/background.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/background.md
@@ -1,0 +1,63 @@
+---
+title: Why device-to-device at the edge
+weight: 2
+
+# FIXED, DO NOT MODIFY
+layout: learningpathall
+---
+
+## Why device-to-device matters at the edge
+
+Arm processors sit at the heart of a remarkable range of systems, from Cortex-M microcontrollers in industrial sensors, to Cortex-A boards driving robots and appliances, to Neoverse servers in the cloud. Many edge applications need these devices to cooperate: a sensor publishes a reading, a supervisor reacts, a controller adjusts an actuator. The obvious way to wire that up is through a central broker or a cloud service, but both add latency, operational overhead, and a single point of failure you may not want in a lab, a vehicle, or a factory cell.
+
+Direct device-to-device (D2D) communication sidesteps that. Devices on the same local network discover each other, exchange typed events, and call each other's functions directly, with no broker, no registry, and no cloud round-trip. It is a good fit for:
+
+- prototyping sensor networks and local automation flows
+- small fleets (roughly 50-100 devices) on a shared network
+- lab setups, demos, and time-sensitive edge applications where a cloud hop would be wasteful
+
+## Where Device Connect fits
+
+Device Connect is Arm's open-source framework for structured edge communication. It gives every device a common language for four core capabilities:
+
+- **Discovery**: devices advertise themselves and can be found by ID, type, or capability
+- **RPC**: peers and agents invoke functions on a device and get a structured response
+- **Status**: each device publishes a live availability and health signal
+- **Events**: devices emit readings, state changes, or alerts as pub/sub messages
+
+Device Connect supports more than one deployment shape. In this Learning Path you'll use its **D2D mode**: a peer-to-peer deployment where device runtimes find each other over the local network using Zenoh-backed multicast discovery. For larger, multi-network deployments, Device Connect also offers a full infrastructure mode with a central registry, but you do not need any of it to ship a working D2D application.
+
+## D2D architecture at a glance
+
+In D2D mode, every participant is a peer. Each device runtime joins the same pub/sub transport and takes part in discovery, events, and RPC on equal footing.
+
+```
+┌──────────────────────────────────────────────┐
+│  Sensor device                               │
+│  - device_id: sensor-001                     │
+│  - @rpc  get_reading                         │
+│  - @emit reading_ready  ─┐                   │
+└──────────────────────────┼───────────────────┘
+                           │ pub/sub (Zenoh)
+                           │ discovery · RPC
+┌──────────────────────────▼───────────────────┐
+│  Threshold monitor                           │
+│  - device_id: monitor-001                    │
+│  - @on   reading_ready                       │
+│  - @emit alert_raised                        │
+│  - @rpc  get_recent_alerts                   │
+└──────────────────────────────────────────────┘
+```
+
+No central server sits between the sensor and the monitor. They advertise themselves, find each other by event name, and exchange typed payloads directly.
+
+## What you'll learn
+
+By the end of this Learning Path you will:
+
+- set up a Python project with uv, the Device Connect runtime, and the agent tools
+- write two cooperating drivers: a simulated sensor and a threshold monitor that reacts to it
+- run both as independent device runtimes on one machine
+- use the Device Connect agent tools to discover both peers and invoke their RPCs
+
+The next section covers the developer model.

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/d2d-setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/d2d-setup.md
@@ -1,0 +1,262 @@
+---
+title: Set up D2D communication between a sensor and a monitor
+weight: 4
+
+# FIXED, DO NOT MODIFY
+layout: learningpathall
+---
+
+In this section you'll build two simulated devices on the same mesh:
+
+- a **sensor** that publishes temperature and humidity readings on a schedule
+- a **threshold monitor** that subscribes to those readings and raises an alert when the temperature crosses a configurable threshold
+
+This mirrors a real edge scenario, a room supervisor watching environmental sensors for out-of-bounds conditions, and exercises every Device Connect primitive across two cooperating devices.
+
+## Install uv
+
+This walkthrough uses [uv](https://docs.astral.sh/uv/) to manage the project and its Python dependencies. uv will resolve a compatible Python interpreter, create a virtual environment, and install packages for you, so no manual `venv` or `pip` steps are needed.
+
+If you do not already have uv installed, run the official installer for your platform:
+
+```bash
+# macOS or Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+```powershell
+# Windows PowerShell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+Alternative install methods (Homebrew, pipx, and others) are listed in the [uv installation docs](https://docs.astral.sh/uv/getting-started/installation/). Verify the install with:
+
+```bash
+uv --version
+```
+
+## Create the project
+
+Create a new project and add the Device Connect packages:
+
+```bash
+mkdir ~/device-connect-d2d
+cd ~/device-connect-d2d
+uv init --python 3.11
+uv add device-connect-edge device-connect-agent-tools
+```
+
+The [`device-connect-edge`](https://pypi.org/project/device-connect-edge/) package is the device runtime SDK. It is what turns a Python class into a live peer on the messaging mesh. The [`device-connect-agent-tools`](https://pypi.org/project/device-connect-agent-tools/) package is the client side: it lets an agent or script discover devices and invoke their RPCs. In production you might consume devices from a different client, but for this walkthrough it is the fastest way to confirm that discovery and RPC are working.
+
+## Write a simulated sensor device
+
+Create a file called `sensor.py`:
+
+```python
+import argparse
+import asyncio
+import random
+
+from device_connect_edge import DeviceRuntime
+from device_connect_edge.drivers import DeviceDriver, emit, periodic, rpc
+from device_connect_edge.types import DeviceIdentity, DeviceStatus
+
+
+class SimulatedSensor(DeviceDriver):
+    device_type = "simulated_sensor"
+
+    def __init__(self):
+        super().__init__()
+        self._last = {"temperature": 24.0, "humidity": 45.0}
+
+    @property
+    def identity(self) -> DeviceIdentity:
+        return DeviceIdentity(
+            device_type="simulated_sensor",
+            manufacturer="Device Connect",
+            model="SIM-TH-100",
+            description="Simulated temperature and humidity sensor",
+        )
+
+    @property
+    def status(self) -> DeviceStatus:
+        return DeviceStatus(availability="available", location="simulator")
+
+    @rpc()
+    async def get_reading(self) -> dict:
+        return self._last
+
+    @emit()
+    async def reading_ready(self, temperature: float, humidity: float):
+        return None
+
+    @periodic(interval=5.0)
+    async def publish_reading(self):
+        self._last = {
+            "temperature": round(random.uniform(22.0, 30.0), 1),
+            "humidity": round(random.uniform(35.0, 55.0), 1),
+        }
+        print(f"publishing {self._last}")
+        await self.reading_ready(**self._last)
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device-id", required=True)
+    args = parser.parse_args()
+
+    runtime = DeviceRuntime(
+        driver=SimulatedSensor(),
+        device_id=args.device_id,
+        allow_insecure=True,
+    )
+    await runtime.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+This driver uses three of the decorators introduced in the overview:
+
+- `@rpc` exposes `get_reading` as a function that other peers or agents can call
+- `@emit` declares `reading_ready` as an event the device publishes to the mesh
+- `@periodic` runs `publish_reading` every five seconds so the sensor produces fresh data on its own
+
+The `identity` and `status` properties are what other peers see during discovery. They are how this device advertises itself as a `simulated_sensor` with a known manufacturer, model, and availability.
+
+## Write a threshold monitor device
+
+Now create a second device that consumes the sensor's data. Create a file called `monitor.py`:
+
+```python
+import argparse
+import asyncio
+from collections import deque
+
+from device_connect_edge import DeviceRuntime
+from device_connect_edge.drivers import DeviceDriver, emit, on, rpc
+from device_connect_edge.types import DeviceIdentity, DeviceStatus
+
+
+class ThresholdMonitor(DeviceDriver):
+    device_type = "threshold_monitor"
+
+    def __init__(self, threshold: float):
+        super().__init__()
+        self._threshold = threshold
+        self._recent_alerts: deque = deque(maxlen=10)
+
+    @property
+    def identity(self) -> DeviceIdentity:
+        return DeviceIdentity(
+            device_type="threshold_monitor",
+            manufacturer="Device Connect",
+            model="MON-T-100",
+            description="Temperature threshold monitor",
+        )
+
+    @property
+    def status(self) -> DeviceStatus:
+        return DeviceStatus(availability="available", location="simulator")
+
+    @on(event_name="reading_ready")
+    async def on_reading(self, device_id: str, event_name: str, payload: dict):
+        temperature = payload["temperature"]
+        print(f"received {temperature} C from {device_id}")
+        if temperature > self._threshold:
+            alert = {"device_id": device_id, "temperature": temperature}
+            self._recent_alerts.append(alert)
+            print(f"ALERT: {device_id} at {temperature} C (threshold {self._threshold})")
+            await self.alert_raised(**alert)
+
+    @emit()
+    async def alert_raised(self, device_id: str, temperature: float):
+        return None
+
+    @rpc()
+    async def get_recent_alerts(self) -> list:
+        return list(self._recent_alerts)
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device-id", required=True)
+    parser.add_argument("--threshold", type=float, default=27.0)
+    args = parser.parse_args()
+
+    runtime = DeviceRuntime(
+        driver=ThresholdMonitor(threshold=args.threshold),
+        device_id=args.device_id,
+        allow_insecure=True,
+    )
+    await runtime.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+The monitor adds one primitive you haven't seen yet:
+
+- `@on(event_name="reading_ready")` subscribes to `reading_ready` events from any device on the mesh. Whenever the sensor emits, the runtime delivers the event to `on_reading` as a method call with three arguments: the source device id, the event name, and a payload dict carrying the emitted fields. This is device-to-device communication without either side knowing the other's address. You can also narrow the subscription by `device_id=` or `device_type=`; the `device_type` filter matches when the source device id starts with `{device_type}-`.
+- `@emit alert_raised` lets the monitor publish its own events when a threshold is crossed, so another peer or agent could subscribe to alerts in turn.
+- `@rpc get_recent_alerts` exposes the monitor's recent history so an external caller can query what it has seen.
+
+## Run the sensor and the monitor
+
+Open two terminals in the project directory (`~/device-connect-d2d`). In terminal 1, start the sensor:
+
+```bash
+uv run python sensor.py --device-id sensor-001
+```
+
+In terminal 2, start the monitor with a threshold below the sensor's typical temperature range so you see alerts quickly:
+
+```bash
+uv run python monitor.py --device-id monitor-001 --threshold 27.0
+```
+
+`uv run` executes the command inside the project's managed environment, so you do not need to activate a virtual environment manually.
+
+Within a few seconds, the monitor terminal should start printing `received ... from sensor-001` lines, and an `ALERT:` line each time the simulated temperature rises above 27.0 °C. This is the sensor invoking the monitor across the mesh through its emitted event, and you did not configure any address or pairing between them.
+
+## Query the monitor from agent tools
+
+Open a third terminal in the project directory and run:
+
+```bash
+uv run python - <<'PY'
+from device_connect_agent_tools import connect, discover_devices, invoke_device
+
+connect()
+
+devices = discover_devices()
+print(f"Found {len(devices)} device(s)")
+for device in devices:
+    print(f"  {device['device_id']} ({device['device_type']})")
+
+sensor_id = next(d["device_id"] for d in devices if d["device_type"] == "simulated_sensor")
+monitor_id = next(d["device_id"] for d in devices if d["device_type"] == "threshold_monitor")
+
+print("latest reading:", invoke_device(sensor_id, "get_reading"))
+print("recent alerts:", invoke_device(monitor_id, "get_recent_alerts"))
+PY
+```
+
+The script discovers both devices, invokes `get_reading` on the sensor, and invokes `get_recent_alerts` on the monitor. The alert list should contain every breach the monitor has observed since it started.
+
+## What happened
+
+You have exercised every Device Connect primitive across two cooperating devices:
+
+- **Discovery**: the monitor found the sensor by `device_type` automatically, and `discover_devices` from agent tools found both peers
+- **RPC**: agent tools called `get_reading` on the sensor and `get_recent_alerts` on the monitor
+- **Events**: the sensor emitted `reading_ready`; the monitor reacted through `@on` and emitted its own `alert_raised`
+- **Status**: both runtimes advertised themselves as `available` through the `status` property
+
+The sensor and monitor did not know about each other before they started. They found each other on the local network and communicated purely through typed events and RPCs, with no broker, no registry, and no cloud service.
+
+## Outcome
+
+You now have a working D2D deployment where two simulated devices cooperate on the same mesh: a sensor that publishes data and a monitor that reacts to it and exposes its own state. This same driver pattern (a class, a handful of decorators, and a runtime) is how you would describe a real sensor, actuator, or monitor on the network.

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/overview.md
@@ -1,0 +1,58 @@
+---
+title: The developer model
+weight: 3
+
+# FIXED, DO NOT MODIFY
+layout: learningpathall
+---
+
+## Device Connect developer model
+
+### Device Connect Edge SDK
+
+The [`device-connect-edge`](https://pypi.org/project/device-connect-edge/) package is the Python SDK you install on every device that joins a Device Connect network. It provides the building blocks for creating a device runtime: the `DeviceDriver` base class you subclass to describe a device, the decorators used to expose its capabilities to peers and agents, and the `DeviceRuntime` that brings a driver online on the network.
+
+You describe a device by subclassing `DeviceDriver` from `device_connect_edge.drivers`, then annotating methods and properties with primitives. The runtime wires them into discovery, pub/sub, and RPC for you.
+
+In this Learning Path you'll use these primitives to write two cooperating drivers: a **sensor** runtime that publishes temperature and humidity readings on a schedule, and a **threshold monitor** runtime that reacts to those readings and raises alerts when a threshold is crossed. The subsections below walk through the identity, decorators, and runtime you'll use to build them, and the agent tools package you'll use to invoke them from a separate client.
+
+#### Identity and status
+
+Every driver declares who it is and how it is doing. These are properties, not decorators:
+
+- `identity` returns a `DeviceIdentity` (device type, manufacturer, model, description). This is what peers see during discovery.
+- `status` returns a `DeviceStatus` (availability, location, optional health fields). This is the live signal other peers use to decide if the device is reachable and usable.
+
+#### Behavior decorators
+
+- `@rpc()`: exposes a method as a remote procedure. Other peers or agents call it by device ID and method name; the return value is serialized back to the caller.
+- `@emit()`: declares that the method is an event publisher. Calling it inside the driver emits the event to any peer subscribed to it.
+- `@periodic(interval=<seconds>)`: runs the method on a fixed schedule once the runtime starts. Useful for sampling, heartbeats, or housekeeping.
+- `@on(event_name=<name>, device_type=<type>)`: subscribes the method to events emitted by other devices. The runtime delivers matching events as method calls with the source device id, event name, and a payload dict.
+
+#### Runtime
+
+`DeviceRuntime(driver=..., device_id=..., allow_insecure=...)` wraps your driver in a process that joins the pub/sub transport, advertises identity and status, and dispatches incoming RPCs and events to the decorated methods. You call `await runtime.run()` to keep it alive.
+
+### Device Connect Agent tools
+
+The [`device-connect-agent-tools`](https://pypi.org/project/device-connect-agent-tools/) package is the companion SDK for the client side of a Device Connect network: anything that wants to interact with devices on the mesh, from a short script or REPL to a full AI agent. It exposes a small set of functions that mirror the core capabilities of the protocol:
+
+- `connect()`: joins the same pub/sub transport as the devices, so the following calls can see and reach them
+- `discover_devices(device_type=..., device_id=...)`: returns a list of devices visible on the mesh, optionally filtered by type or ID
+- `invoke_device(device_id, method_name, ...)`: calls an `@rpc` method on a specific device and returns the response
+
+Any Python process that imports this package can find and drive devices without running a device runtime itself. In this Learning Path you'll use it from a third terminal to verify that the sensor and monitor runtimes are discoverable and callable.
+
+## What you'll build
+
+In this Learning Path you will build two cooperating simulated devices on the same local network:
+
+- a **sensor** driver that publishes temperature and humidity readings on a schedule using `@rpc`, `@emit`, and `@periodic`
+- a **threshold monitor** driver that uses `@on` to subscribe to the sensor's readings, emits its own `alert_raised` event when a reading crosses a threshold, and exposes the alert history through an `@rpc` method
+
+You will run both devices as independent runtimes on one machine and watch the monitor react to the sensor in real time. Finally, you will use the agent tools package to discover both devices and query their RPCs from a separate terminal.
+
+By the end, you will have a working D2D deployment where two devices find each other automatically and communicate through typed events and RPCs. This is the same pattern you would use to model a real sensor and a real supervisor on an edge network.
+
+The next section walks through the full setup and test.


### PR DESCRIPTION
## Summary
- New Learning Path at `content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/` covering zero-config device-to-device communication with Device Connect.
- Walks through the edge-side developer model (`DeviceDriver`, identity, behavior decorators, `DeviceRuntime`) and the `device-connect-agent-tools` client package.
- Builds two cooperating simulated drivers (a temperature/humidity sensor and a threshold monitor) and runs them on a local network without any broker or cloud service.

## Test plan
- [ ] `hugo server --buildDrafts` renders the new pages without YAML errors
- [ ] `/learning-paths/embedded-and-microcontrollers/device-connect-d2d/` landing page shows metadata (authors, prerequisites, tags)
- [ ] Each page in the path (background, developer model, d2d-setup, next-steps) renders and links between pages work
- [ ] Copy-paste `uv init` + `uv add` + `python sensor.py` + `python monitor.py` reproduces the walkthrough end-to-end on Python 3.11