### PR TITLE
Redis: refresh tuning guidance

### DIFF
--- a/content/learning-paths/servers-and-cloud-computing/redis_tune/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/redis_tune/_index.md
@@ -3,18 +3,18 @@ title: Learn how to tune Redis
 
 minutes_to_complete: 30
 
-who_is_this_for: This is an advanced topic for software developers who want to deploy Redis on Arm-based servers and follow best practices to get performance benefits.
+who_is_this_for: This is an advanced topic for software developers who want to tune Redis on Arm-based servers and evaluate performance-sensitive configuration settings.
 
 learning_objectives:
     - Learn about kernel parameters that can impact Redis performance
     - Learn about compiler and libraries that can impact Redis performance
-    - Tune a Redis configuration file for deployment
+    - Tune Redis server configuration for improved performance
 
 prerequisites:
-    - Cloud or bare-metal installation of an Redis file server
+    - Cloud or bare-metal installation of a Redis server
     - Review [Learn how to deploy Redis](/learning-paths/servers-and-cloud-computing/redis/) if you do not already have Redis setup
 
-author: Elham Harirpoush
+author: Elham Harirpoush, Kelsey Steele
 
 ### Tags
 skilllevels: Advanced
@@ -27,7 +27,7 @@ cloud_service_providers:
 armips:
     - Neoverse
 tools_software_languages:
-    - Redis    
+    - Redis
     - Runbook
 
 operatingsystems:
@@ -38,7 +38,7 @@ further_reading:
         title: Redis Documentation
         link: https://redis.io/docs/
         type: documentation
-    
+
 
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/servers-and-cloud-computing/redis_tune/kernel_comp_lib.md
+++ b/content/learning-paths/servers-and-cloud-computing/redis_tune/kernel_comp_lib.md
@@ -4,41 +4,53 @@ weight: 2
 layout: "learningpathall"
 ---
 
-In this section you can get an overview of the linux kernel, compiler and OpenSSL settings that impact the performance of Redis.
+This section gives an overview of Linux kernel, compiler, and OpenSSL settings that can impact Redis performance.
 
-##  Kernel configuration
+## Kernel Configuration
 
-The profile of requests made by clients will differ based on the use case. This means there is no one size fits all set of tuning parameters for Redis. Use the information below as general guidance to tune Redis.
+The request profile varies by use case, so there is no one-size-fits-all set of tuning parameters for Redis. Use the information below as a starting point, then measure the impact for your workload.
 
 ### Memory Management
 
-The memory related kernel parameters can be changed either temporarily through the `/proc` file system or permanently using the `sysctl` command.
-To improve memory utilization on your system, use the following commands:
+Memory-related kernel parameters can be changed temporarily with `sysctl -w` or made persistent by adding them to a file under `/etc/sysctl.d/`.
+
+Use the following commands to apply the settings immediately:
 
 ```console
-sudo echo 'vm.overcommit_memory = 1' >> /etc/sysctl.conf 
-sudo echo 'vm.swappiness=1' >> /etc/sysctl.conf 
+sudo sysctl -w vm.overcommit_memory=1
+sudo sysctl -w vm.swappiness=1
 ```
-Understand the parameters:
 
-* `vm.overcommit_memory`:
-  * Enabling overcommit_memory to avoid out of memory space issues. If the overcommit memory value is 0 then there is chance that Redis will get an OOM (out of memory) error.  
-* `vm.swappiness`:
-  * When the Redis server consuming high memory, configuring the swappiness to its lowest value could be helpful. 
+To make the settings persistent across reboots, create a Redis-specific sysctl file:
+
+```console
+printf "vm.overcommit_memory = 1\nvm.swappiness = 1\n" | sudo tee /etc/sysctl.d/99-redis.conf
+sudo sysctl --system
+```
+
+`vm.overcommit_memory` should be set to `1` so Redis background save and rewrite operations are less likely to fail during `fork()`.
+
+`vm.swappiness` controls how aggressively Linux swaps memory pages. A low value helps reduce Redis latency caused by paging under memory pressure.
 
 ### Transparent Huge Page
 
-Redis by default will disable transparent huge page (THP) if it is enabled for Redis process to avoid latency problems. You should disable this parameter in case this config has no effect.
+Transparent Huge Pages (THP) can increase Redis latency and memory use, especially when Redis forks for RDB snapshots or AOF rewrite. Disable THP at the kernel level on systems used for Redis performance tuning.
 
-The command to disable this setting is shown below:
+Check the current THP setting:
 
 ```console
-sudo echo never > /sys/kernel/mm/transparent_hugepage/enabled  
+cat /sys/kernel/mm/transparent_hugepage/enabled
+```
+
+Disable THP until the next reboot:
+
+```console
+echo never | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
 ```
 
 ### Linux Network Stack
 
-The Linux Network stack settings can be changed in the `/etc/sysctl.conf` file, or by using the `sysctl` command.
+Linux network stack settings can be changed temporarily with `sysctl -w` or made persistent by adding them to a file under `/etc/sysctl.d/`.
 
 Documentation on each of the parameters discussed below can be found in the [admin-guide](https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/sysctl/net.rst) and [networking](https://github.com/torvalds/linux/blob/master/Documentation/networking/ip-sysctl.rst) documentation within the Linux source.
 
@@ -48,34 +60,39 @@ Run the command below to list all kernel parameters.
 sudo sysctl -a
 ```
 
-Shown below are the network stack settings used for performance testing.
+Shown below are network stack settings used for Redis performance tuning.
 
 ```console
 sudo sysctl -w net.core.somaxconn=65535
 sudo sysctl -w net.ipv4.tcp_max_syn_backlog=65535
-
 ```
 
-These settings open up the network stack to make sure it is not a bottleneck.
+These settings raise connection queue limits so the kernel is less likely to be the bottleneck during high connection churn.
 
 * `net.core.somaxconn`:
-  * This setting is used to select the maximum number of connections the kernel will allow.
+  * This setting controls the maximum listen backlog the kernel allows.
   * If the Redis server is expected to support a large number of clients, it may be helpful to increase this parameter.
-  * A value of 65535 is probably excessively large for production. In practice, this just needs to be large enough to support the peak number of connections that will be made.
+  * The value should be at least as large as the Redis `tcp-backlog` setting.
+  * A value of 65535 is probably too large for production. In practice, this only needs to support the expected peak connection backlog.
 * `net.ipv4.tcp_max_syn_backlog`:
-  * This setting is used to select the maximum number of connection requests that are pending but not established yet.
-  * A value of 65535 is probably excessively large for production. In practice, this just needs to be large enough to support the peak number of connection requests that will be made.
+  * This setting controls the maximum number of connection requests that are pending but not established.
+  * A value of 65535 is probably too large for production. In practice, this only needs to support the expected peak rate of new connection attempts.
 
 
-##  Compiler Considerations
+## Compiler Considerations
 
-The easiest way to gain performance is to use the latest version of GCC. Aside from that, the flag `-mcpu` and `-flto` can be used to potentially gain additional performance. Usage of these flags is explained in the [Migrating C/C++ applications](/learning-paths/servers-and-cloud-computing/migration/c/) section of the [Migrating applications to Arm servers](/learning-paths/servers-and-cloud-computing/migration/) learning path.
+If you build Redis from source, use a recent GCC version from your Linux distribution. Compiler flags such as `-mcpu` and `-flto` can change performance, but they should be tested against your workload before use. Usage of these flags is explained in the [Migrating C/C++ applications](/learning-paths/servers-and-cloud-computing/migration/c/) section of the [Migrating applications to Arm servers](/learning-paths/servers-and-cloud-computing/migration/) learning path.
 
-If you need to understand how to configure a build of Redis. Please review the [build Redis from source](https://redis.io/docs/latest/operate/oss_and_stack/install/archive/install-redis/install-redis-from-source/).
+For Redis build instructions, review the [build Redis from source](https://redis.io/docs/latest/operate/oss_and_stack/install/archive/install-redis/install-redis-from-source/) documentation.
 
-##  OpenSSL Considerations
+## OpenSSL Considerations
 
-Redis relies on [OpenSSL](https://www.openssl.org/) for cryptographic operations. Thus, the version of OpenSSL used with Redis (and the GCC version and switches used to compile it) can impact performance. Typically using the Linux distribution default version of OpenSSL is sufficient.
+Redis uses [OpenSSL](https://www.openssl.org/) for TLS. TLS adds encryption and integrity-check overhead, so it can reduce the maximum throughput of a Redis instance. Typically, the Linux distribution default OpenSSL version is sufficient.
 
-However, it is possible to use newer versions of OpenSSL which could yield performance improvements. This is achieved by using the `--with-openssl` switch when configuring the Redis build. Point this switch to the directory that contains the source code of the version of OpenSSL you'd like to have Redis link to. The Redis build system takes care of the rest. There is also a `--with-openssl-opt` switch which allows you to add options to the build for OpenSSL.
+To build Redis with TLS support, install the OpenSSL development libraries for your distribution and build Redis with:
 
+```console
+make BUILD_TLS=yes
+```
+
+Only test a newer OpenSSL version if TLS is part of the workload. If clients connect without TLS, OpenSSL does not affect Redis command throughput.

--- a/content/learning-paths/servers-and-cloud-computing/redis_tune/tune_redis.md
+++ b/content/learning-paths/servers-and-cloud-computing/redis_tune/tune_redis.md
@@ -4,58 +4,116 @@ weight: 3
 layout: "learningpathall"
 ---
 
-##  Redis Deployment Tuning
+## Redis Deployment Tuning
 
-Optimizing Redis allows you to gain performance improvement without scaling your deployment up (bigger machines/nodes) or out (more machines/nodes). This gained performance can either be used, or traded for cost savings by reducing the amount of compute resources provisioned. The profile of requests made by clients will vary based on the use case. This means there is no one size fits all set of tuning parameters for Redis. Use the information below as general guidance on tuning Redis.
+Optimizing Redis can improve performance without scaling your deployment up to larger machines or out to more nodes. The gained performance can be used directly, or traded for cost savings by reducing provisioned compute resources.
 
-##  Redis File Configuration
+The profile of requests made by clients varies by use case, so there is no one-size-fits-all Redis configuration. Start with a small, explicit `redis.conf`, measure throughput, latency, memory use, and CPU use, then change one setting at a time.
 
-In the [Configure Redis single-node](/learning-paths/servers-and-cloud-computing/redis/single-node_deployment/) section of the [Learn how to deploy Redis on Arm](/learning-paths/servers-and-cloud-computing/redis/) learning path, a bare minimum file server configuration was discussed. In this section, a tuned file server configuration is discussed.
+If you do not already have a Redis server running, review [Learn how to deploy Redis on Arm](/learning-paths/servers-and-cloud-computing/redis/) and the [Configure Redis single-node](/learning-paths/servers-and-cloud-computing/redis/single-node_deployment/) section before applying these tuning settings.
 
-### Top Level redis.conf
+For the complete list of Redis configuration directives, see the [Redis configuration documentation](https://redis.io/docs/latest/operate/oss_and_stack/management/config/) and the self-documented `redis.conf` file shipped with your Redis release.
 
-A tuned top level configuration file [/etc/redis/redis.conf](https://raw.githubusercontent.com/redis/redis/7.0/redis.conf) is shown below. Only performance relevant parameters are discussed.
+## Baseline redis.conf
+
+The following configuration is a good starting point for performance tuning on a dedicated Redis server. It includes performance-related settings and a small number of operational settings that make results easier to compare. Replace the placeholder values before applying the configuration.
+
+Add these settings to the Redis configuration file used by your server, commonly `/etc/redis/redis.conf`. If Redis is managed by `systemd`, restart the service after editing the file:
+
+```bash
+sudo systemctl restart redis-server
+```
+
+If you start Redis manually, pass the configuration file path to `redis-server`:
+
+```bash
+redis-server /etc/redis/redis.conf
+```
 
 ```console
-################################ SNAPSHOTTING  #################################
+################################## NETWORK #####################################
 
-save ""
+bind <server-private-ip>
+protected-mode yes
+port 6379
+tcp-backlog 511
+tcp-keepalive 300
+timeout 0
 
-stop-writes-on-bgsave-error no
+################################## GENERAL #####################################
+
+daemonize no
+supervised no
+databases 16
 
 ################################### CLIENTS ####################################
 
-maxclients 10000 
+maxclients 10000
 
-############################## MEMORY MANAGEMENT ################################
+################################ SNAPSHOTTING ##################################
+
+save ""
+stop-writes-on-bgsave-error yes
+
+################################ APPEND ONLY MODE ##############################
+
+appendonly no
+appendfsync everysec
+no-appendfsync-on-rewrite no
+
+############################### MEMORY MANAGEMENT ##############################
 
 maxmemory <bytes>
- 
+maxmemory-policy noeviction
+maxmemory-samples 5
+lazyfree-lazy-eviction no
+lazyfree-lazy-expire no
+lazyfree-lazy-server-del no
+replica-lazy-flush no
+activedefrag no
 
-################################ THREADED I/O #################################
+################################ THREADED I/O ##################################
 
 io-threads 1
+
+################################### LATENCY ####################################
+
+hz 10
+dynamic-hz yes
 ```
 
-* `save`:
-  * Redis by default tries to store data on the disk which creates forks that can result in overall system slowdown. You can prevent this by commenting out the lines that begin with "save".
-  * To entirely disable snapshotting, you can provide a single empty string argument.
-* `stop-writes-on-bgsave-error`:
-  *  If you have setup your proper monitoring of the Redis server and persistence, you may want to disable background saving so that Redis will continue to work as usual even if there are problems with disk, permissions, and so forth.
-* `maxclients`:
-  * If your system has a many connections, set the maxclients to a higher value (default is 10000). 
-  * If your resources are limited but you are employing efficient horizontal sharding through a Redis cluster, consider reducing this value to prevent potential bottlenecks from arising.
-* `maxmemory`:
-  * If maxmemory is not defined, Redis will continuously allocate memory based on its requirements, potentially consuming all available free memory over time. Therefore, it is generally recommended to configure this value to certain limits to prevent this from occurring. 
-  * You can allocate 75-80% of your memory to Redis by changing maxmemory value in the configuration file. 
-* `io-thread`:
-  * Redis is mostly single threaded and usually threading reads does not help much. 
-  * Redis documentation advises to use default value because if you need more threads, sharding redis or using pipeline > 1 is a better way to add parallelism.
-  * The commented io-threads value in the configuration file is 4, which means Redis will use the default value for io-threads which is 1.  
+## Configuration options
 
-  #### Client side pipelining
+| Setting | Starting value | Why it matters and when to change it |
+| --- | --- | --- |
+| `bind` | Private server IP | Bind to the private or VPN interface used by benchmark clients. Use `0.0.0.0` only in isolated benchmark environments where clients may connect through multiple private interfaces and access to port `6379` is already restricted by network controls. |
+| `protected-mode` | `yes` | Keep enabled by default. Set to `no` only for isolated benchmark networks where Redis access is already restricted by VPN, firewall rules, cloud security groups, or equivalent controls. |
+| `port` | `6379` | Change only to avoid a port conflict or to run multiple Redis instances on the same host. |
+| `tcp-backlog` | `511` | Increase for high connection churn. The Linux `net.core.somaxconn` value must be at least as large. |
+| `tcp-keepalive` | `300` | Reduce when you need faster detection of dead TCP peers. Increase if idle connections are long lived and stable. |
+| `timeout` | `0` | Keep `0` for benchmarks so idle clients are not disconnected. Set a finite value for production connection cleanup. |
+| `supervised` | `no` | Use `systemd` when Redis is managed as a system service. Use `no` for manual foreground testing. |
+| `databases` | `16` | Use the default unless the application requires fewer logical databases. Redis Cluster only uses database `0`. |
+| `maxclients` | `10000` | Increase only if the workload needs more concurrent connections and the OS file descriptor limit has been raised. Lower it to fail early on small test systems. |
+| `save` | `""` | Disables RDB snapshots. Use this for pure cache or throughput tests. Add snapshot intervals when restart recovery from disk is required. |
+| `stop-writes-on-bgsave-error` | `yes` | Keep `yes` when RDB persistence is required and failed snapshots must stop writes. Use `no` only when monitoring catches persistence failures. |
+| `appendonly` | `no` | Keep disabled for cache-style or maximum throughput tests. Enable AOF when durability is required. |
+| `appendfsync` | `everysec` | Relevant only when `appendonly yes` is set. Use `always` for stronger durability with higher latency. Use `no` only when OS-managed flushing is acceptable. |
+| `no-appendfsync-on-rewrite` | `no` | Relevant only with AOF. Use `yes` to reduce latency spikes during AOF rewrite at the cost of more data-loss exposure during the rewrite window. |
+| `maxmemory` | Host-specific | Set this explicitly. Start at 70-80% of RAM on a dedicated Redis server, leaving memory for the OS, replicas, forked persistence, and client buffers. |
+| `maxmemory-policy` | `noeviction` | Use `noeviction` for correctness testing because writes fail instead of silently evicting keys. Use `allkeys-lru` or `allkeys-lfu` for cache workloads. Use `volatile-*` policies only when the application reliably sets TTLs. |
+| `maxmemory-samples` | `5` | Increase to improve LRU/LFU eviction accuracy with more CPU cost. Leave unchanged for a first test. |
+| `lazyfree-lazy-eviction` | `no` | Enable when eviction of large values causes latency spikes. Background freeing can increase memory pressure temporarily. |
+| `lazyfree-lazy-expire` | `no` | Enable when expiration of large values causes latency spikes. |
+| `lazyfree-lazy-server-del` | `no` | Enable when commands that replace or delete large values, such as `DEL`, `RENAME`, or writes over existing keys, cause latency spikes. |
+| `replica-lazy-flush` | `no` | Enable on replicas when full resynchronization or flush operations create latency spikes. |
+| `activedefrag` | `no` | Enable for long-running write-heavy workloads with high memory fragmentation. Keep disabled for first-pass throughput tests because it consumes CPU. |
+| `io-threads` | `1` | `1` uses the main thread only, which is the standard starting point. Increase only when Redis is CPU-bound on network I/O, the server has at least four cores, and the workload benefits in measurement. Redis 8 uses I/O threads for reads and writes when this is enabled. |
+| `hz` | `10` | Increase only when background maintenance, key expiration, or client timeout responsiveness is too slow. Higher values use more CPU. |
+| `dynamic-hz` | `yes` | Keep enabled so Redis can adjust background task frequency as client count changes. |
 
-Pipelining is a feature primarily implemented on the client side. When a client uses the Redis client library like [memtier](https://github.com/RedisLabs/memtier_benchmark) does then the client can choose to use pipelining, which is a more effective approach for achieving parallelism. You should use a pipeline ranging from 1 (default) to approximately 20 as a large pipeline value (> 20) will increase latency. You will need to experiment and decide what pipeline value makes the most sense for your use case.
+## Client-side pipelining
 
+Test client-side pipelining separately from Redis I/O threads. Pipelining reduces round-trip and socket syscall overhead, and is often the simplest way to increase throughput from benchmark clients such as [memtier_benchmark](https://github.com/RedisLabs/memtier_benchmark). I/O threads are a server-side option for workloads limited by Redis network I/O.
 
-
+Start with pipeline depth `1`, then test values such as `4`, `8`, `16`, and `32`. Larger pipeline depths can increase throughput, but they also increase tail latency and client-side memory use.


### PR DESCRIPTION
Update Redis tuning guidance to use an explicit baseline redis.conf with concise guidance for operational and performance-sensitive settings.

Fix kernel tuning commands so sysctl and THP changes are applied through commands that work with sudo. Correct the TLS build guidance to use BUILD_TLS=yes.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)

- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
