### PR TITLE
Removing draft flag from Flatpak Learning Path

### DIFF
--- a/content/install-guides/flatpak.md
+++ b/content/install-guides/flatpak.md
@@ -5,7 +5,6 @@ official_docs: "https://docs.flatpak.org/en/latest/"
 author: "Jason Andrews"
 description: "Install Flatpak on Arm Linux, add the Flathub remote, and verify the setup by installing and running a native aarch64 application."
 weight: 1
-draft: true
 tool_install: true
 layout: installtoolsall
 multi_install: false


### PR DESCRIPTION
Realized that I missed removing 'draft:true' from the metadata

Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
