### PR TITLE
Update vcpkg installation commands with fixed release URLs

### DIFF
--- a/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/installation.md
+++ b/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/installation.md
@@ -18,13 +18,13 @@ To install the tool, open your favorite Terminal application and run one of the 
 
 {{< tabpane code=true >}}
   {{< tab header="Windows (cmd)" language="shell">}}
-curl -LO https://aka.ms/vcpkg-init.cmd && .\vcpkg-init.cmd
+curl -LO https://github.com/microsoft/vcpkg-tool/releases/download/2026-04-08/vcpkg-init.cmd && .\vcpkg-init.cmd
   {{< /tab >}}
   {{< tab header="Windows (PowerShell)" language="shell">}}
-iex (iwr -useb https://aka.ms/vcpkg-init.ps1)
+iex (iwr -useb https://github.com/microsoft/vcpkg-tool/releases/download/2026-04-08/vcpkg-init.ps1)
   {{< /tab >}}
   {{< tab header="Linux/macOS" language="shell">}}
-. <(curl https://aka.ms/vcpkg-init.sh -L)
+. <(curl https://github.com/microsoft/vcpkg-tool/releases/download/2026-04-08/vcpkg-init.sh -L)
   {{< /tab >}}
 {{< /tabpane >}}
 


### PR DESCRIPTION
Microsoft is removing the artifacts feature from vcpkg in July 2026 vcpkg release.  This PR replaces the redirect `https://aka.ms/vcpkg-init.*` with a url pointing to the vcpkg release as of 2026-04-08 a version where the artifacts feature is still "Experimental" and not notified to be removed.

https://github.com/microsoft/vcpkg-tool/releases/download/2026-04-08/vcpkg-init.*

This will be the mitigation until we have an alternative approach agreed with Microsoft or a replacement tool developed.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
