### PR TITLE
[Platform Migration] Remove old targets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,17 +9,13 @@ on:
         type: string
       aws-region:
         description: "AWS Region to use for fetching credentials"
-        required: false
+        required: true
         type: string
-        default: "us-west-2"
       deploy-role-arn:
         description: "AWS OIDC role ARN to assume"
-        required: false
+        required: true
         type: string
-        default: ""
     secrets:
-      AWS_OIDC_ROLE:
-        required: false
       HUGO_LLM_API:
         required: true
       HUGO_RAG_API:
@@ -64,20 +60,10 @@ jobs:
       - name: Install Post-CSS
         run: npm install postcss-cli
 
-      - name: Validate AWS OIDC role
-        run: |
-          if [ -z "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_OIDC_ROLE" ]; then
-            printf '%s\n' "Either the deploy-role-arn input or AWS_OIDC_ROLE secret must be provided." >&2
-            exit 1
-          fi
-        env:
-          DEPLOY_ROLE_ARN: ${{ inputs.deploy-role-arn }}
-          AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE }}
-
       - name: AWS Github OIDC Login
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ inputs.deploy-role-arn || secrets.AWS_OIDC_ROLE }}
+          role-to-assume: ${{ inputs.deploy-role-arn }}
           aws-region: ${{ inputs.aws-region }}
 
       # Builds arm-software-developer repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This workflow will be triggered on a push to the 'main' branch automatically or when called manually.
-# Upon running this workflow, the website will be built and deployed to the internal instance.
-name: Build and Deploy Internal Website
+# Upon running this workflow, the website will be built and deployed to the dev instance.
+name: Build and Deploy Dev Website
 
 on:
   # Runs on pushes to the 'main' branch
@@ -11,24 +11,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Deprecated: kept temporarily while the dev deployment is validated.
-  build_and_deploy_internal:
-    name: Build and Deploy Internal
-    uses: ./.github/workflows/deploy.yml
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      target: internal
-    secrets:
-      AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE_INTERNAL }}
-      HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
-      HUGO_RAG_API: ${{ secrets.HUGO_RAG_API }}
-      HUGO_AUDIO_API: ${{ secrets.HUGO_AUDIO_API }}
-      HUGO_PHI_ONNX_LLM_API: ${{ secrets.HUGO_PHI_ONNX_LLM_API }}
-      HUGO_DEV_PROG_SIGNIUP_FORM_MUNCHKIN_ID: ${{ secrets.HUGO_DEV_PROG_SIGNIUP_FORM_MUNCHKIN_ID }}
-      HUGO_FORM_ID_FOR_PROGRAM_SIGNUP: ${{ secrets.HUGO_FORM_ID_FOR_PROGRAM_SIGNUP }}
-
   build_and_deploy_dev:
     name: Build and Deploy Dev
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -11,24 +11,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Deprecated: kept temporarily while the prod deployment is validated.
-  build_and_deploy_production:
-    name: Build and Deploy Production Deprecated
-    uses: ./.github/workflows/deploy.yml
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      target: production
-    secrets:
-      AWS_OIDC_ROLE: ${{ secrets.AWS_OIDC_ROLE_PRODUCTION }}
-      HUGO_LLM_API: ${{ secrets.HUGO_LLM_API }}
-      HUGO_RAG_API: ${{ secrets.HUGO_RAG_API }}
-      HUGO_AUDIO_API: ${{ secrets.HUGO_AUDIO_API }}
-      HUGO_PHI_ONNX_LLM_API: ${{ secrets.HUGO_PHI_ONNX_LLM_API }}
-      HUGO_DEV_PROG_SIGNIUP_FORM_MUNCHKIN_ID: ${{ secrets.HUGO_DEV_PROG_SIGNIUP_FORM_MUNCHKIN_ID }}
-      HUGO_FORM_ID_FOR_PROGRAM_SIGNUP: ${{ secrets.HUGO_FORM_ID_FOR_PROGRAM_SIGNUP }}
-
   build_and_deploy_prod:
     name: Build and Deploy Prod
     uses: ./.github/workflows/deploy.yml

--- a/config.toml
+++ b/config.toml
@@ -9,26 +9,9 @@ enableRobotsTXT = true
 
 [deployment]
 [[deployment.targets]]
-name = "internal-existing"
-URL = "s3://armswdev.tk?region=us-east-1"
-cloudFrontDistributionID = "E2VDQ2CYZATMO9"
-
-# Deprecated: kept temporarily while the dev deployment is validated.
-[[deployment.targets]]
-name = "internal"
-URL = "s3://arm-learning-paths-internal?region=us-west-2"
-cloudFrontDistributionID = "ENN4LK1IZUDIX"
-
-[[deployment.targets]]
 name = "dev"
 URL = "s3://arm-learning-paths-dev?region=us-east-1"
 cloudFrontDistributionID = "EAMKPMDBM18II"
-
-# Deprecated: kept temporarily while the prod deployment is validated.
-[[deployment.targets]]
-name = "production"
-URL = "s3://arm-learning-paths?region=us-west-2"
-cloudFrontDistributionID = "E2NEF61QWPFRIH"
 
 [[deployment.targets]]
 name = "prod"


### PR DESCRIPTION
Removing the old deployment targets since we migrated to new accounts. Also undoing some temp measures added in https://github.com/ArmDeveloperEcosystem/arm-learning-paths/pull/3311