### PR TITLE
Bulk adding metadata descriptions for all embedded and microcontrollers LPs

### DIFF
--- a/content/learning-paths/embedded-and-microcontrollers/advanced_soc/connecting_peripheral.md
+++ b/content/learning-paths/embedded-and-microcontrollers/advanced_soc/connecting_peripheral.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Connect AXI4 Peripheral to ZYNQ Processing System" 
+description: Connect the custom AXI4 peripheral to the Zynq processing system in Vivado so switch inputs can drive LED outputs on the Zybo Z7-10 board.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/advanced_soc/creating_peripheral.md
+++ b/content/learning-paths/embedded-and-microcontrollers/advanced_soc/creating_peripheral.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Create a custom AXI4 Peripheral" 
+description: Create an AXI4-Lite peripheral in Vivado and define the registers and IP package used by the custom Zynq design.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/advanced_soc/generating_bitstream.md
+++ b/content/learning-paths/embedded-and-microcontrollers/advanced_soc/generating_bitstream.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Generate the bitstream and write your application using Vitis IDE" 
+description: Generate the Vivado bitstream, export the hardware design, and write a Vitis application to test the custom AXI4 peripheral.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/advanced_soc/setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/advanced_soc/setup.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Setup a Workspace in Xilinx Vivado" 
+description: Create a Vivado workspace for the Zybo Z7-10 board and configure the base Zynq processing system for a custom peripheral design.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/application-code.md
+++ b/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/application-code.md
@@ -1,5 +1,6 @@
 ---
 title: Add the application code
+description: Add firmware code for camera input, image preprocessing, and Ethos-U85 inference in the Alif Ensemble image classification project.
 weight: 5
 
 layout: "learningpathall"

--- a/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/aws-ec2-setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/aws-ec2-setup.md
@@ -1,5 +1,6 @@
 ---
 title: Compile the model on an Arm cloud instance
+description: Set up an Arm-based AWS EC2 instance to compile the neural network model used by the Alif Ensemble image classification firmware.
 weight: 3
 
 layout: "learningpathall"

--- a/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/aws-ec2-setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/aws-ec2-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Compile the model on an Arm cloud instance
-description: Set up an Arm-based AWS EC2 instance to compile the neural network model used by the Alif Ensemble image classification firmware.
+description: Set up an Arm-based Amazon EC2 instance to compile the neural network model used by the Alif Ensemble image classification firmware.
 weight: 3
 
 layout: "learningpathall"

--- a/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/board-setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/board-setup.md
@@ -1,5 +1,6 @@
 ---
 title: Set up the Alif Ensemble E8 DevKit
+description: Connect and configure the Alif Ensemble E8 DevKit so it is ready for firmware flashing and image classification inference.
 weight: 2
 
 layout: "learningpathall"

--- a/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/build-flash-verify.md
+++ b/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/build-flash-verify.md
@@ -1,5 +1,6 @@
 ---
 title: Build, flash, and verify inference
+description: Build the Alif Ensemble firmware, flash it to the E8 DevKit, and verify image classification output over the serial console.
 weight: 8
 
 layout: "learningpathall"

--- a/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/create-project.md
+++ b/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/create-project.md
@@ -1,5 +1,6 @@
 ---
 title: Create the image classification firmware project
+description: Create the Alif Ensemble firmware project in VS Code and add the files needed for the image classification application.
 weight: 4
 
 layout: "learningpathall"

--- a/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/image-preparation.md
+++ b/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/image-preparation.md
@@ -1,5 +1,6 @@
 ---
 title: Prepare a test image
+description: Prepare a test image with the expected size and format so the Alif Ensemble firmware can run image classification inference.
 weight: 7
 
 layout: "learningpathall"

--- a/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/memory-configuration.md
+++ b/content/learning-paths/embedded-and-microcontrollers/alif-image-classification/memory-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configure memory layout and flash settings
+description: Configure SRAM, flash, and scatter file settings so the Alif Ensemble application can load the model and run on the target hardware.
 weight: 6
 
 layout: "learningpathall"

--- a/content/learning-paths/embedded-and-microcontrollers/arduino-pico/app_stack.md
+++ b/content/learning-paths/embedded-and-microcontrollers/arduino-pico/app_stack.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Application Programming"
+description: Understand the application stack for the Raspberry Pi Pico motion detector before connecting sensors and implementing the firmware.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/arduino-pico/arduino_sketch.md
+++ b/content/learning-paths/embedded-and-microcontrollers/arduino-pico/arduino_sketch.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Program your smart device prototype"
+description: Write and upload the Arduino sketch for the Raspberry Pi Pico so the smart device prototype can react to motion events.
 
 weight: 7 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/arduino-pico/arm_embedded.md
+++ b/content/learning-paths/embedded-and-microcontrollers/arduino-pico/arm_embedded.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Embedded Programming on Arm"
+description: Review Arm embedded development concepts and tool options used when programming Cortex-M based microcontroller projects.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/arduino-pico/background.md
+++ b/content/learning-paths/embedded-and-microcontrollers/arduino-pico/background.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "About Embedded Programming"
+description: Review embedded programming fundamentals and the hardware and software constraints that shape microcontroller applications.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/arduino-pico/embedded_stack.md
+++ b/content/learning-paths/embedded-and-microcontrollers/arduino-pico/embedded_stack.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Embedded Programming"
+description: Understand the layers of an embedded software stack and how firmware, runtime libraries, and hardware interact on microcontrollers.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/arduino-pico/int-background.md
+++ b/content/learning-paths/embedded-and-microcontrollers/arduino-pico/int-background.md
@@ -1,5 +1,6 @@
 ---
 title: Learn about interrupts
+description: Learn why interrupt-driven programming improves responsiveness compared with polling in the Raspberry Pi Pico prototype.
 weight: 8
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/arduino-pico/int-setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/arduino-pico/int-setup.md
@@ -1,5 +1,6 @@
 ---
 title: Add the interrupt code
+description: Add interrupt handling code to the Raspberry Pi Pico application so the device responds to sensor changes without constant polling.
 weight: 9
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/arduino-pico/raspberrypi_pico.md
+++ b/content/learning-paths/embedded-and-microcontrollers/arduino-pico/raspberrypi_pico.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Build a smart device prototype"
+description: Build the first Raspberry Pi Pico motion detection prototype by wiring the PIR sensor and LED and uploading the initial Arduino sketch.
 
 weight: 6 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/arduino-pico/refactoring.md
+++ b/content/learning-paths/embedded-and-microcontrollers/arduino-pico/refactoring.md
@@ -1,5 +1,6 @@
 ---
 title: Refactor the application
+description: Refactor the Raspberry Pi Pico application to separate state handling from hardware control and improve the device workflow.
 weight: 10
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/armds/build.md
+++ b/content/learning-paths/embedded-and-microcontrollers/armds/build.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Import and build example project"
+description: Import an embedded example project into Arm Development Studio and build it for the selected compiler and target platform.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/armds/debug.md
+++ b/content/learning-paths/embedded-and-microcontrollers/armds/debug.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Debug the example
+description: Debug the example project in Arm Development Studio using an FVP target and inspect execution with breakpoints and registers.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/armds/misc.md
+++ b/content/learning-paths/embedded-and-microcontrollers/armds/misc.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Other compilers and project types
+description: Adjust Arm Development Studio projects for alternate compiler versions and project types when the default setup does not match your environment.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/asm/coding.md
+++ b/content/learning-paths/embedded-and-microcontrollers/asm/coding.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Writing assembly functions
+description: Create C and Arm assembly source files that work together under the Arm Procedure Call Standard for a Cortex-M project.
 
 weight: 6 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/asm/intro.md
+++ b/content/learning-paths/embedded-and-microcontrollers/asm/intro.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Keil MDK versions
+description: Compare Keil MDK versions and choose the development environment used for the embedded assembly programming examples.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/asm/setup_mdk5.md
+++ b/content/learning-paths/embedded-and-microcontrollers/asm/setup_mdk5.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Setting up a Project in Keil MDK (μVision)"
+description: Create and configure a Keil MDK uVision project for the Cortex-M assembly examples.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/asm/setup_mdk6.md
+++ b/content/learning-paths/embedded-and-microcontrollers/asm/setup_mdk6.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Setting up a Project in Keil Studio (VS Code)" 
+description: Create a Keil Studio csolution project for the Cortex-M assembly examples and prepare it for mixed C and assembly code.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/avh_balena/2setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_balena/2setup.md
@@ -1,5 +1,6 @@
 ---
 title: "Prepare a custom Balena OS image"
+description: Create a Balena Cloud application and prepare a custom Balena OS image for a virtual Raspberry Pi 4 device.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/avh_balena/3install.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_balena/3install.md
@@ -1,5 +1,6 @@
 ---
 title: "Install Balena OS on AVH"
+description: Provision a Raspberry Pi 4 instance in Arm Virtual Hardware and install the custom Balena OS image on the virtual device.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/avh_balena/4deploy.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_balena/4deploy.md
@@ -1,5 +1,6 @@
 ---
 title: "Deploy an application to your device"
+description: Deploy an application from Balena Hub to the Arm Virtual Hardware device and verify that it runs in Balena Cloud.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/avh_greengrass/2setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_greengrass/2setup.md
@@ -1,5 +1,6 @@
 ---
 title: Set  up your accounts and create a virtual device
+description: Configure AWS and Arm Virtual Hardware accounts and create the virtual Raspberry Pi 4 device used as a Greengrass core.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/avh_greengrass/3deploy.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_greengrass/3deploy.md
@@ -1,5 +1,6 @@
 ---
 title: Deploy an AWS IoT Greengrass component to your device
+description: Create an AWS IoT Greengrass deployment and run a Greengrass component on the virtual Raspberry Pi 4 device.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/avh_matter/2setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_matter/2setup.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Prepare AVH instances of Raspberry Pi 4"
+description: Prepare two Raspberry Pi 4 instances in Arm Virtual Hardware for building and testing Matter examples.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/avh_matter/3build.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_matter/3build.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Build and run Matter examples on Arm Virtual Hardware"
+description: Build Matter reference examples on Arm Virtual Hardware and run device communication between the virtual Raspberry Pi instances.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/avh_matter/4cicdsh.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_matter/4cicdsh.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Manage development in a CI/CD workflow with Self-Hosted Runner"
+description: Configure a GitHub Actions self-hosted runner on Arm Virtual Hardware to automate Matter example builds and tests.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/avh_matter/5cicdapi.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_matter/5cicdapi.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Control Arm Virtual Hardware with API"
+description: Use the Arm Virtual Hardware API from GitHub Actions to create, control, and clean up virtual devices during Matter CI workflows.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/avh_ppocr/end-to-end_workflow.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_ppocr/end-to-end_workflow.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Deploy the PaddleOCR model"
+description: Compile and deploy the PaddleOCR model to the Corstone-300 FVP and run the end-to-end optical character recognition workflow.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/avh_ppocr/overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_ppocr/overview.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Overview of OCR"
+description: Review optical character recognition concepts and the PaddleOCR model workflow before deploying it on Arm Virtual Hardware.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/avh_vio/vio.md
+++ b/content/learning-paths/embedded-and-microcontrollers/avh_vio/vio.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Create a peripheral using Virtual Input/Output (VIO)"
+description: Create a virtual LED peripheral with Arm Virtual Hardware VIO and connect it to firmware running on the simulated platform.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/azure-iot/aggregation.md
+++ b/content/learning-paths/embedded-and-microcontrollers/azure-iot/aggregation.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Sensor Data Aggregation Using Azure Functions"
+description: Aggregate IoT telemetry with Azure Functions so sensor data from Arm devices can be summarized for downstream services.
 
 weight: 8
 

--- a/content/learning-paths/embedded-and-microcontrollers/azure-iot/device_registration.md
+++ b/content/learning-paths/embedded-and-microcontrollers/azure-iot/device_registration.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Build a Python-based IoT telemetry simulator"
+description: Build a Python telemetry simulator and register it as an Azure IoT device for sending sample sensor readings.
 
 weight: 4
 

--- a/content/learning-paths/embedded-and-microcontrollers/azure-iot/intro.md
+++ b/content/learning-paths/embedded-and-microcontrollers/azure-iot/intro.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Overview"
+description: Review the Azure IoT services and telemetry flow used to build an end-to-end cloud pipeline for Arm devices.
 
 weight: 2
 

--- a/content/learning-paths/embedded-and-microcontrollers/azure-iot/iot-hub.md
+++ b/content/learning-paths/embedded-and-microcontrollers/azure-iot/iot-hub.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Create Azure IoT Hub"
+description: Create an Azure IoT Hub and configure the device connection details needed for streaming telemetry from Arm devices.
 
 weight: 3
 

--- a/content/learning-paths/embedded-and-microcontrollers/azure-iot/monitoring.md
+++ b/content/learning-paths/embedded-and-microcontrollers/azure-iot/monitoring.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Set up data monitoring and alerts with Azure Functions"
+description: Set up Azure Functions based monitoring and alerts so incoming IoT telemetry can trigger automated responses.
 
 weight: 7
 

--- a/content/learning-paths/embedded-and-microcontrollers/azure-iot/portal.md
+++ b/content/learning-paths/embedded-and-microcontrollers/azure-iot/portal.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "IoT Portal"
+description: Create an IoT portal that visualizes telemetry from Azure services and gives users a dashboard for device data.
 
 weight: 9
 

--- a/content/learning-paths/embedded-and-microcontrollers/azure-iot/stream-analytics-dynamo-db.md
+++ b/content/learning-paths/embedded-and-microcontrollers/azure-iot/stream-analytics-dynamo-db.md
@@ -1,7 +1,7 @@
 ---
 # User change
 title: "Store data in Azure Cosmos DB with Azure Stream Analytics"
-description: Store processed telemetry in Azure Cosmos DB by configuring an Azure Stream Analytics output for the IoT pipeline.
+description: Store processed telemetry in Azure Cosmos DB by configuring an Azure Stream Analytics job for the IoT pipeline.
 
 weight: 6
 

--- a/content/learning-paths/embedded-and-microcontrollers/azure-iot/stream-analytics-dynamo-db.md
+++ b/content/learning-paths/embedded-and-microcontrollers/azure-iot/stream-analytics-dynamo-db.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Store data in Azure Cosmos DB with Azure Stream Analytics"
+description: Store processed telemetry in Azure Cosmos DB by configuring an Azure Stream Analytics output for the IoT pipeline.
 
 weight: 6
 

--- a/content/learning-paths/embedded-and-microcontrollers/azure-iot/stream-analytics.md
+++ b/content/learning-paths/embedded-and-microcontrollers/azure-iot/stream-analytics.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Process IoT telemetry in real time with Azure Stream Analytics"
+description: Configure Azure Stream Analytics to process IoT Hub telemetry in real time and route results to downstream services.
 
 weight: 5
 

--- a/content/learning-paths/embedded-and-microcontrollers/bare-metal/event-driven1.md
+++ b/content/learning-paths/embedded-and-microcontrollers/bare-metal/event-driven1.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Create event-driven application (1)
+description: Configure exception routing and the first interrupt handling pieces for an event-driven bare-metal Armv8-A application.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/bare-metal/event-driven2.md
+++ b/content/learning-paths/embedded-and-microcontrollers/bare-metal/event-driven2.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Create event-driven application (2)
+description: Set up the Generic Interrupt Controller and complete the event-driven Armv8-A application on the FVP.
 
 weight: 6 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/bare-metal/exception-levels.md
+++ b/content/learning-paths/embedded-and-microcontrollers/bare-metal/exception-levels.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Switching Exception Levels
+description: Modify the bare-metal example to switch Armv8-A exception levels and observe how execution changes on the FVP.
 
 weight: 7 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/bare-metal/hello.md
+++ b/content/learning-paths/embedded-and-microcontrollers/bare-metal/hello.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Create and build a Hello World example project
+description: Create and build a bare-metal Hello World project with Arm tools and run it on an Arm Fixed Virtual Platform.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/bare-metal/reset.md
+++ b/content/learning-paths/embedded-and-microcontrollers/bare-metal/reset.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Write a reset handler
+description: Write the reset handler for the bare-metal Armv8-A example so execution reaches the application entry point correctly.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/bare-metal/retarget.md
+++ b/content/learning-paths/embedded-and-microcontrollers/bare-metal/retarget.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Modify the example to use the UART for printf output"
+description: Retarget printf output to the UART so the bare-metal Armv8-A application can print messages from the FVP.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/avh-setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/avh-setup.md
@@ -1,5 +1,6 @@
 ---
 title: AVH device setup
+description: Set up the i.MX 8M Plus model in Arm Virtual Hardware for testing hybrid edge application deployment.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/build-runtime.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/build-runtime.md
@@ -1,5 +1,6 @@
 ---
 title: Building the hybrid-runtime and container image (optional)
+description: Build the hybrid-runtime and firmware container image used to run Cortex-M workloads from a Cortex-A Linux environment.
 weight: 7
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/containerd.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/containerd.md
@@ -1,5 +1,6 @@
 ---
 title: Deploy firmware container using `containerd`
+description: Deploy a firmware container with containerd and verify a Hello World workload on the hybrid edge runtime.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/k3s.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/k3s.md
@@ -1,5 +1,6 @@
 ---
 title: Deploy SMARTER Demo using K3s
+description: Deploy the SMARTER demo with K3s on Arm Virtual Hardware and verify container orchestration for the hybrid edge system.
 weight: 6
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/motivation.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/motivation.md
@@ -1,5 +1,6 @@
 ---
 title: Motivation
+description: Understand why hybrid-runtime enables cloud-native deployment of embedded workloads across Cortex-A and Cortex-M cores.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/runtime-overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cloud-native-deployment-on-hybrid-edge-systems/runtime-overview.md
@@ -1,5 +1,6 @@
 ---
 title: Hybrid container runtime
+description: Review the hybrid container runtime architecture and how it maps firmware containers to Arm edge hardware.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx/build_and_run.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx/build_and_run.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Build and run the application"
+description: Build and run the CMSIS-RTOS2 RTX application in Keil MDK and verify the thread behavior on the target.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx/create.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx/create.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Create and setup Keil MDK project"
+description: Create a Keil MDK project, install CMSIS packs, and configure the components needed for an RTX5 application.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx/eventrecorder.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx/eventrecorder.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Using Event Recorder"
+description: Enable Event Recorder for the RTX5 application so thread scheduling and runtime behavior can be inspected during debug.
 
 weight: 6 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx/initialize.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx/initialize.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Initialize the operating system"
+description: Initialize the CMSIS-RTOS2 kernel in the example application and start the main RTOS entry point.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx/threads.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx/threads.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Create RTOS threads"
+description: Create RTX5 threads with CMSIS-RTOS2 APIs and coordinate them in the embedded example application.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx_vs/build_and_run.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx_vs/build_and_run.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Build and run the application"
+description: Build and run the CMSIS-RTOS2 RTX application from Keil Studio for VS Code and verify the generated firmware.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx_vs/create.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx_vs/create.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Create csolution project"
+description: Create a csolution project in Keil Studio for VS Code and configure CMSIS components for an RTX5 application.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx_vs/initialize.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx_vs/initialize.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Initialize the Operating System"
+description: Initialize the CMSIS-RTOS2 kernel in the Keil Studio project and prepare the application startup code.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx_vs/threads.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsis_rtx_vs/threads.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Create RTOS Threads"
+description: Add RTX5 threads to the Keil Studio project using CMSIS-RTOS2 APIs and verify the multitasking flow.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-1.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-1.md
@@ -1,5 +1,6 @@
 ---
 title: CMSIS-DSP Python package
+description: Install and explore the CMSIS-DSP Python package so you can prototype signal processing algorithms before porting to C.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-2.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-2.md
@@ -1,5 +1,6 @@
 ---
 title: Set up environment 
+description: Create the Python environment and install the packages needed to develop and test CMSIS-DSP signal processing code.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-3.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-3.md
@@ -1,5 +1,6 @@
 ---
 title: Load an audio file
+description: Load and inspect an audio file in Python so it can be used as input for the CMSIS-DSP voice activity workflow.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-4.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-4.md
@@ -1,5 +1,6 @@
 ---
 title: Write a simple VAD
+description: Implement a simple voice activity detector in Python and validate the signal processing behavior before optimization.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-5.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-5.md
@@ -1,5 +1,6 @@
 ---
 title: Write a noise suppression algorithm
+description: Build a noise suppression algorithm in Python and understand the math that prepares it for embedded DSP implementation.
 weight: 6
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-6.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-6.md
@@ -1,5 +1,6 @@
 ---
 title: Write the CMSIS-DSP Q15 implementation
+description: Implement the voice activity detector with CMSIS-DSP Q15 functions and compare it with the Python prototype.
 weight: 7
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-7.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-7.md
@@ -1,5 +1,6 @@
 ---
 title: Convert the CMSIS-DSP Python to C
+description: Convert the CMSIS-DSP Python prototype to C so the algorithm can run efficiently on Arm embedded targets.
 weight: 8
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-8.md
+++ b/content/learning-paths/embedded-and-microcontrollers/cmsisdsp-dev-with-python/how-to-8.md
@@ -1,5 +1,6 @@
 ---
 title: Develop your knowledge
+description: Explore additional CMSIS-DSP resources and example projects to continue developing embedded signal processing skills.
 weight: 9
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/context-switch-cortex-m/example.md
+++ b/content/learning-paths/embedded-and-microcontrollers/context-switch-cortex-m/example.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Example Arm DS project to demonstrate context switching operations
+description: Explore the Arm Development Studio example project that demonstrates Cortex-M context switching with the MPU and SysTick exception.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/coverage_mdk/cc.md
+++ b/content/learning-paths/embedded-and-microcontrollers/coverage_mdk/cc.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "What is Code Coverage?"
+description: Understand code coverage concepts for embedded software testing and how they apply to Keil MDK projects.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/coverage_mdk/mdk.md
+++ b/content/learning-paths/embedded-and-microcontrollers/coverage_mdk/mdk.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Set up Code Coverage"
+description: Enable code coverage in Keil MDK, run the embedded example, and review the coverage results from the FVP.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/_index.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Device-to-Device communication with Device Connect
+description: Learn how to connect simulated edge devices directly with Device Connect and build a sensor-to-monitor workflow without cloud infrastructure.
 
 minutes_to_complete: 25
 

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/background.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/background.md
@@ -1,5 +1,6 @@
 ---
 title: Why device-to-device at the edge
+description: Understand when device-to-device communication is useful at the edge and how Device Connect supports local device workflows.
 weight: 2
 
 # FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/d2d-setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/d2d-setup.md
@@ -1,5 +1,6 @@
 ---
 title: Set up D2D communication between a sensor and a monitor
+description: Set up Device Connect for a simulated sensor and monitor so the devices can discover each other and exchange data locally.
 weight: 4
 
 # FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-d2d/overview.md
@@ -1,5 +1,6 @@
 ---
 title: Device Connect developer model
+description: Review the Device Connect Edge SDK developer model and how capabilities, devices, and applications interact.
 weight: 3
 
 # FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-server/background.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-server/background.md
@@ -1,5 +1,6 @@
 ---
 title: Learn when to use Device Connect server for multi-network deployments
+description: Understand when Device Connect server is useful for multi-network edge deployments and how it extends device-to-device workflows.
 weight: 2
 
 # FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-server/server-setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-server/server-setup.md
@@ -1,5 +1,6 @@
 ---
 title: Run devices and an orchestrating agent on a Device Connect server
+description: Provision Device Connect server credentials, run example devices, and connect an orchestrating agent across networks.
 weight: 3
 
 # FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-strands/background.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-strands/background.md
@@ -1,5 +1,6 @@
 ---
 title: Learn Device Connect and Strands architecture for edge devices
+description: Review the Device Connect and Strands architecture that lets AI agents discover and control edge devices.
 weight: 2
 
 # FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-strands/run-example.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-strands/run-example.md
@@ -1,5 +1,6 @@
 ---
 title: Run device discovery and agent control examples
+description: Run local Device Connect examples that demonstrate device discovery and agent control with simulated edge devices.
 weight: 4
 
 # FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-strands/run-infra-example.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-strands/run-infra-example.md
@@ -1,5 +1,6 @@
 ---
 title: Run with full Device Connect infrastructure (optional)
+description: Run the optional Device Connect infrastructure example to connect agents and devices through shared services.
 weight: 5
 
 # FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/device-connect-strands/setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/device-connect-strands/setup.md
@@ -1,5 +1,6 @@
 ---
 title: Set up the Device Connect and Strands developer environment
+description: Install the tools and dependencies needed to run Device Connect and Strands examples for edge device orchestration.
 weight: 3
 
 # FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/docker/dockerfile.md
+++ b/content/learning-paths/embedded-and-microcontrollers/docker/dockerfile.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Create Dockerfile and build docker image"
+description: Create a Dockerfile for Arm Compiler for Embedded and FVP tools, build the image, and test the containerized workflow.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/edge/connect-and-set-up-arduino.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge/connect-and-set-up-arduino.md
@@ -1,5 +1,6 @@
 ---
 title: Board connection and IDE setup
+description: Connect the Arduino Nano RP2040 board and configure the Arduino IDE so it is ready for TinyML deployment.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge/overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge/overview.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Review the Edge AI workflow for collecting audio data, training a model, and deploying it to an Arm microcontroller board.
 weight: 2
 
 # FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge/program-and-deployment.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge/program-and-deployment.md
@@ -1,5 +1,6 @@
 ---
 title: Program your first TinyML device
+description: Flash the TinyML firmware to the Arduino Nano RP2040 and verify that voice commands control the LEDs.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge/software-edge-impulse.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge/software-edge-impulse.md
@@ -1,5 +1,6 @@
 ---
 title: Train and deploy a TinyML audio classifier with Edge Impulse
+description: Use Edge Impulse to collect audio samples, train a TinyML classifier, and generate deployment code for the board.
 weight: 3
 
 # FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/cleanup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/cleanup.md
@@ -1,5 +1,6 @@
 ---
 title: Clean up AWS resources
+description: Remove AWS IoT Greengrass and related cloud resources created for the Edge Impulse deployment when the project is complete.
 weight: 11
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/customcomponentdeployment.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/customcomponentdeployment.md
@@ -1,5 +1,6 @@
 ---
 title: Deploy the component to your edge device
+description: Deploy the Edge Impulse Greengrass component to the selected Arm edge device and confirm the component is running.
 weight: 8
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/edgeimpulsecustomcomponentinstall.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/edgeimpulsecustomcomponentinstall.md
@@ -1,5 +1,6 @@
 ---
 title: Create the Edge Impulse Greengrass component
+description: Create the AWS IoT Greengrass custom component that installs and runs the Edge Impulse model on the edge device.
 weight: 7
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/edgeimpulseprojectbuild.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/edgeimpulseprojectbuild.md
@@ -1,5 +1,6 @@
 ---
 title: Set up your Edge Impulse project
+description: Create an Edge Impulse project, train the model, and prepare the deployment artifacts for AWS IoT Greengrass.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/greengrassinstallation.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/greengrassinstallation.md
@@ -1,5 +1,6 @@
 ---
 title: Install AWS IoT Greengrass
+description: Install AWS IoT Greengrass on the Arm edge device and configure the credentials needed for component deployment.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/hardwaresetup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/hardwaresetup.md
@@ -1,5 +1,6 @@
 ---
 title: Select and set up your edge device
+description: Choose an Arm edge platform and complete the hardware setup required for the Edge Impulse Greengrass workflow.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/hardwaresetupec2.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/hardwaresetupec2.md
@@ -1,5 +1,6 @@
 ---
 hide_from_navpane: true
+description: Launch an Ubuntu AWS EC2 Arm instance and install the dependencies needed to simulate an Edge Impulse Greengrass device.
 
 ### FIXED, DO NOT MODIFY
 layout: learningpathall

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/hardwaresetupnvidiajetson.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/hardwaresetupnvidiajetson.md
@@ -1,5 +1,6 @@
 ---
 hide_from_navpane: true
+description: Prepare an Nvidia Jetson device with JetPack and the dependencies required for Edge Impulse and AWS IoT Greengrass.
 
 ### FIXED, DO NOT MODIFY
 layout: learningpathall

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/hardwaresetupqc6490ubuntu.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/hardwaresetupqc6490ubuntu.md
@@ -1,5 +1,6 @@
 ---
 hide_from_navpane: true
+description: Set up a Qualcomm Dragonwing QC6490 board with Ubuntu and install the packages needed for Edge Impulse Greengrass.
 
 ### FIXED, DO NOT MODIFY
 layout: learningpathall

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/hardwaresetuprpi5.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/hardwaresetuprpi5.md
@@ -1,5 +1,6 @@
 ---
 hide_from_navpane: true
+description: Configure a Raspberry Pi 5 with Raspberry Pi OS and install the dependencies needed for Edge Impulse Greengrass deployment.
 
 ### FIXED, DO NOT MODIFY
 layout: learningpathall

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/noncameracustomcomponent.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/noncameracustomcomponent.md
@@ -1,5 +1,6 @@
 ---
 hide_from_navpane: true
+description: Create a non-camera Greengrass component that provides sample images to the Edge Impulse runner on devices without cameras.
 
 ### FIXED, DO NOT MODIFY
 layout: learningpathall

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/overview.md
@@ -1,5 +1,6 @@
 ---
 title: Overview of Edge Impulse and AWS IoT Greengrass
+description: Understand how Edge Impulse models are packaged as AWS IoT Greengrass components for deployment to Arm-based edge devices.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/running.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/running.md
@@ -1,5 +1,6 @@
 ---
 title: Verify inference and view results
+description: Verify that the deployed Edge Impulse model runs on the edge device and view live inference results in the browser.
 weight: 9
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/secretmanagersetup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/secretmanagersetup.md
@@ -1,5 +1,6 @@
 ---
 title: Store your API key in AWS Secrets Manager
+description: Store the Edge Impulse API key in AWS Secrets Manager so Greengrass components can access it securely.
 weight: 6
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/summary.md
+++ b/content/learning-paths/embedded-and-microcontrollers/edge_impulse_greengrass/summary.md
@@ -1,5 +1,6 @@
 ---
 title: Command and metrics reference
+description: Review the commands, metrics, and configuration values used throughout the Edge Impulse Greengrass deployment.
 weight: 10
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/img_nn_stcube/build_nn.md
+++ b/content/learning-paths/embedded-and-microcontrollers/img_nn_stcube/build_nn.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Build an image classification NN model trained with the CIFAR-10 dataset
+description: Train an image classification model with the CIFAR-10 dataset and prepare it for deployment with STM32 tools.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/img_nn_stcube/deploy_nn.md
+++ b/content/learning-paths/embedded-and-microcontrollers/img_nn_stcube/deploy_nn.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Deploy the image classification NN model on STM32
+description: Import the trained image classification model into STM32CubeMX and generate code for the STM32 board.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/img_nn_stcube/run_nn.md
+++ b/content/learning-paths/embedded-and-microcontrollers/img_nn_stcube/run_nn.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Run the image classification NN model on STM32
+description: Run the image classification model on the STM32 development board and verify inference results from the deployed firmware.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/img_nn_stcube/setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/img_nn_stcube/setup.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Prepare environment
+description: Install Anaconda and the required Python packages for building and deploying the STM32 image classification model.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/intro/background.md
+++ b/content/learning-paths/embedded-and-microcontrollers/intro/background.md
@@ -1,6 +1,7 @@
 ---
 layout: learningpathall
 title: Arm in Microcontrollers
+description: Understand how Arm Cortex-M processors are used in microcontrollers and where they fit in embedded system design.
 weight: 2
 ---
 

--- a/content/learning-paths/embedded-and-microcontrollers/intro/find-hardware.md
+++ b/content/learning-paths/embedded-and-microcontrollers/intro/find-hardware.md
@@ -1,6 +1,7 @@
 ---
 layout: learningpathall
 title: Find Arm hardware
+description: Identify Arm-based microcontroller development boards and choose hardware for embedded software projects.
 weight: 3
 ---
 

--- a/content/learning-paths/embedded-and-microcontrollers/intro/resources.md
+++ b/content/learning-paths/embedded-and-microcontrollers/intro/resources.md
@@ -1,6 +1,7 @@
 ---
 layout: learningpathall
 title: Other learning resources
+description: Find additional Arm microcontroller documentation, courses, and examples to continue embedded software learning.
 weight: 4
 ---
 ## Reading resources

--- a/content/learning-paths/embedded-and-microcontrollers/introduction-to-tinyml-on-arm/1-overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/introduction-to-tinyml-on-arm/1-overview.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Review TinyML concepts, Arm-based edge devices, and the ExecuTorch workflow used in the rest of the Learning Path.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/introduction-to-tinyml-on-arm/2-env-setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/introduction-to-tinyml-on-arm/2-env-setup.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Install ExecuTorch"
+description: Install ExecuTorch and its dependencies so you can convert and run PyTorch models for TinyML on Arm targets.
 
 weight: 3
 

--- a/content/learning-paths/embedded-and-microcontrollers/introduction-to-tinyml-on-arm/3-env-setup-fvp.md
+++ b/content/learning-paths/embedded-and-microcontrollers/introduction-to-tinyml-on-arm/3-env-setup-fvp.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Set up the Corstone-320 FVP"
+description: Install and configure the Corstone-320 Fixed Virtual Platform for running TinyML examples without physical hardware.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/introduction-to-tinyml-on-arm/4-build-model.md
+++ b/content/learning-paths/embedded-and-microcontrollers/introduction-to-tinyml-on-arm/4-build-model.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Build a simple PyTorch model"
+description: Build a small PyTorch model and prepare it for ExecuTorch deployment on the Corstone-320 FVP.
 
 weight: 7 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/iot-sdk/aws.md
+++ b/content/learning-paths/embedded-and-microcontrollers/iot-sdk/aws.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Enable AWS connectivity
+description: Enable AWS connectivity in the Open-IoT-SDK example so the application can communicate with AWS IoT services.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/iot-sdk/openiot.md
+++ b/content/learning-paths/embedded-and-microcontrollers/iot-sdk/openiot.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Build and run Open-IoT-SDK examples
+description: Build Open-IoT-SDK examples and run them on Arm Virtual Hardware to validate the IoT software stack.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/jetson_object_detection/2setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/jetson_object_detection/2setup.md
@@ -1,5 +1,6 @@
 ---
 title: Set up your Jetson Orin Nano
+description: Prepare the Jetson Orin Nano hardware, camera, and software environment for image classification and object detection.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/jetson_object_detection/3docker.md
+++ b/content/learning-paths/embedded-and-microcontrollers/jetson_object_detection/3docker.md
@@ -1,5 +1,6 @@
 ---
 title: Launch the image classification Docker container
+description: Download and run the image classification Docker container on Jetson Orin Nano to test the accelerated inference setup.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/jetson_object_detection/4object.md
+++ b/content/learning-paths/embedded-and-microcontrollers/jetson_object_detection/4object.md
@@ -1,5 +1,6 @@
 ---
 title: Detect objects in video and images
+description: Run object detection on images and live video with Jetson Orin Nano and verify DetectNet output.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/keilstudiocloud/2build.md
+++ b/content/learning-paths/embedded-and-microcontrollers/keilstudiocloud/2build.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Work with an example project"
+description: Import an example project into Keil Studio Cloud, build it, and run a basic debug session in the browser.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/linux-nxp-board/1-overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/linux-nxp-board/1-overview.md
@@ -1,5 +1,6 @@
 ---
 title: Set up the board
+description: Boot and inspect the NXP FRDM i.MX 93 board so it is ready for Linux-based ML development on Arm.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/linux-nxp-board/3-create-super-user.md
+++ b/content/learning-paths/embedded-and-microcontrollers/linux-nxp-board/3-create-super-user.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Set up a Linux user and connect to WiFi"
+description: Create a non-root Linux user with sudo access and configure WiFi connectivity on the NXP FRDM i.MX 93 board.
 
 weight: 3
 

--- a/content/learning-paths/embedded-and-microcontrollers/linux-nxp-board/4-enable-wifi.md
+++ b/content/learning-paths/embedded-and-microcontrollers/linux-nxp-board/4-enable-wifi.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Transfer files to the board"
+description: Transfer files to the NXP FRDM i.MX 93 board over the network using WiFi and secure copy.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/linux-nxp-board/7-enable-persistent-wifi.md
+++ b/content/learning-paths/embedded-and-microcontrollers/linux-nxp-board/7-enable-persistent-wifi.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "(Optional) Enable Persistent WiFi"
+description: Configure persistent WiFi on the NXP FRDM i.MX 93 board so networking reconnects after reboot.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/linux-on-fvp/debug.md
+++ b/content/learning-paths/embedded-and-microcontrollers/linux-on-fvp/debug.md
@@ -1,5 +1,6 @@
 ---
 title: Debug the software stack
+description: Use Arm Development Studio to debug Trusted Firmware-A and the Linux kernel while the software stack runs on an FVP.
 weight: 6
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/linux-on-fvp/intro.md
+++ b/content/learning-paths/embedded-and-microcontrollers/linux-on-fvp/intro.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to Arm Fixed Virtual Platforms (FVPs)
+description: Understand Arm Fixed Virtual Platforms and how they support Linux software development before hardware is available.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/linux-on-fvp/modify.md
+++ b/content/learning-paths/embedded-and-microcontrollers/linux-on-fvp/modify.md
@@ -1,5 +1,6 @@
 ---
 title: Modify the device tree for CPU FVPs
+description: Update the device tree so the Linux software stack matches the selected Arm CPU FVP model.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/linux-on-fvp/run.md
+++ b/content/learning-paths/embedded-and-microcontrollers/linux-on-fvp/run.md
@@ -1,5 +1,6 @@
 ---
 title: Run the Linux software stack on an FVP
+description: Launch the Linux software stack on an Arm FVP and verify that the virtual platform boots successfully.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/linux-on-fvp/steps.md
+++ b/content/learning-paths/embedded-and-microcontrollers/linux-on-fvp/steps.md
@@ -1,5 +1,6 @@
 ---
 title: Configure Trusted Firmware-A build flags to include cpu_ops support
+description: Configure Trusted Firmware-A build flags for cpu_ops support and rebuild the Linux software stack for the FVP.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/llama-python-cpu/llama-python-chatbot.md
+++ b/content/learning-paths/embedded-and-microcontrollers/llama-python-cpu/llama-python-chatbot.md
@@ -1,5 +1,6 @@
 ---
 title: Run a Large Language Model (LLM) chatbot on a Raspberry Pi 5
+description: Install llama.cpp Python bindings on Raspberry Pi 5, download an LLM, and run an interactive chatbot locally.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/migration/2_porting_methodology.md
+++ b/content/learning-paths/embedded-and-microcontrollers/migration/2_porting_methodology.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Porting methodology" 
+description: Apply a structured porting methodology for moving Linux applications from x86_64 to Arm AArch64.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/migration/3_porting_analysis.md
+++ b/content/learning-paths/embedded-and-microcontrollers/migration/3_porting_analysis.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Porting analysis" 
+description: Analyze source code, dependencies, and build settings to identify issues before porting an application to Arm.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/migration/4_development_environment.md
+++ b/content/learning-paths/embedded-and-microcontrollers/migration/4_development_environment.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Development environment" 
+description: Set up the compilers, libraries, and tools needed to build and test the application on Arm Linux.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/migration/5_application_porting.md
+++ b/content/learning-paths/embedded-and-microcontrollers/migration/5_application_porting.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Application porting" 
+description: Port application code to Arm by addressing architecture assumptions, compiler intrinsics, and build configuration differences.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/migration/6_run_evaluate.md
+++ b/content/learning-paths/embedded-and-microcontrollers/migration/6_run_evaluate.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Run and evaluate" 
+description: Run the ported application on Arm, evaluate behavior and performance, and compare results with the original environment.
 
 weight: 6 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/migration/7_alternative.md
+++ b/content/learning-paths/embedded-and-microcontrollers/migration/7_alternative.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Evaluating performance on Arm hardware (Optional)" 
+description: Optionally evaluate the ported workload on Arm hardware and use the results to guide further optimization.
 
 weight: 7 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/mlek/build.md
+++ b/content/learning-paths/embedded-and-microcontrollers/mlek/build.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Build the ML Evaluation Kit examples"
+description: Build ML Evaluation Kit examples for the selected target so they are ready to run on Arm virtual hardware.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/mlek/fvp.md
+++ b/content/learning-paths/embedded-and-microcontrollers/mlek/fvp.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Install Arm Ecosystem FVP"
+description: Install the Arm Ecosystem FVP and configure it as the execution target for ML Evaluation Kit examples.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/mlek/run.md
+++ b/content/learning-paths/embedded-and-microcontrollers/mlek/run.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Run the examples on the FVP"
+description: Run ML Evaluation Kit examples on the Arm Ecosystem FVP and inspect the model output.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/nav-mlek/intro.md
+++ b/content/learning-paths/embedded-and-microcontrollers/nav-mlek/intro.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Review ML Evaluation Kit concepts and the Arm hardware options available for embedded machine learning development.
 
 weight: 2
 

--- a/content/learning-paths/embedded-and-microcontrollers/nav-mlek/platforms.md
+++ b/content/learning-paths/embedded-and-microcontrollers/nav-mlek/platforms.md
@@ -1,5 +1,6 @@
 ---
 title: Development platforms
+description: Compare physical boards and virtual platforms for developing Cortex-M and Ethos-U machine learning applications.
 
 weight: 3
 

--- a/content/learning-paths/embedded-and-microcontrollers/nav-mlek/sw.md
+++ b/content/learning-paths/embedded-and-microcontrollers/nav-mlek/sw.md
@@ -1,5 +1,6 @@
 ---
 title: Software development considerations
+description: Review software development tools, model formats, and example applications used with the ML Evaluation Kit.
 
 weight: 4
 

--- a/content/learning-paths/embedded-and-microcontrollers/new_debug_targets_armds/dstream.md
+++ b/content/learning-paths/embedded-and-microcontrollers/new_debug_targets_armds/dstream.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Debug connection with Arm DSTREAM
+description: Create an Arm Development Studio debug connection for a hardware target using a DSTREAM debug probe.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/new_debug_targets_armds/fastmodels.md
+++ b/content/learning-paths/embedded-and-microcontrollers/new_debug_targets_armds/fastmodels.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Debug connection to Arm Fast Models
+description: Create an Arm Development Studio debug connection for Arm Fast Models and verify the virtual target setup.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/1-overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/1-overview.md
@@ -1,5 +1,6 @@
 ---
 title: Understand ExecuTorch deployment on NXP with Ethos-U
+description: Understand the ExecuTorch and Ethos-U deployment flow used to run accelerated inference on the NXP FRDM i.MX 93 board.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/10-deploy-executorchrunner-nxp-board.md
+++ b/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/10-deploy-executorchrunner-nxp-board.md
@@ -1,5 +1,6 @@
 ---
 title: Deploy and test on FRDM-IMX93
+description: Deploy the ExecuTorch runner to the NXP FRDM i.MX 93 board and test inference on the Cortex-M33 with Ethos-U acceleration.
 weight: 11
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/2-boot-nxp.md
+++ b/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/2-boot-nxp.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Boot the NXP FRDM i.MX 93 board"
+description: Connect to the NXP FRDM i.MX 93 board, boot Linux, and verify the board is ready for ExecuTorch deployment.
 
 weight: 3
 

--- a/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/4-environment-setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/4-environment-setup.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Set up the ExecuTorch build environment"
+description: Set up the ExecuTorch build environment for the NXP workflow using Docker or a native Linux host.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/6-build-executorch.md
+++ b/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/6-build-executorch.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Build and install ExecuTorch"
+description: Build and install ExecuTorch components needed to generate and run models for the NXP FRDM i.MX 93 target.
 
 weight: 7 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/7-build-executorch-pte.md
+++ b/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/7-build-executorch-pte.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Build ExecuTorch models for Ethos-U65"
+description: Compile ExecuTorch model artifacts for Ethos-U65 so they can run with NPU acceleration on the NXP board.
 
 weight: 8 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/9-build-executorch-runner-for-cm33.md
+++ b/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/9-build-executorch-runner-for-cm33.md
@@ -1,5 +1,6 @@
 ---
 title: Build Cortex-M33 firmware for ExecuTorch
+description: Build Cortex-M33 firmware that runs the ExecuTorch executor runner on the NXP FRDM i.MX 93 board.
 weight: 10
 # FIXED, DO NOT MODIFY
 layout: learningpathall

--- a/content/learning-paths/embedded-and-microcontrollers/pack-migration-cmsis-v6/device_support.md
+++ b/content/learning-paths/embedded-and-microcontrollers/pack-migration-cmsis-v6/device_support.md
@@ -1,5 +1,6 @@
 ---
 title: Device support
+description: Review CMSIS-Pack device support changes needed when migrating device packs from CMSIS v5 to CMSIS v6.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/pack-migration-cmsis-v6/example_projects.md
+++ b/content/learning-paths/embedded-and-microcontrollers/pack-migration-cmsis-v6/example_projects.md
@@ -1,5 +1,6 @@
 ---
 title: Example projects
+description: Update CMSIS-Pack example projects so they remain compatible after migrating the pack to CMSIS v6.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/pqc_pqm4/adding-new-schemes.md
+++ b/content/learning-paths/embedded-and-microcontrollers/pqc_pqm4/adding-new-schemes.md
@@ -1,5 +1,6 @@
 ---
 title: Add a KEM implementation to pqm4
+description: Add a new key encapsulation mechanism implementation to pqm4 and integrate it with the Cortex-M4 benchmark framework.
 
 weight: 5
 

--- a/content/learning-paths/embedded-and-microcontrollers/pqc_pqm4/introduction.md
+++ b/content/learning-paths/embedded-and-microcontrollers/pqc_pqm4/introduction.md
@@ -1,5 +1,6 @@
 ---
 title: Understand pqm4 and post-quantum cryptography
+description: Understand pqm4, post-quantum cryptography, and how the library benchmarks algorithms on Arm Cortex-M4.
 weight: 2
 layout: learningpathall
 ---

--- a/content/learning-paths/embedded-and-microcontrollers/pqc_pqm4/running-tests-and-benchmarks.md
+++ b/content/learning-paths/embedded-and-microcontrollers/pqc_pqm4/running-tests-and-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: Run pqm4 tests and benchmarks
+description: Build and run pqm4 tests and benchmarks to measure post-quantum cryptography implementations on Cortex-M4.
 
 weight: 4
 

--- a/content/learning-paths/embedded-and-microcontrollers/pqc_pqm4/setup-installation.md
+++ b/content/learning-paths/embedded-and-microcontrollers/pqc_pqm4/setup-installation.md
@@ -1,5 +1,6 @@
 ---
 title: Set up the pqm4 development environment
+description: Install the dependencies and toolchains needed to build and test pqm4 post-quantum cryptography examples.
 
 weight: 3
 

--- a/content/learning-paths/embedded-and-microcontrollers/project-migration-cmsis-v6/device_mapping.md
+++ b/content/learning-paths/embedded-and-microcontrollers/project-migration-cmsis-v6/device_mapping.md
@@ -1,5 +1,6 @@
 ---
 title: Device mapping
+description: Map legacy device identifiers to CMSIS v6 device definitions so migrated projects select the correct target.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/project-migration-cmsis-v6/packs.md
+++ b/content/learning-paths/embedded-and-microcontrollers/project-migration-cmsis-v6/packs.md
@@ -1,5 +1,6 @@
 ---
 title: Required CMSIS-Packs
+description: Identify and install the CMSIS-Packs required to migrate a CMSIS v5 project to CMSIS v6.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/project-migration-cmsis-v6/project_format.md
+++ b/content/learning-paths/embedded-and-microcontrollers/project-migration-cmsis-v6/project_format.md
@@ -1,5 +1,6 @@
 ---
 title: Project format conversion
+description: Convert a legacy CMSIS project format to the CMSIS v6 csolution structure used by modern tools.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/project-migration-cmsis-v6/toolchains.md
+++ b/content/learning-paths/embedded-and-microcontrollers/project-migration-cmsis-v6/toolchains.md
@@ -1,5 +1,6 @@
 ---
 title: Supported toolchains
+description: Review supported toolchains for CMSIS v6 project migration and select the compiler configuration for the target.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/project-migration-cmsis-v6/troubleshooting.md
+++ b/content/learning-paths/embedded-and-microcontrollers/project-migration-cmsis-v6/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+description: Resolve common CMSIS v6 migration issues related to packs, devices, project format, and toolchain settings.
 weight: 6
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/raspberry-pi-smart-home/1-overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/raspberry-pi-smart-home/1-overview.md
@@ -1,5 +1,6 @@
 ---
 title: Run LLMs locally on Raspberry Pi 5 for Edge AI
+description: Review the Raspberry Pi 5 smart home architecture and how local LLMs can control GPIO-connected devices.
 
 weight: 2
 

--- a/content/learning-paths/embedded-and-microcontrollers/raspberry-pi-smart-home/2-software-dependencies.md
+++ b/content/learning-paths/embedded-and-microcontrollers/raspberry-pi-smart-home/2-software-dependencies.md
@@ -1,5 +1,6 @@
 ---
 title: Set up software dependencies on Raspberry Pi 5 for Ollama and LLMs
+description: Install Ollama, Python dependencies, and supporting software for running local LLM smart home workloads on Raspberry Pi 5.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/raspberry-pi-smart-home/3-test-gpio.md
+++ b/content/learning-paths/embedded-and-microcontrollers/raspberry-pi-smart-home/3-test-gpio.md
@@ -1,5 +1,6 @@
 ---
 title: Test Raspberry Pi 5 GPIO pins for smart home devices
+description: Test Raspberry Pi 5 GPIO outputs with connected devices so the smart home assistant can control hardware reliably.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/raspberry-pi-smart-home/4-smart-home-assistant.md
+++ b/content/learning-paths/embedded-and-microcontrollers/raspberry-pi-smart-home/4-smart-home-assistant.md
@@ -1,5 +1,6 @@
 ---
 title: Build and Run a Smart Home Assistant on Raspberry Pi 5 with LLMs
+description: Build and run the web-based Raspberry Pi 5 smart home assistant that uses a local LLM to control GPIO devices.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/raspberry_pi_chatgpt_bot/2setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/raspberry_pi_chatgpt_bot/2setup.md
@@ -1,5 +1,6 @@
 ---
 title: Initial setup
+description: Install Raspberry Pi OS and configure the packages needed to build the voice-controlled ChatGPT bot.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/raspberry_pi_chatgpt_bot/3audio.md
+++ b/content/learning-paths/embedded-and-microcontrollers/raspberry_pi_chatgpt_bot/3audio.md
@@ -1,5 +1,6 @@
 ---
 title: Configure and test audio
+description: Configure and test the Raspberry Pi microphone and speakers so the bot can capture speech and play responses.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/raspberry_pi_chatgpt_bot/4python-code.md
+++ b/content/learning-paths/embedded-and-microcontrollers/raspberry_pi_chatgpt_bot/4python-code.md
@@ -1,5 +1,6 @@
 ---
 title: Create the Python application
+description: Create the Python application that detects a wake word, sends speech input to ChatGPT, and plays audio output.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/raspberry_pi_chatgpt_bot/5run.md
+++ b/content/learning-paths/embedded-and-microcontrollers/raspberry_pi_chatgpt_bot/5run.md
@@ -1,5 +1,6 @@
 ---
 title: Run and test the bot
+description: Run the Raspberry Pi ChatGPT bot and test the complete voice interaction workflow.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/rpi-llama3/dev-env.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi-llama3/dev-env.md
@@ -1,5 +1,6 @@
 ---
 title: Set up the development environment
+description: Set up an Arm Linux development machine with the tools required to build Llama 3 for ExecuTorch.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/rpi-llama3/executorch.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi-llama3/executorch.md
@@ -1,5 +1,6 @@
 ---
 title: Set up ExecuTorch
+description: Install and configure ExecuTorch so the Llama 3 model can be compiled for Raspberry Pi 5.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/rpi-llama3/llama3.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi-llama3/llama3.md
@@ -1,5 +1,6 @@
 ---
 title: Set up Llama 3
+description: Download and prepare the Llama 3 model assets needed for the ExecuTorch deployment workflow.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/rpi-llama3/run.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi-llama3/run.md
@@ -1,5 +1,6 @@
 ---
 title: Run the model on a Raspberry Pi 5
+description: Deploy the compiled Llama 3 model to Raspberry Pi 5 and run local inference on the device.
 weight: 6
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/build.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/build.md
@@ -1,5 +1,4 @@
- ---
-# User change
+---
 title: "Build MXNet"
 
 weight: 3

--- a/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/build.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/build.md
@@ -1,5 +1,6 @@
 ---
 title: "Build MXNet"
+description: Build and install MXNet inside the Raspberry Pi OS file system on an Arm server, then verify the Python package before deployment.
 
 weight: 3
 
@@ -105,4 +106,3 @@ Building MXNet takes about 20 minutes on an AWS c6g.2xlarge EC2 instance.
 A native build on a Raspberry Pi 4 can be done using the steps above. Setting the number of jobs too high will result in out of memory failures. With `-j4` and the build fails, even on a Raspberry Pi with Gb RAM. With `-j1` the build completes, but takes over 6 hours.
 
 Continue to the next section to download the new image and install it on a Raspberry Pi for testing. 
-

--- a/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/deploy.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/deploy.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Install on Raspberry Pi"
+description: Copy the Raspberry Pi OS image with MXNet to a local machine, write it to an SD card, and verify MXNet on a Raspberry Pi.
 
 weight: 4
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/deploy.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/deploy.md
@@ -1,4 +1,4 @@
- ---
+---
 # User change
 title: "Install on Raspberry Pi"
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/setup.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Install a Raspberry Pi OS file system"
+description: Prepare a Raspberry Pi OS image on an Arm Linux server by resizing, mounting, and entering the file system with chroot for an MXNet build.
 
 weight: 2
 
@@ -160,4 +161,3 @@ sudo chroot /mnt /bin/bash
 The bash shell is now inside the Raspberry Pi file system. It runs as if this is a Raspberry Pi and the file system is the same as if it was being done on a Raspberry Pi board. 
 
 Continue to the next section to build MXNet, an example C++ application. 
-

--- a/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi-mxnet/setup.md
@@ -1,4 +1,4 @@
- ---
+---
 # User change
 title: "Install a Raspberry Pi OS file system"
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi/docker.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi/docker.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Docker"
+description: Install Docker on Raspberry Pi 4 and run a containerized workload to validate the Arm Linux environment.
 
 weight: 7 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi/id.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi/id.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Identifying the hardware"
+description: Identify Raspberry Pi 4 hardware details and system information before running software and performance examples.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi/intro.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi/intro.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Introduction to the Raspberry Pi 4" 
+description: Review Raspberry Pi 4 hardware specifications and setup considerations for Arm software development.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi/kernel.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi/kernel.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Linux Kernel Compile"
+description: Compile the Linux kernel for Raspberry Pi 4 and compare build behavior with an Arm cloud instance.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi/perf.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi/perf.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Linux Perf"
+description: Use Linux perf on Raspberry Pi 4 to collect performance data from Arm workloads.
 
 weight: 8 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi/setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi/setup.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Setup a Raspberry Pi 4 and an Arm cloud instance" 
+description: Set up Raspberry Pi 4 and an Arm cloud instance so you can compare local and remote Arm development workflows.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi/tf.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi/tf.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "TensorFlow"
+description: Install and run TensorFlow on Raspberry Pi 4 to test machine learning workloads on Arm hardware.
 
 weight: 6 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi_pico/debug.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi_pico/debug.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "How do I debug RPi Pico applications?"
+description: Connect debug wiring for Raspberry Pi Pico applications and use the debugger to inspect firmware execution.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi_pico/hello.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi_pico/hello.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "How do I run Hello World for Raspberry Pi Pico?"
+description: Build and run the Hello World example for Raspberry Pi Pico to verify the SDK and board setup.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi_pico/perf.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi_pico/perf.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "How do I measure RPi Pico Application Performance?"
+description: Build a Raspberry Pi Pico application and measure its execution performance on the microcontroller.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/rpi_pico/sdk.md
+++ b/content/learning-paths/embedded-and-microcontrollers/rpi_pico/sdk.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "How do I install the Raspberry Pi Pico SDK?"
+description: Install the Raspberry Pi Pico SDK and configure the tools needed to build Pico applications.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/1_overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/1_overview.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Linux kernel modules with Arm Streamline
+description: Review the Arm Streamline kernel module profiling workflow and the Linux targets used for performance analysis.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/2_build_kernel_image.md
+++ b/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/2_build_kernel_image.md
@@ -1,5 +1,6 @@
 ---
 title: Set up your environment 
+description: Build a Linux image with Buildroot so the target environment can run kernel module profiling examples.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/3_oot_module.md
+++ b/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/3_oot_module.md
@@ -1,5 +1,6 @@
 ---
 title: Build the out-of-tree kernel module
+description: Create and build an out-of-tree Linux kernel module designed to expose cache-unfriendly behavior for Streamline analysis.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/4_sl_profile_oot.md
+++ b/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/4_sl_profile_oot.md
@@ -1,5 +1,6 @@
 ---
 title: Profile the out-of-tree kernel module
+description: Profile the out-of-tree kernel module with Arm Streamline and inspect the performance bottlenecks it exposes.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/5_intree_kernel_driver.md
+++ b/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/5_intree_kernel_driver.md
@@ -1,5 +1,6 @@
 ---
 title: Integrate a custom character device driver into the Linux kernel
+description: Integrate a custom character device driver into the Linux kernel so it can be profiled as an in-tree module.
 weight: 6
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/6_sl_profile_intree.md
+++ b/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/6_sl_profile_intree.md
@@ -1,5 +1,6 @@
 ---
 title: Profile the in-tree kernel driver
+description: Profile the in-tree kernel driver with Arm Streamline and compare results with the out-of-tree module workflow.
 weight: 7
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/7_sl_spe.md
+++ b/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/7_sl_spe.md
@@ -1,5 +1,6 @@
 ---
 title: Use Streamline with the Statistical Profiling Extension
+description: Use Arm Streamline with Statistical Profiling Extension data to analyze Linux workload behavior in more detail.
 weight: 8
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/8_summary.md
+++ b/content/learning-paths/embedded-and-microcontrollers/streamline-kernel-module/8_summary.md
@@ -1,5 +1,6 @@
 ---
 title: Summary
+description: Summarize the kernel module profiling workflow and the Streamline techniques used to analyze Linux drivers.
 weight: 9
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/tflow_nn_stcube/features.md
+++ b/content/learning-paths/embedded-and-microcontrollers/tflow_nn_stcube/features.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Feature extraction
+description: Extract features from captured training data so the TensorFlow model can learn the letter recognition task.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/tflow_nn_stcube/run_nn.md
+++ b/content/learning-paths/embedded-and-microcontrollers/tflow_nn_stcube/run_nn.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Run the model on development board
+description: Deploy the trained TensorFlow model to the STM32 development board and run inference from the generated firmware.
 
 weight: 6 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/tflow_nn_stcube/setup.md
+++ b/content/learning-paths/embedded-and-microcontrollers/tflow_nn_stcube/setup.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Prepare development environment
+description: Install Anaconda and prepare the Python environment for training and deploying the STM32 TensorFlow model.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/tflow_nn_stcube/test.md
+++ b/content/learning-paths/embedded-and-microcontrollers/tflow_nn_stcube/test.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Train the model
+description: Create and train the TensorFlow model used for letter recognition before deploying it to the STM32 board.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/tflow_nn_stcube/train_nn.md
+++ b/content/learning-paths/embedded-and-microcontrollers/tflow_nn_stcube/train_nn.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Collect training data
+description: Collect training data for the letter recognition model and prepare it for TensorFlow feature extraction.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/tfm/tfm.md
+++ b/content/learning-paths/embedded-and-microcontrollers/tfm/tfm.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Build and run TF-M tests and example application"
+description: Build and run Trusted Firmware-M tests and the reference application on an Arm Fixed Virtual Platform.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/training-inference-pytorch/env-setup-1.md
+++ b/content/learning-paths/embedded-and-microcontrollers/training-inference-pytorch/env-setup-1.md
@@ -1,5 +1,6 @@
 ---
 title: Set up your environment 
+description: Install the tools and Python dependencies needed to train and deploy the tiny rock-paper-scissors model on Arm.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/training-inference-pytorch/fine-tune-2.md
+++ b/content/learning-paths/embedded-and-microcontrollers/training-inference-pytorch/fine-tune-2.md
@@ -1,5 +1,6 @@
 ---
 title: Train and Test the rock-paper-scissors Model
+description: Train and test the PyTorch rock-paper-scissors classifier before converting it for embedded inference.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/training-inference-pytorch/fvp-3.md
+++ b/content/learning-paths/embedded-and-microcontrollers/training-inference-pytorch/fvp-3.md
@@ -1,5 +1,6 @@
 ---
 title: Run the model on Corstone-320 FVP
+description: Compile the rock-paper-scissors model for ExecuTorch and run it on the Corstone-320 Fixed Virtual Platform.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/trustzone_nxp_lpc/hello.md
+++ b/content/learning-paths/embedded-and-microcontrollers/trustzone_nxp_lpc/hello.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Run TrustZone Hello World example"
+description: Build and run the TrustZone Hello World example on the NXP LPCXpresso55S69 board with Keil MDK.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/trustzone_nxp_lpc/trustzone_concepts.md
+++ b/content/learning-paths/embedded-and-microcontrollers/trustzone_nxp_lpc/trustzone_concepts.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Breaking down the application"
+description: Understand the secure and non-secure application flow used by the TrustZone example on the NXP board.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/universal-sbc-chassis/bay-assembly.md
+++ b/content/learning-paths/embedded-and-microcontrollers/universal-sbc-chassis/bay-assembly.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Assembly Instructions for the Chassis Bays
+description: Assemble the 3D-printed chassis bays used to mount single board computers in the universal SBC rack system.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/universal-sbc-chassis/card-plate-assembly.md
+++ b/content/learning-paths/embedded-and-microcontrollers/universal-sbc-chassis/card-plate-assembly.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Assembly Instructions for the Chassis Bays
+description: Assemble the card plates that hold single board computers within the universal SBC chassis.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/universal-sbc-chassis/print-parts.md
+++ b/content/learning-paths/embedded-and-microcontrollers/universal-sbc-chassis/print-parts.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: Print the Required Parts
+description: Print the required 3D parts for the universal SBC chassis and prepare them for assembly.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/uv_debug/2_basics.md
+++ b/content/learning-paths/embedded-and-microcontrollers/uv_debug/2_basics.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Use basic run/stop debug"
+description: Use basic run and stop debugging in Keil uVision to inspect an embedded application on the target.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/uv_debug/3_event_recorder.md
+++ b/content/learning-paths/embedded-and-microcontrollers/uv_debug/3_event_recorder.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Debug using Event Recorder"
+description: Use Event Recorder in Keil uVision to capture and analyze runtime events from an embedded application.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/uv_debug/4_swv.md
+++ b/content/learning-paths/embedded-and-microcontrollers/uv_debug/4_swv.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Debug using Serial Wire Viewer"
+description: Use Serial Wire Viewer in Keil uVision to observe trace data from a running Cortex-M application.
 
 weight: 4 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/uv_debug/5_etm_trace.md
+++ b/content/learning-paths/embedded-and-microcontrollers/uv_debug/5_etm_trace.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Advanced debug with ETM trace"
+description: Use ETM trace in Keil uVision to capture instruction flow and analyze advanced debug behavior.
 
 weight: 5 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/uv_debug/6_power_ulplus.md
+++ b/content/learning-paths/embedded-and-microcontrollers/uv_debug/6_power_ulplus.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Measure Power with ULINKplus"
+description: Measure target power with ULINKplus in Keil uVision and correlate energy use with firmware execution.
 
 weight: 6 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/uvprojx-conversion/how-to-1.md
+++ b/content/learning-paths/embedded-and-microcontrollers/uvprojx-conversion/how-to-1.md
@@ -1,5 +1,6 @@
 ---
 title: Using Keil Studio
+description: Convert a uVision project to csolution format in Keil Studio and build it with CMSIS-Toolbox.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/uvprojx-conversion/how-to-2.md
+++ b/content/learning-paths/embedded-and-microcontrollers/uvprojx-conversion/how-to-2.md
@@ -1,5 +1,6 @@
 ---
 title: Using the command line
+description: Convert a uVision project to csolution format from the command line and verify the CMSIS-Toolbox build.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/uvprojx-conversion/how-to-mdk.md
+++ b/content/learning-paths/embedded-and-microcontrollers/uvprojx-conversion/how-to-mdk.md
@@ -1,5 +1,6 @@
 ---
 title: Using µVision
+description: Convert a uVision project inside Keil MDK and prepare it for CMSIS-Toolbox based workflows.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/config_creation.md
+++ b/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/config_creation.md
@@ -1,5 +1,6 @@
 ---
 title: Create a vcpkg-configuration.json file
+description: Create a vcpkg-configuration.json file that defines tool sources and versions for reproducible embedded development.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/initialization.md
+++ b/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/initialization.md
@@ -1,5 +1,6 @@
 ---
 title: Initialize vcpkg
+description: Initialize vcpkg in the project so command-line tools can be installed from the configured registries.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/installation.md
+++ b/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Install vcpkg
+description: Install vcpkg and verify the command-line setup used for managing Arm development tools.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/licenseactivation.md
+++ b/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/licenseactivation.md
@@ -1,5 +1,6 @@
 ---
 title: Activate a license
+description: Activate tool licenses through vcpkg so installed Arm command-line tools are ready for use.
 weight: 6
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/removal.md
+++ b/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/removal.md
@@ -1,5 +1,6 @@
 ---
 title: Remove vcpkg
+description: Remove vcpkg-managed tools and configuration when you need to reset the local tool installation.
 weight: 7
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/usage.md
+++ b/content/learning-paths/embedded-and-microcontrollers/vcpkg-tool-installation/usage.md
@@ -1,5 +1,6 @@
 ---
 title: Use vcpkg
+description: Use vcpkg commands to install, list, and manage versioned tools for an embedded development workflow.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/2-overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/2-overview.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Review the TinyML performance visualization workflow for deploying ExecuTorch models on Corstone-320 virtual hardware.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/3-executorch-workflow.md
+++ b/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/3-executorch-workflow.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Understand the ExecuTorch workflow"
+description: Understand the ExecuTorch conversion and runtime flow used to deploy neural network models to Arm targets.
 
 weight: 3
 

--- a/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/4-env-setup-execut.md
+++ b/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/4-env-setup-execut.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Set up your ExecuTorch environment"
+description: Install ExecuTorch and prepare the Python environment needed for model conversion and deployment.
 
 weight: 4
 

--- a/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/5-env-setup-fvp.md
+++ b/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/5-env-setup-fvp.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Set up the Corstone-320 Fixed Virtual Platform"
+description: Install and configure the Corstone-320 Fixed Virtual Platform for running and visualizing TinyML models.
 
 weight: 5 
 

--- a/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/6-run-model.md
+++ b/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/6-run-model.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Deploy and run Mobilenet V2 on the Corstone-320 FVP"
+description: Deploy MobileNet V2 with ExecuTorch on the Corstone-320 FVP and verify model execution.
 
 weight: 6 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/7-configure-fvp-gui.md
+++ b/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/7-configure-fvp-gui.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Enable GUI and deploy a model on Corstone-320 FVP"
+description: Enable the Corstone-320 FVP graphical interface so you can visualize model execution while inference runs.
 
 weight: 7 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/8-evaluate-output.md
+++ b/content/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/8-evaluate-output.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Evaluate Ethos-U Performance"
+description: Interpret Ethos-U performance output from the FVP and use the results to understand model behavior.
 
 weight: 8 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/yocto_qemu/yocto_build.md
+++ b/content/learning-paths/embedded-and-microcontrollers/yocto_qemu/yocto_build.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "How do I get started with Yocto Linux on Qemu?" 
+description: Build a minimal Yocto Linux image for a 64-bit Arm QEMU target and boot it in the emulator.
 
 weight: 3 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/yolo-on-himax/build-firmware.md
+++ b/content/learning-paths/embedded-and-microcontrollers/yolo-on-himax/build-firmware.md
@@ -1,5 +1,6 @@
 ---
 title: Build the firmware
+description: Build the Himax firmware that runs the YOLO object detection model on the WiseEye2 microcontroller module.
 weight: 4
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/yolo-on-himax/dev-env.md
+++ b/content/learning-paths/embedded-and-microcontrollers/yolo-on-himax/dev-env.md
@@ -1,5 +1,6 @@
 ---
 title: Set up the environment
+description: Install the software tools and SDK dependencies required to build YOLO firmware for the Himax WiseEye2 module.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/yolo-on-himax/flash-and-run.md
+++ b/content/learning-paths/embedded-and-microcontrollers/yolo-on-himax/flash-and-run.md
@@ -1,5 +1,6 @@
 ---
 title: Flash firmware onto the microcontroller
+description: Flash YOLO firmware to the Himax WiseEye2 module and verify object detection on the microcontroller.
 weight: 5
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/yolo-on-himax/overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/yolo-on-himax/overview.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Review the Himax WiseEye2 module and the YOLO object detection workflow before building and flashing firmware.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/yolo-on-himax/web-toolkit.md
+++ b/content/learning-paths/embedded-and-microcontrollers/yolo-on-himax/web-toolkit.md
@@ -1,5 +1,6 @@
 ---
 title: Run additional models in the web toolkit
+description: Modify the Himax web toolkit build settings and run additional models on the Grove Vision AI module.
 weight: 6
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/zephyr/zephyr.md
+++ b/content/learning-paths/embedded-and-microcontrollers/zephyr/zephyr.md
@@ -1,6 +1,7 @@
 ---
 # User change
 title: "Build and run Zephyr applications"
+description: Build and run Zephyr RTOS applications on the Corstone-300 FVP using Arm Virtual Hardware.
 
 weight: 2 # 1 is first, 2 is second, etc.
 

--- a/content/learning-paths/embedded-and-microcontrollers/zephyr_vsworkbench/1_installation.md
+++ b/content/learning-paths/embedded-and-microcontrollers/zephyr_vsworkbench/1_installation.md
@@ -1,5 +1,6 @@
 ---
 title: Set up the Workbench for Zephyr development environment
+description: Install Workbench for Zephyr in VS Code and configure the tools needed for Arm Cortex-M Zephyr development.
 weight: 2
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/zephyr_vsworkbench/2_development.md
+++ b/content/learning-paths/embedded-and-microcontrollers/zephyr_vsworkbench/2_development.md
@@ -1,5 +1,6 @@
 ---
 title: Build a Zephyr application with Workbench for Zephyr
+description: Create and build a Zephyr application with Workbench for Zephyr and prepare it for a supported development board.
 weight: 3
 
 ### FIXED, DO NOT MODIFY

--- a/content/learning-paths/embedded-and-microcontrollers/zephyr_vsworkbench/3_debug.md
+++ b/content/learning-paths/embedded-and-microcontrollers/zephyr_vsworkbench/3_debug.md
@@ -1,5 +1,6 @@
 ---
 title: Analyze and debug a Zephyr application
+description: Debug a Zephyr application with Workbench for Zephyr and inspect firmware behavior using integrated analysis tools.
 weight: 4
 
 ### FIXED, DO NOT MODIFY


### PR DESCRIPTION
Fixed metadata whitespace issues for one LP and bulk-added descriptions to embedded LPs (at LP-level and on each content page) using metadata skill and Codex CLI. 

Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [ ] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [ ] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
