### PR TITLE
Add link for older Arm GNU Toolchain versions KBA

### DIFF
--- a/content/install-guides/gcc/arm-gnu.md
+++ b/content/install-guides/gcc/arm-gnu.md
@@ -26,6 +26,8 @@ There are many versions of the [Arm GNU Toolchain](https://developer.arm.com/Too
 
 However there are reasons you may wish to use earlier compiler versions, so older versions are also available.
 
+See also [Where can I get older versions of the Arm GNU Toolchain and GCC for Arm Platforms?](https://developer.arm.com/documentation/ka005611/latest)
+
 ## Download the Arm GNU Toolchain {#download}
 
 Arm GNU Toolchain releases consist of cross toolchains for the following host operating systems:


### PR DESCRIPTION
Added a link to resources for obtaining older versions of the Arm GNU Toolchain.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [ ] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [ ] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
