### PR TITLE
Fix Hugo v0.160+ template compatibility issues

### DIFF
--- a/themes/arm-design-system-hugo-theme/layouts/index.html
+++ b/themes/arm-design-system-hugo-theme/layouts/index.html
@@ -9,7 +9,10 @@ Website homepage.
 
 
 <!-- GitHub links calculated from GitHub repo, defined in config.toml -->
-{{ $pathFormatted := replace .File.Path "\\" "/" -}}
+{{ $pathFormatted := "" -}}
+{{ with .File }}
+{{ $pathFormatted = replace .Path "\\" "/" -}}
+{{ end -}}
 {{ $gh_repo := ($.Param "github_repo") -}}
 {{ $gh_url := ($.Param "github_url") -}}
 {{ $gh_subdir := ($.Param "github_subdir") -}}

--- a/themes/arm-design-system-hugo-theme/layouts/stats/list.html
+++ b/themes/arm-design-system-hugo-theme/layouts/stats/list.html
@@ -4,7 +4,7 @@
 {{/* Hugo Processing  */}}
 {{/*===================================================================*/}}
     <!--  Create accessable data vars -->
-    {{ $this_week_stats := index .Site.Data.stats_weekly_data (sub (len .Site.Data.stats_weekly_data) 1) }}
+    {{ $this_week_stats := index hugo.Data.stats_weekly_data (sub (len hugo.Data.stats_weekly_data) 1) }}
 
     <!-- reorganize contributor data -->
     {{$authors_dict_array := slice }}
@@ -235,7 +235,7 @@
 {{$dates := slice}}
 {{$legend := slice         "Cross Platform"        "Embedded Systems"        "Install Guides"        "Laptops and Desktops"        "Microcontrollers"        "Servers and Cloud Computing"        "Smartphones and Mobile"}}
 {{$data_and_legend := dict "Cross Platform" slice  "Embedded Systems" slice  "Install Guides" slice  "Laptops and Desktops" slice  "Microcontrollers" slice  "Servers and Cloud Computing" slice  "Smartphones and Mobile" slice }}
-{{ range .Site.Data.stats_weekly_data }}
+{{ range hugo.Data.stats_weekly_data }}
 
     {{/* Add date to array */}}
     {{ $dates = append $dates (slice .a_date) }}
@@ -370,7 +370,7 @@
     {{$legend := slice         "Forks"        "Pull Requests"}}
     {{$data_and_legend := dict "Forks" slice  "Pull Requests" slice}}
     {{$data := slice}}
-    {{ range .Site.Data.stats_weekly_data }}
+    {{ range hugo.Data.stats_weekly_data }}
 
         {{/* Add date to array */}}
         {{ $dates = append $dates (slice .a_date) }}


### PR DESCRIPTION
Summary

Fixes template issues introduced after upgrading Hugo from v0.152.2 to v0.160.1.

Problem

Builds failed on the homepage with:

render: failed to render pages: render of “/” failed: execute of template failed: File is nil

The upgrade also exposed compatibility issues in stats templates related to data access.

Changes
	•	Added a guard around .File in layouts/index.html to avoid nil access on pages where .File is not set
	•	Updated layouts/stats/list.html to use hugo.Data.stats_weekly_data instead of .Site.Data.stats_weekly_data

Impact
	•	Fixes homepage render failure
	•	Restores successful builds on Hugo v0.160.1
	•	Updates stats templates for newer Hugo data access