### PR TITLE
adding outbound links to learning paths to address 'dead-end' pages finding

### DIFF
--- a/content/install-guides/go.md
+++ b/content/install-guides/go.md
@@ -79,4 +79,4 @@ The output is similar to:
 go version go1.24.5 linux/arm64
 ```
 
-You are now ready to use the Go programming language on your Arm machine running Ubuntu.
+You are now ready to use the Go programming language on your Arm machine running Ubuntu. You can explore Learning Paths for working with Go on Arm, such as [Deploy Golang on Azure Cobalt 100 on Arm](/learning-paths/servers-and-cloud-computing/golang-on-azure/) and [Benchmark Go performance with Sweet and Benchstat](/learning-paths/servers-and-cloud-computing/go-benchmarking-with-sweet/).

--- a/content/install-guides/go.md
+++ b/content/install-guides/go.md
@@ -79,4 +79,6 @@ The output is similar to:
 go version go1.24.5 linux/arm64
 ```
 
+## Next steps
+
 You are now ready to use the Go programming language on your Arm machine running Ubuntu. You can explore Learning Paths for working with Go on Arm, such as [Deploy Golang on Azure Cobalt 100 on Arm](/learning-paths/servers-and-cloud-computing/golang-on-azure/) and [Benchmark Go performance with Sweet and Benchstat](/learning-paths/servers-and-cloud-computing/go-benchmarking-with-sweet/).

--- a/content/install-guides/java.md
+++ b/content/install-guides/java.md
@@ -406,5 +406,6 @@ INFO: Created user preferences directory.
 
 Copyright (c) 1999-2024 The Apache Software Foundation
 ```
+## Next steps
 
 You are now ready to use Java on your Arm Linux system. You can explore Learning Paths for working with Java on Arm, such as [Run Java applications on Google Axion processors](/learning-paths/servers-and-cloud-computing/java-on-axion/) and [Tune the performance of the Java garbage collector](/learning-paths/servers-and-cloud-computing/java-gc-tuning/). 

--- a/content/install-guides/java.md
+++ b/content/install-guides/java.md
@@ -407,4 +407,4 @@ INFO: Created user preferences directory.
 Copyright (c) 1999-2024 The Apache Software Foundation
 ```
 
-You are now ready to use Java on your Arm Linux system. 
+You are now ready to use Java on your Arm Linux system. You can explore Learning Paths for working with Java on Arm, such as [Run Java applications on Google Axion processors](/learning-paths/servers-and-cloud-computing/java-on-axion/) and [Tune the performance of the Java garbage collector](/learning-paths/servers-and-cloud-computing/java-gc-tuning/). 

--- a/content/install-guides/terraform.md
+++ b/content/install-guides/terraform.md
@@ -102,4 +102,4 @@ Terraform v1.14.9
 on darwin_arm64
 ```
 
-You are now ready to use Terraform.
+You are now ready to use Terraform. You can explore Learning Paths to work with Terraform on Arm, such as [Deploy Arm virtual machines on Google Cloud Platform (GCP) using Terraform](/learning-paths/servers-and-cloud-computing/gcp/) and [Deploy Arm instances on AWS using Terraform](/learning-paths/servers-and-cloud-computing/aws-terraform/).

--- a/content/install-guides/terraform.md
+++ b/content/install-guides/terraform.md
@@ -101,5 +101,6 @@ The output for macOS is similar to:
 Terraform v1.14.9
 on darwin_arm64
 ```
+## Next steps
 
 You are now ready to use Terraform. You can explore Learning Paths to work with Terraform on Arm, such as [Deploy Arm virtual machines on Google Cloud Platform (GCP) using Terraform](/learning-paths/servers-and-cloud-computing/gcp/) and [Deploy Arm instances on AWS using Terraform](/learning-paths/servers-and-cloud-computing/aws-terraform/).


### PR DESCRIPTION
Task 4 from Maddy's set of findings:

"Context: Several guides have 0 outbound links. This effectively ends the user's session once they finish the article.
• Target Pages:
• /install-guides/go/
• /install-guides/java/
• /install-guides/terraform/
• /learning-paths/automotive/
• Instructions:
• Scroll to the bottom of these pages.
• Add a section titled "Next Steps" or "Related Learning Paths."
• Link to at least two relevant pieces of content to keep the user engaged (e.g., on the Java install guide, link to the "Migrating Java Applications" path)."


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [ ] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [ ] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
