### PR TITLE
[Platform Migration] Add `dev` and `prod` deployment targets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,16 @@ jobs:
       - name: Install Post-CSS
         run: npm install postcss-cli
 
+      - name: Validate AWS OIDC role
+        run: |
+          if [ -z "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_OIDC_ROLE" ]; then
+            printf '%s\n' "Either the deploy-role-arn input or AWS_OIDC_ROLE secret must be provided." >&2
+            exit 1
+          fi
+        env:
+          DEPLOY_ROLE_ARN: ${{ inputs.deploy-role-arn }}
+          AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE }}
+
       - name: AWS Github OIDC Login
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,14 @@ on:
         required: false
         type: string
         default: "us-west-2"
+      deploy-role-arn:
+        description: "AWS OIDC role ARN to assume"
+        required: false
+        type: string
+        default: ""
     secrets:
       AWS_OIDC_ROLE:
-        required: true
+        required: false
       HUGO_LLM_API:
         required: true
       HUGO_RAG_API:
@@ -40,7 +45,7 @@ jobs:
       contents: read
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so the job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true # Fetch Hugo Themes
           fetch-depth: 0
@@ -60,9 +65,9 @@ jobs:
         run: npm install postcss-cli
 
       - name: AWS Github OIDC Login
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
+          role-to-assume: ${{ inputs.deploy-role-arn || secrets.AWS_OIDC_ROLE }}
           aws-region: ${{ inputs.aws-region }}
 
       # Builds arm-software-developer repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Deprecated: kept temporarily while the dev deployment is validated.
   build_and_deploy_internal:
     name: Build and Deploy Internal
     uses: ./.github/workflows/deploy.yml
@@ -21,6 +22,24 @@ jobs:
       target: internal
     secrets:
       AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE_INTERNAL }}
+      HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
+      HUGO_RAG_API: ${{ secrets.HUGO_RAG_API }}
+      HUGO_AUDIO_API: ${{ secrets.HUGO_AUDIO_API }}
+      HUGO_PHI_ONNX_LLM_API: ${{ secrets.HUGO_PHI_ONNX_LLM_API }}
+      HUGO_DEV_PROG_SIGNIUP_FORM_MUNCHKIN_ID: ${{ secrets.HUGO_DEV_PROG_SIGNIUP_FORM_MUNCHKIN_ID }}
+      HUGO_FORM_ID_FOR_PROGRAM_SIGNUP: ${{ secrets.HUGO_FORM_ID_FOR_PROGRAM_SIGNUP }}
+
+  build_and_deploy_dev:
+    name: Build and Deploy Dev
+    uses: ./.github/workflows/deploy.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      target: dev
+      aws-region: us-east-1
+      deploy-role-arn: arn:aws:iam::688080325088:role/Proj-GHA-arm-learning-paths-dev
+    secrets:
       HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
       HUGO_RAG_API: ${{ secrets.HUGO_RAG_API }}
       HUGO_AUDIO_API: ${{ secrets.HUGO_AUDIO_API }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -11,8 +11,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Deprecated: kept temporarily while the prod deployment is validated.
   build_and_deploy_production:
-    name: Build and Deploy Production
+    name: Build and Deploy Production Deprecated
     uses: ./.github/workflows/deploy.yml
     permissions:
       id-token: write
@@ -21,6 +22,24 @@ jobs:
       target: production
     secrets:
       AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE_PRODUCTION }}
+      HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
+      HUGO_RAG_API: ${{ secrets.HUGO_RAG_API }}
+      HUGO_AUDIO_API: ${{ secrets.HUGO_AUDIO_API }}
+      HUGO_PHI_ONNX_LLM_API: ${{ secrets.HUGO_PHI_ONNX_LLM_API }}
+      HUGO_DEV_PROG_SIGNIUP_FORM_MUNCHKIN_ID: ${{ secrets.HUGO_DEV_PROG_SIGNIUP_FORM_MUNCHKIN_ID }}
+      HUGO_FORM_ID_FOR_PROGRAM_SIGNUP: ${{ secrets.HUGO_FORM_ID_FOR_PROGRAM_SIGNUP }}
+
+  build_and_deploy_prod:
+    name: Build and Deploy Prod
+    uses: ./.github/workflows/deploy.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      target: prod
+      aws-region: us-east-1
+      deploy-role-arn: arn:aws:iam::084149021538:role/Proj-GHA-arm-learning-paths-prod
+    secrets:
       HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
       HUGO_RAG_API: ${{ secrets.HUGO_RAG_API }}
       HUGO_AUDIO_API: ${{ secrets.HUGO_AUDIO_API }}

--- a/config.toml
+++ b/config.toml
@@ -24,10 +24,16 @@ name = "dev"
 URL = "s3://arm-learning-paths-dev?region=us-east-1"
 cloudFrontDistributionID = "EAMKPMDBM18II"
 
+# Deprecated: kept temporarily while the prod deployment is validated.
 [[deployment.targets]]
 name = "production"
 URL = "s3://arm-learning-paths?region=us-west-2"
 cloudFrontDistributionID = "E2NEF61QWPFRIH"
+
+[[deployment.targets]]
+name = "prod"
+URL = "s3://arm-learning-paths-prod?region=us-east-1"
+cloudFrontDistributionID = "E2IA2AC83UE2VJ"
 
 [markup]
   [markup.goldmark]

--- a/config.toml
+++ b/config.toml
@@ -13,10 +13,16 @@ name = "internal-existing"
 URL = "s3://armswdev.tk?region=us-east-1"
 cloudFrontDistributionID = "E2VDQ2CYZATMO9"
 
+# Deprecated: kept temporarily while the dev deployment is validated.
 [[deployment.targets]]
 name = "internal"
 URL = "s3://arm-learning-paths-internal?region=us-west-2"
 cloudFrontDistributionID = "ENN4LK1IZUDIX"
+
+[[deployment.targets]]
+name = "dev"
+URL = "s3://arm-learning-paths-dev?region=us-east-1"
+cloudFrontDistributionID = "EAMKPMDBM18II"
 
 [[deployment.targets]]
 name = "production"


### PR DESCRIPTION
## Summary
Adds a temporary `dev` and `prod` deployment targets alongside the existing deployments for testing.
## Changes
- Added Hugo deployment target `dev` and `prod`
  - S3 bucket: `arm-learning-paths-dev` and `arm-learning-paths-prod`
  - Region: `us-east-1`
  - CloudFront distribution: `EAMKPMDBM18II` and `E2IA2AC83UE2VJ`
- Added a new `Build and Deploy Dev` job to the `main` workflow.
- Added a new `Build and Deploy Prod` job to the `production` workflow.
- Updated reusable deploy workflow to support passing an AWS OIDC role ARN directly via `deploy-role-arn`.
- Marked the existing deployments as deprecated for future removal.