### PR TITLE
Frame device-connect-server LP around a globally connected fleet

### DIFF
--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-server/_index.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-server/_index.md
@@ -4,7 +4,7 @@ title: Deploy multi-network device meshes using Device Connect server and NATS
 description: Connect devices and AI agents across networks using Device Connect server. Learn to provision NATS credentials, commission devices, manage persistent registry, and orchestrate multi-network IoT fleets with secure authentication.
 minutes_to_complete: 30
 
-who_is_this_for: This Learning Path is for developers who have completed the Device-to-device Learning Path and want to add a server layer to their Device Connect mesh. You'll learn to use persistent registry, distributed state, and security features (commissioning, ACLs) to operate a multi-network fleet. If you're new to Device Connect, start with the device-to-device Learning Path first.
+who_is_this_for: This Learning Path is for developers who have completed the Device-to-device Learning Path and want to build a globally connected fleet of devices and AI agents on top of their Device Connect mesh. You'll add a server layer that gives you persistent registry, distributed state, and security features (commissioning, ACLs) so devices and agents on different networks can find and call each other through a single namespace. If you're new to Device Connect, start with the device-to-device Learning Path first.
 
 learning_objectives:
     - Understand what the Device Connect server adds on top of the edge SDK and when you'd reach for it

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-server/background.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-server/background.md
@@ -19,7 +19,7 @@ This model works well for:
 
 ### When D2D isn't enough
 
-As your fleet grows, D2D mode has limitations. You might need devices on different networks to communicate, or a registry that remembers devices after they disconnect. You might also need stronger identity controls, credential rotation, or audit logs.
+As your fleet grows beyond a single local network, D2D mode has limitations. You might need devices in different sites or regions to find and call each other, or a registry that remembers devices after they disconnect. You might also need stronger identity controls, credential rotation, or audit logs.
 
 ### When to add a server
 


### PR DESCRIPTION
## Summary
Small prose update to the device-connect-server Learning Path so the **globally connected fleet** angle (already present in the embedded animation) shows up in the lead-in instead of being buried under the abstract registry + state + security list.

Two single-sentence rewrites, no structural or code changes:
- `_index.md` `who_is_this_for` — leads with "build a globally connected fleet of devices and AI agents" and explains that devices on different networks can find and call each other through one namespace
- `background.md` "When D2D isn't enough" — the existing paragraph now opens "As your fleet grows beyond a single local network" and explicitly mentions devices in different sites or regions

Original review feedback that prompted this: the animated graphic and the message-flow section already tell a "globally connected fleet" story, but the very first thing readers see was framed as "add a server to your D2D mesh" — technical, not visual.

## Test plan
- [ ] `hugo server --buildDrafts` renders the LP cleanly
- [ ] `/learning-paths/embedded-and-microcontrollers/device-connect-server/` shows the new `who_is_this_for` in the metadata card
- [ ] `background.md` "When D2D isn't enough" paragraph reads naturally with the new opening