### PR TITLE
Fix code sample at perf_event_open.md

### DIFF
--- a/content/learning-paths/servers-and-cloud-computing/arm_pmu/perf_event_open.md
+++ b/content/learning-paths/servers-and-cloud-computing/arm_pmu/perf_event_open.md
@@ -212,7 +212,7 @@ int main() {
   for(int i = 0; i < counter_results.nr; i++) {
     for(int j = 0; j < TOTAL_EVENTS ;j++){
       if(counter_results.values[i].id == id[j]){
-        pe_val[i] = counter_results.values[i].value;
+        pe_val[j] = counter_results.values[i].value;
       }
     }
   }

--- a/content/learning-paths/servers-and-cloud-computing/arm_pmu/perf_event_open.md
+++ b/content/learning-paths/servers-and-cloud-computing/arm_pmu/perf_event_open.md
@@ -213,6 +213,7 @@ int main() {
     for(int j = 0; j < TOTAL_EVENTS ;j++){
       if(counter_results.values[i].id == id[j]){
         pe_val[j] = counter_results.values[i].value;
+        break;
       }
     }
   }


### PR DESCRIPTION
Fix bug on the code sample for printing the counter values. The original code is storing the counters to the pe_val array while trusting that the events read are coming sequentially from the kernel. The fix is to store the counters in their correct location, that is, using the index of the matched event id.

Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [X] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [X] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
