### PR TITLE
Adding metadata descriptions to install guides 

### DIFF
--- a/content/install-guides/_index.md
+++ b/content/install-guides/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Install Guides"
+description: Browse install guides for Arm developer tools, cloud CLIs, compilers, containers, and platform setup across Arm Linux, Windows on Arm, and macOS.
 additional_search_terms:
     - compiler 
     - ide

--- a/content/install-guides/ambaviz.md
+++ b/content/install-guides/ambaviz.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Arm AMBA Viz
+description: Install Arm AMBA Viz from Arm Product Download Hub and set up the environment to visualize AMBA events for SoC verification workflows.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/ams.md
+++ b/content/install-guides/ams.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Arm Performance Studio
+description: Install Arm Performance Studio on Windows, macOS, or Linux to profile Android and Linux applications with Arm performance analysis tools.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/ansible.md
+++ b/content/install-guides/ansible.md
@@ -14,6 +14,7 @@ test_images:
 - ubuntu:latest
 test_link: null
 title: Ansible
+description: Install Ansible command-line tools on Ubuntu for Arm or macOS so you can automate configuration and software deployment from Arm-based systems.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/arduino-pico.md
+++ b/content/install-guides/arduino-pico.md
@@ -1,5 +1,6 @@
 ---
 title: Arduino core for the Raspberry Pi Pico
+description: Install the Arduino IDE and Raspberry Pi Pico board support so you can build and upload Arduino sketches for RP2040-based boards.
 author: Michael Hall
 additional_search_terms:
 - arduino

--- a/content/install-guides/armds.md
+++ b/content/install-guides/armds.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Arm Development Studio
+description: Install Arm Development Studio on Windows or Linux and configure licensing for embedded C and C++ development, debug, and SoC validation.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/avh.md
+++ b/content/install-guides/avh.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Arm Virtual Hardware
+description: Access Arm Virtual Hardware Corstone and third-party platforms so you can develop and test embedded software without physical hardware.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/aws-cli.md
+++ b/content/install-guides/aws-cli.md
@@ -14,6 +14,7 @@ test_images:
 - ubuntu:latest
 test_maintenance: true
 title: AWS CLI
+description: Install AWS CLI version 2 on Ubuntu for Arm and verify the setup so you can manage AWS services from the command line.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/aws-copilot.md
+++ b/content/install-guides/aws-copilot.md
@@ -14,6 +14,7 @@ test_images:
 - ubuntu:latest
 test_maintenance: true
 title: AWS Copilot CLI
+description: Install AWS Copilot CLI on Ubuntu for Arm or macOS and verify the setup so you can deploy container applications to AWS services.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/aws-greengrass-v2.md
+++ b/content/install-guides/aws-greengrass-v2.md
@@ -1,5 +1,6 @@
 ---
 title: AWS IoT Greengrass
+description: Install AWS IoT Greengrass on an Arm device and register it with AWS so you can build and manage IoT edge applications.
 author: Michael Hall
 additional_search_terms:
 - iot

--- a/content/install-guides/aws-sam-cli.md
+++ b/content/install-guides/aws-sam-cli.md
@@ -1,5 +1,6 @@
 ---
 title: AWS SAM CLI
+description: Install AWS SAM CLI on Ubuntu for Arm and test the setup so you can build, test, and deploy serverless applications locally.
 
 author: Jason Andrews
 minutes_to_complete: 15
@@ -174,4 +175,3 @@ REPORT RequestId: 513dbd6f-7fc0-4212-ae13-a9a4ce2f21f4	Init Duration: 0.26 ms	Du
 ```
 
 You are ready to use the AWS SAM CLI to build more complex functions and deploy them into AWS. Make sure to select `arm64` as the architecture for your Lambda functions.
-

--- a/content/install-guides/aws_access_keys.md
+++ b/content/install-guides/aws_access_keys.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: AWS Credentials
+description: Generate AWS access keys and configure them for AWS CLI so command-line tools can sign programmatic requests to AWS services.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/azure-cli.md
+++ b/content/install-guides/azure-cli.md
@@ -13,6 +13,7 @@ test_images:
 - ubuntu:latest
 test_maintenance: true
 title: Azure CLI
+description: Install Azure CLI on Ubuntu for Arm using a script or pip so you can manage Azure resources from an Arm Linux system.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/azure_login.md
+++ b/content/install-guides/azure_login.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Azure Authentication
+description: Sign in to Azure with Azure CLI and select a subscription so you can query and manage Azure cloud resources from the command line.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/bedrust.md
+++ b/content/install-guides/bedrust.md
@@ -1,5 +1,6 @@
 ---
 title: Bedrust - invoke models on Amazon Bedrock
+description: Build and install Bedrust on Arm Linux so you can invoke Amazon Bedrock foundation models from the command line.
 minutes_to_complete: 10
 author: Jason Andrews
 
@@ -202,6 +203,5 @@ Options:
 The output shows the model strings you can use. Make sure to enable the models you want to use in the Bedrock console. 
 
 You are now ready to use Bedrust as a quick way to explore many Bedrock models and compare them.
-
 
 

--- a/content/install-guides/browsers/_index.md
+++ b/content/install-guides/browsers/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Browsers on Arm
+description: Review browser availability on Arm Linux and Windows on Arm so you can choose and install a browser for development workflows.
 author: Jason Andrews
 additional_search_terms:
 - browser
@@ -52,5 +53,4 @@ The primary functional issue for browsers on Arm is DRM (digital rights manageme
 Edge and Firefox are good native browsers with DRM support for Windows on Arm. There are no easy DRM solutions for Arm Linux.
 
 Please share your experiences with browsers on Arm by submitting a [GitHub issue](https://github.com/ArmDeveloperEcosystem/arm-learning-paths/issues/new) or a GitHub Pull Request to add additional browsers. 
-
 

--- a/content/install-guides/browsers/brave.md
+++ b/content/install-guides/browsers/brave.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Brave
+description: Install Brave on Arm Linux or Windows on Arm and use a native browser for development and web testing on Arm platforms.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:
@@ -78,7 +79,6 @@ To install Brave on Windows on Arm:
 {{% notice Note %}}
 If you want the smaller, online installer download the file `BraveBrowserSetupArm64.exe`
 {{% /notice %}}
-
 
 
 

--- a/content/install-guides/browsers/chrome.md
+++ b/content/install-guides/browsers/chrome.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Chrome
+description: Install Chrome on Windows on Arm and understand its Arm Linux availability so you can choose a supported browser for Arm devices.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/browsers/chromium.md
+++ b/content/install-guides/browsers/chromium.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Chromium
+description: Install Chromium on Arm Linux or Windows on Arm and use a native open-source browser for development and testing.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:
@@ -74,4 +75,3 @@ Chromium on Windows on Arm does not update itself so you need to update manually
 {{% notice Note3%}}
 Certain types of videos don't play with Chromium. Video support is less than other browsers without DRM. 
 {{% /notice %}}
-

--- a/content/install-guides/browsers/edge.md
+++ b/content/install-guides/browsers/edge.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Edge
+description: Use Microsoft Edge on Windows on Arm and review install options so you can work with the default native browser on Arm devices.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:
@@ -34,7 +35,6 @@ Visit the [download page](https://www.microsoft.com/en-us/edge/download) for add
 {{% notice Note %}}
 The Linux downloads are not for the Arm architecture.
 {{% /notice %}}
-
 
 
 

--- a/content/install-guides/browsers/firefox.md
+++ b/content/install-guides/browsers/firefox.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Firefox
+description: Install Firefox on Arm Linux or Windows on Arm and use a native browser for development and testing on Arm platforms.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:
@@ -64,5 +65,4 @@ To install Firefox on Windows on Arm:
 3. Run the downloaded `.exe` file 
 
 4. Find and start Firefox from the applications menu
-
 

--- a/content/install-guides/browsers/vivaldi.md
+++ b/content/install-guides/browsers/vivaldi.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Vivaldi
+description: Install Vivaldi on Arm Linux or Windows on Arm and use a native browser for development and web workflows.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/claude-code.md
+++ b/content/install-guides/claude-code.md
@@ -1,5 +1,6 @@
 ---
 title: Claude Code
+description: Install Claude Code on Arm Linux, Apple Silicon macOS, or Windows on Arm so you can use terminal-based AI coding assistance.
 
 author: Pareena Verma
 minutes_to_complete: 10

--- a/content/install-guides/container.md
+++ b/content/install-guides/container.md
@@ -1,5 +1,6 @@
 ---
 title: Container CLI for macOS
+description: Install Apple Container CLI on Apple Silicon macOS and verify it by building and running Arm Linux containers in lightweight virtual machines.
 author: Rani Chowdary Mandepudi
 minutes_to_complete: 10
 official_docs: https://github.com/apple/container

--- a/content/install-guides/cyclonedds.md
+++ b/content/install-guides/cyclonedds.md
@@ -1,5 +1,6 @@
 ---
 title: Cyclone DDS
+description: Build and install Eclipse Cyclone DDS on Arm Linux and test the setup for real-time publish-subscribe communication in robotics and IoT applications.
 author: Odin Shen
 minutes_to_complete: 20
 official_docs: https://cyclonedds.io/
@@ -119,4 +120,4 @@ If you observe the following output from each of the terminals, Cyclone DDS is r
   {{< /tab >}}
 {{< /tabpane >}}
 
-You are now ready to use Cyclone DDS. 
+You are now ready to use Cyclone DDS.

--- a/content/install-guides/dcperf.md
+++ b/content/install-guides/dcperf.md
@@ -1,5 +1,6 @@
 ---
 title: DCPerf
+description: Install and run DCPerf on Arm-based servers to benchmark data center workloads and collect performance data for analysis or regression testing.
 author: Kieran Hejmadi
 minutes_to_complete: 20
 official_docs: https://github.com/facebookresearch/DCPerf?tab=readme-ov-file#install-and-run-benchmarks

--- a/content/install-guides/docker/_index.md
+++ b/content/install-guides/docker/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Docker
+description: Choose the right Docker installation path for Arm Linux, ChromeOS, Windows, or macOS so you can build and run containers on Arm systems.
 author: Jason Andrews
 additional_search_terms:
 - containers

--- a/content/install-guides/docker/docker-desktop-arm-linux.md
+++ b/content/install-guides/docker/docker-desktop-arm-linux.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Docker Desktop for Arm Linux
+description: Install Docker Desktop on Arm Linux and verify the setup so you can run container workflows with the Docker Desktop environment.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/docker/docker-desktop.md
+++ b/content/install-guides/docker/docker-desktop.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Docker Desktop
+description: Install Docker Desktop on Windows or macOS and test container execution so you can build and run Docker workloads on Arm-capable systems.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/docker/docker-engine.md
+++ b/content/install-guides/docker/docker-engine.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Docker Engine
+description: Install Docker Engine on Linux, WSL 2, or ChromeOS and verify the setup so you can run containers from the command line.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:
@@ -157,4 +158,3 @@ sudo systemctl stop docker.socket
 You can now use Docker Engine and explore [Docker related Learning Paths](/tag/docker/).
 
 You can also create an account on [Docker Hub](https://hub.docker.com) to share images and automate workflows.
-

--- a/content/install-guides/dotnet.md
+++ b/content/install-guides/dotnet.md
@@ -13,6 +13,7 @@ test_images:
 test_link: null
 test_maintenance: true
 title: .NET SDK
+description: Install the .NET SDK on Arm Linux and choose an SDK version so you can build and run .NET applications on Arm-based systems.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/finch.md
+++ b/content/install-guides/finch.md
@@ -1,5 +1,6 @@
 ---
 title: Finch on Arm Linux
+description: Install Finch on Amazon Linux 2023 or Ubuntu 24.04 for Arm and verify Docker-compatible container workflows with containerd and nerdctl.
 author: Jason Andrews
 
 minutes_to_complete: 10

--- a/content/install-guides/fm_fvp/_index.md
+++ b/content/install-guides/fm_fvp/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Arm Fast Models and FVPs
+description: Install Arm Fast Models and Fixed Virtual Platforms so you can create and run virtual Arm platforms for software development and verification.
 author: Ronan Synnott
 
 additional_search_terms:

--- a/content/install-guides/fm_fvp/eco_fvp.md
+++ b/content/install-guides/fm_fvp/eco_fvp.md
@@ -1,5 +1,6 @@
 ---
 title: Arm Ecosystem FVPs and Architecture Envelope Models
+description: Download and install Arm Ecosystem FVPs or Architecture Envelope Models on supported hosts to explore Arm systems before hardware is available.
 minutes_to_complete: 15
 official_docs: https://developer.arm.com/documentation/100966
 author: Ronan Synnott

--- a/content/install-guides/fm_fvp/fm.md
+++ b/content/install-guides/fm_fvp/fm.md
@@ -1,5 +1,6 @@
 ---
 title: Arm Fast Models
+description: Install Arm Fast Models on Linux or Windows and prepare host toolchains so you can build executable virtual platforms for Arm software development.
 minutes_to_complete: 15
 official_docs: https://developer.arm.com/documentation/107572
 author: Ronan Synnott

--- a/content/install-guides/fm_fvp/fvp.md
+++ b/content/install-guides/fm_fvp/fvp.md
@@ -1,5 +1,6 @@
 ---
 title: Fixed Virtual Platforms (FVP)
+description: Install the legacy Arm Fixed Virtual Platform library on Windows or Linux so you can run ready-to-use virtual Arm platforms.
 minutes_to_complete: 15
 official_docs: https://developer.arm.com/documentation/100966/
 author: Ronan Synnott
@@ -82,4 +83,3 @@ You can a workaround this error using `execstack` on each of the runtime binarie
 execstack -c <binary>
 ```
 {{% /notice %}}
-

--- a/content/install-guides/fvps-on-macos.md
+++ b/content/install-guides/fvps-on-macos.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: AVH FVPs on macOS
+description: Run Arm Virtual Hardware Fixed Virtual Platforms on macOS with Docker containers so you can use FVP models from an Apple development machine.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/gcc/_index.md
+++ b/content/install-guides/gcc/_index.md
@@ -1,5 +1,6 @@
 ---
 title: GNU Compiler
+description: Choose and install the right GCC toolchain for native Arm Linux development, Arm Linux cross-compilation, or bare-metal Arm targets.
 author: Jason Andrews
 additional_search_terms:
 - compiler

--- a/content/install-guides/gcc/cross.md
+++ b/content/install-guides/gcc/cross.md
@@ -13,6 +13,7 @@ test_images:
 test_link: null
 test_maintenance: true
 title: Cross-compiler
+description: Install GCC cross-compilers on Linux so you can build 32-bit or 64-bit Arm Linux applications from a non-target host.
 tool_install: false
 weight: 3
 ---

--- a/content/install-guides/gcc/native.md
+++ b/content/install-guides/gcc/native.md
@@ -14,6 +14,7 @@ test_images:
 test_link: null
 test_maintenance: true
 title: Native compiler
+description: Install native GCC and G++ packages on Arm Linux so you can compile C and C++ applications directly on an Arm machine.
 tool_install: false
 weight: 2
 ---

--- a/content/install-guides/gcloud.md
+++ b/content/install-guides/gcloud.md
@@ -16,6 +16,7 @@ test_images:
 - ubuntu:latest
 test_maintenance: true
 title: Google Cloud Platform (GCP) CLI
+description: Install the Google Cloud CLI on Ubuntu for Arm and verify the setup so you can manage Google Cloud resources with gcloud.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/gemini.md
+++ b/content/install-guides/gemini.md
@@ -1,5 +1,6 @@
 ---
 title: Gemini CLI
+description: Install Gemini CLI on macOS or Arm Linux and configure authentication so you can use Google's command-line AI assistant for development tasks.
 
 author: Jason Andrews
 minutes_to_complete: 15

--- a/content/install-guides/gfortran.md
+++ b/content/install-guides/gfortran.md
@@ -19,6 +19,7 @@ test_images:
 test_link: null
 test_maintenance: true
 title: GFortran
+description: Install GNU Fortran on Arm Linux and compile a test program so you can build Fortran applications with GCC tooling.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/git-woa.md
+++ b/content/install-guides/git-woa.md
@@ -1,5 +1,6 @@
 ---
 title: Git for Windows on Arm
+description: Install native Git for Windows on Arm and verify Git commands in Command Prompt, PowerShell, or Git Bash.
 
 additional_search_terms:
 - git

--- a/content/install-guides/github-copilot.md
+++ b/content/install-guides/github-copilot.md
@@ -1,5 +1,6 @@
 ---
 title: GitHub Copilot
+description: Install GitHub Copilot in Visual Studio Code on Arm systems and connect it with the Arm MCP Server for Arm-focused development assistance.
 
 author: Pareena Verma
 minutes_to_complete: 10

--- a/content/install-guides/helm.md
+++ b/content/install-guides/helm.md
@@ -1,5 +1,6 @@
 ---
 title: Helm
+description: Install Helm on Ubuntu for Arm and verify the setup so you can manage Kubernetes applications with charts.
 
 author: Jason Andrews
 minutes_to_complete: 10

--- a/content/install-guides/hyper-v.md
+++ b/content/install-guides/hyper-v.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Hyper-V on Arm
+description: Enable Hyper-V on Windows 11 on Arm so you can create and run virtual machines on supported Arm devices.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/ipexplorer.md
+++ b/content/install-guides/ipexplorer.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Arm IP Explorer
+description: Access Arm IP Explorer in the browser and use it to explore Arm IP, simulate processors, and create SoC concepts.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/java.md
+++ b/content/install-guides/java.md
@@ -1,5 +1,6 @@
 ---
 title: Java
+description: Install Java runtimes and development kits on Arm Linux using package managers, Snap, or vendor distributions for Java application development.
 author: Jason Andrews
 minutes_to_complete: 15
 official_docs: https://docs.oracle.com/en/java/

--- a/content/install-guides/keilstudio_vs.md
+++ b/content/install-guides/keilstudio_vs.md
@@ -1,5 +1,6 @@
 ---
 title: Arm Keil Studio for VS Code
+description: Install Arm Keil Studio extensions for Visual Studio Code and verify the setup for Cortex-M embedded development on desktop hosts.
 
 additional_search_terms:
 - cortex-m

--- a/content/install-guides/keilstudiocloud.md
+++ b/content/install-guides/keilstudiocloud.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Arm Keil Studio Cloud
+description: Open Arm Keil Studio Cloud in a Chromium-based browser and start browser-based Cortex-M, IoT, and embedded development without local installation.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/kiro-cli.md
+++ b/content/install-guides/kiro-cli.md
@@ -1,5 +1,6 @@
 ---
 title: Kiro CLI
+description: Install Kiro CLI on macOS or Arm Linux and verify authentication so you can use AWS-focused AI assistance from the command line.
 
 author: Jason Andrews
 minutes_to_complete: 10

--- a/content/install-guides/kubectl.md
+++ b/content/install-guides/kubectl.md
@@ -18,6 +18,7 @@ test_images:
 test_link: null
 test_maintenance: true
 title: Kubectl
+description: Install kubectl on Ubuntu for Arm and verify the Kubernetes CLI so you can run commands against Kubernetes clusters.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/license/_index.md
+++ b/content/install-guides/license/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Arm Software Licensing
+description: Configure Arm software licensing with user-based, cloud, local, or FlexNet license servers so Arm commercial tools can check out licenses.
 author: Ronan Synnott
 additional_search_terms:
 - success kits

--- a/content/install-guides/license/cloud.md
+++ b/content/install-guides/license/cloud.md
@@ -1,5 +1,6 @@
 ---
 title: UBL Cloud server setup
+description: Generate and activate Arm user-based licenses with the Cloud License Server so end users can check out commercial Arm tool licenses.
 minutes_to_complete: 15
 official_docs: https://developer.arm.com/documentation/107573
 author: Ronan Synnott

--- a/content/install-guides/license/flexnet.md
+++ b/content/install-guides/license/flexnet.md
@@ -1,5 +1,6 @@
 ---
 title: FlexNet Publisher Floating license setup
+description: Set up a FlexNet Publisher floating license server and configure end-user machines for older Arm products that do not support user-based licensing.
 minutes_to_complete: 15
 official_docs: https://developer.arm.com/documentation/dui0209
 author: Ronan Synnott

--- a/content/install-guides/license/ubl_license_admin.md
+++ b/content/install-guides/license/ubl_license_admin.md
@@ -1,5 +1,6 @@
 ---
 title: UBL Local License Server (LLS) setup
+description: Install and configure an Arm user-based Local License Server so administrators can host and manage commercial Arm tool licenses.
 minutes_to_complete: 15
 official_docs: https://developer.arm.com/documentation/107573
 author: Ronan Synnott

--- a/content/install-guides/license/ubl_license_enduser.md
+++ b/content/install-guides/license/ubl_license_enduser.md
@@ -1,5 +1,6 @@
 ---
 title: UBL LLS End-user setup
+description: Activate Arm user-based licenses from a Local License Server on an end-user machine using environment variables, tool IDEs, or manual activation.
 minutes_to_complete: 15
 official_docs: https://developer.arm.com/documentation/102516
 author: Ronan Synnott

--- a/content/install-guides/linux-migration-tools.md
+++ b/content/install-guides/linux-migration-tools.md
@@ -1,5 +1,6 @@
 ---
 title: Arm Linux Migration Tools
+description: Install Arm Linux Migration Tools on Arm Linux to access utilities for code analysis, performance profiling, containers, and migration assessment.
 
 additional_search_terms:
 - migration

--- a/content/install-guides/llvm-embedded.md
+++ b/content/install-guides/llvm-embedded.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: LLVM Embedded Toolchain for Arm
+description: Install the LLVM Embedded Toolchain for Arm on Windows, macOS, or Linux and verify clang for Cortex-M embedded development.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/llvm-woa.md
+++ b/content/install-guides/llvm-woa.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: LLVM toolchain for Windows on Arm
+description: Install the native LLVM toolchain for Windows on Arm and verify clang so you can build software directly on Windows Arm devices.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/mcuxpresso_vs.md
+++ b/content/install-guides/mcuxpresso_vs.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: NXP MCUXpresso for VS Code
+description: Install the NXP MCUXpresso extension for Visual Studio Code and required dependencies for embedded development on supported desktop hosts.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:
@@ -70,6 +71,5 @@ Select one or more packages and click `Install`.
 ### Are there other embedded development extensions for VS Code?
 
 [Keil Studio for VS Code](https://www.keil.arm.com/) is also available. Refer to the [Arm Keil Studio for VS Code install guide](/install-guides/keilstudio_vs/) for more information.
-
 
 

--- a/content/install-guides/mdk.md
+++ b/content/install-guides/mdk.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Arm Keil μVision
+description: Install Arm Keil MDK on Windows and configure licensing so you can develop and debug Cortex-M microcontroller applications with uVision.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/multipass.md
+++ b/content/install-guides/multipass.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Multipass
+description: Install Multipass on Apple Silicon macOS or Arm Linux and create Ubuntu virtual machine instances for local Arm cloud-style development.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/nerdctl.md
+++ b/content/install-guides/nerdctl.md
@@ -1,5 +1,6 @@
 ---
 title: Nerdctl
+description: Install containerd, nerdctl, CNI plugins, and BuildKit on Arm Linux so you can run Docker-compatible container workflows without Docker Engine.
 author: Jason Andrews
 
 minutes_to_complete: 10

--- a/content/install-guides/nomachine.md
+++ b/content/install-guides/nomachine.md
@@ -15,6 +15,7 @@ test_images:
 test_link: null
 test_maintenance: false
 title: NoMachine
+description: Install NoMachine and an xfce desktop on remote Arm Linux so you can connect to a graphical development environment.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/oc.md
+++ b/content/install-guides/oc.md
@@ -1,5 +1,6 @@
 ---
 title: OpenShift CLI (oc)
+description: Install the OpenShift CLI on Ubuntu for Arm or Apple Silicon macOS so you can manage OpenShift and Kubernetes resources from a terminal.
 
 author: Jason Andrews
 

--- a/content/install-guides/oci-cli.md
+++ b/content/install-guides/oci-cli.md
@@ -15,6 +15,7 @@ test_images:
 - ubuntu:latest
 test_maintenance: true
 title: Oracle Cloud Infrastructure (OCI) CLI
+description: Install OCI CLI on Ubuntu for Arm, verify the installation, and configure access so you can manage Oracle Cloud Infrastructure resources.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/openvscode-server.md
+++ b/content/install-guides/openvscode-server.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: OpenVSCode Server
+description: Install OpenVSCode Server on Arm Linux and start a browser-accessible VS Code environment for remote or headless development.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/papi.md
+++ b/content/install-guides/papi.md
@@ -1,5 +1,6 @@
 ---
 title: Performance API (PAPI)
+description: Build and install PAPI on Arm Linux so applications can access hardware performance counters for profiling specific code sections.
 minutes_to_complete: 15
 official_docs: https://github.com/icl-utk-edu/papi/wiki/Downloading-and-Installing-PAPI
 author: Jason Andrews

--- a/content/install-guides/pdh/_index.md
+++ b/content/install-guides/pdh/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Arm Product Download Hub
+description: Access Arm Product Download Hub through a browser or API so you can find and download entitled Arm IP and software product packages.
 author: Ronan Synnott
 
 additional_search_terms:

--- a/content/install-guides/pdh/api.md
+++ b/content/install-guides/pdh/api.md
@@ -1,5 +1,6 @@
 ---
 title: Access via API
+description: Install and use the Entitlements and Download Manager on Linux to automate Arm Product Download Hub authentication and package downloads.
 minutes_to_complete: 15
 official_docs: https://anypoint.mulesoft.com/exchange/portals/arm-3/f5af04c7-2f93-4d1e-8355-a60625973e1f/product-entitlement-customer-experience-api/
 author: Ronan Synnott

--- a/content/install-guides/pdh/browser.md
+++ b/content/install-guides/pdh/browser.md
@@ -1,5 +1,6 @@
 ---
 title: Access via Internet Browser
+description: Search and download Arm products from Arm Product Download Hub in a browser, including entitled packages, updates, and product-code lookups.
 minutes_to_complete: 15
 official_docs: https://developer.arm.com/documentation/107572
 author: Ronan Synnott

--- a/content/install-guides/perf.md
+++ b/content/install-guides/perf.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Perf for Linux on Arm (LinuxPerf)
+description: Install Linux Perf on Arm Linux with a package manager or from source so you can collect hardware and software performance data.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/performix.md
+++ b/content/install-guides/performix.md
@@ -1,5 +1,6 @@
 ---
 title: Arm Performix
+description: Install Arm Performix on a desktop host and connect to remote Arm Linux targets for graphical performance profiling with hardware counters.
 
 additional_search_terms:
   - performix

--- a/content/install-guides/porting-advisor.md
+++ b/content/install-guides/porting-advisor.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Porting Advisor for Graviton
+description: Install Porting Advisor for Graviton on Ubuntu or Amazon Linux 2023 and scan application source code for portability issues on AWS Graviton.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:
@@ -200,4 +201,3 @@ Report generated successfully. Hint: you can use --output FILENAME.html to gener
 Try out the other sample projects. 
 
 You are now ready to use Porting Advisor for Graviton on your own projects.
-

--- a/content/install-guides/powershell.md
+++ b/content/install-guides/powershell.md
@@ -1,5 +1,6 @@
 ---
 title: PowerShell
+description: Install PowerShell on Arm Linux and verify the shell so you can run cross-platform automation commands and scripts.
 minutes_to_complete: 10
 official_docs: https://learn.microsoft.com/en-us/powershell/
 ecosystem_dashboard: https://developer.arm.com/ecosystem-dashboard/linux?package=powershell

--- a/content/install-guides/pulumi.md
+++ b/content/install-guides/pulumi.md
@@ -1,5 +1,6 @@
 ---
 title: Pulumi
+description: Install Pulumi on Linux and verify the setup with a container registry example so you can deploy infrastructure as code from Arm systems.
 minutes_to_complete: 5
 official_docs: https://www.pulumi.com/docs/
 ecosystem_dashboard: https://developer.arm.com/ecosystem-dashboard/linux?package=pulumi

--- a/content/install-guides/py-woa.md
+++ b/content/install-guides/py-woa.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Python for Windows on Arm
+description: Install native Python on Windows on Arm, run a test program, and install packages for Python development on Arm devices.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/pytorch-woa.md
+++ b/content/install-guides/pytorch-woa.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: PyTorch for Windows on Arm
+description: Install native PyTorch for Windows on Arm and run a Python example to verify machine learning workflows on Arm devices.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/pytorch.md
+++ b/content/install-guides/pytorch.md
@@ -16,6 +16,7 @@ test_images:
 test_link: null
 test_maintenance: false
 title: PyTorch
+description: Install PyTorch on Arm Linux and run a starter example so you can build and test machine learning applications with Python.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/ros2.md
+++ b/content/install-guides/ros2.md
@@ -1,5 +1,6 @@
 ---
 title: ROS - Robot Operating System
+description: Install ROS 2 on Ubuntu for Arm and configure dependencies so you can build and run robotics applications on Arm Linux.
 author: Odin Shen
 minutes_to_complete: 30
 official_docs: https://www.ros.org/blog/getting-started/

--- a/content/install-guides/rust.md
+++ b/content/install-guides/rust.md
@@ -1,5 +1,6 @@
 ---
 title: Rust for Linux Applications
+description: Install Rust on Arm Linux and compile a sample project so you can build Linux applications with the Rust toolchain.
 minutes_to_complete: 10
 official_docs: https://www.rust-lang.org/tools/install
 ecosystem_dashboard: https://developer.arm.com/ecosystem-dashboard/linux?package=rust

--- a/content/install-guides/rust_embedded.md
+++ b/content/install-guides/rust_embedded.md
@@ -1,5 +1,6 @@
 ---
 title: Rust for Embedded Applications
+description: Install Rust and Arm cross-compilation support on Ubuntu so you can build embedded applications for Arm targets.
 minutes_to_complete: 10
 official_docs: https://docs.rust-embedded.org/
 author: Ronan Synnott

--- a/content/install-guides/sbt.md
+++ b/content/install-guides/sbt.md
@@ -1,5 +1,6 @@
 ---
 title: sbt
+description: Install sbt on Ubuntu for Arm so you can build Scala and Java projects with the standard sbt command-line tool.
 
 author: Jason Andrews
 minutes_to_complete: 10

--- a/content/install-guides/skopeo.md
+++ b/content/install-guides/skopeo.md
@@ -1,5 +1,6 @@
 ---
 title: Skopeo
+description: Install Skopeo on Ubuntu for Arm and inspect container images so you can work with registries without a local container daemon.
 author: Jason Andrews
 minutes_to_complete: 10
 official_docs: https://github.com/containers/skopeo

--- a/content/install-guides/socrates.md
+++ b/content/install-guides/socrates.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Arm Socrates
+description: Install Arm Socrates from Arm Product Download Hub, configure licensing, and update the IP catalog for Arm IP selection and SoC creation.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:
@@ -93,4 +94,3 @@ They are available on the [Arm YouTube channel](https://www.youtube.com/c/arm):
  * [Getting Started](https://youtube.com/playlist?list=PLgyFKd2HIZlY_y7b5OTtyrso45q-eCM_s)
  * [NIC-400 Configuration](https://youtube.com/playlist?list=PLgyFKd2HIZlaQBfd8YEMwSQX_cWIxODgG)
  * [NI-700 Configuration](https://youtube.com/playlist?list=PLgyFKd2HIZlahIsHSSw7ViwiFxeBYc36b)
-

--- a/content/install-guides/ssh.md
+++ b/content/install-guides/ssh.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: SSH
+description: Install and configure SSH on Arm Linux so you can securely connect to remote servers for cloud and server development.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/stm32_vs.md
+++ b/content/install-guides/stm32_vs.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: STM32 extensions for VS Code
+description: Install STM32 extensions and dependencies for Visual Studio Code so you can configure and develop STM32 projects on desktop hosts.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/streamline-cli.md
+++ b/content/install-guides/streamline-cli.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Streamline CLI Tools
+description: Install Streamline CLI tools on Arm Linux and prepare applications for command-line performance profiling on Arm servers.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:
@@ -273,4 +274,3 @@ Follow these steps to integrate these patches into an RPM-based distribution's k
     ```
 
 You are now ready to use Streamline CLI Tools. Refer to [Profiling for Neoverse with Streamline CLI Tools](/learning-paths/servers-and-cloud-computing/profiling-for-neoverse/) to get started.
-

--- a/content/install-guides/streamline.md
+++ b/content/install-guides/streamline.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Arm Streamline
+description: Install Arm Streamline from Arm Performance Studio or Arm Development Studio to profile Android, Linux, or bare-metal applications.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/successkits.md
+++ b/content/install-guides/successkits.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Arm Success Kits
+description: Download and install Arm Success Kit components from Arm Product Download Hub so licensed development tools are available on your workstation.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:
@@ -58,4 +59,3 @@ Bundles are provided for Windows, Linux, or Mac OS. Not all components are suppo
 [Install Arm Socrates](/install-guides/socrates/)
 
 [Install Arm AMBA Viz](/install-guides/ambaviz/)
-

--- a/content/install-guides/swift.md
+++ b/content/install-guides/swift.md
@@ -1,6 +1,7 @@
 ---
 
 title: Swift
+description: Install Swift on Ubuntu for Arm and verify the toolchain so you can build and run Swift applications on Arm Linux.
 author: Jason Andrews
 
 minutes_to_complete: 10
@@ -139,4 +140,3 @@ Hello from Swift on Arm Linux!
 ```
 
 You are now ready to use the Swift programming language on your Arm Linux computer.
-

--- a/content/install-guides/sysbox.md
+++ b/content/install-guides/sysbox.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Sysbox
+description: Install Sysbox on Arm Linux and verify Docker workloads that need system-level container behavior without running a full virtual machine.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/terraform.md
+++ b/content/install-guides/terraform.md
@@ -18,6 +18,7 @@ test_images:
 test_link: false
 test_maintenance: true
 title: Terraform
+description: Install Terraform on Ubuntu for Arm or Apple Silicon macOS and verify the CLI so you can manage cloud infrastructure as code.
 tool_install: true
 weight: 1
 ---

--- a/content/install-guides/tkn.md
+++ b/content/install-guides/tkn.md
@@ -1,5 +1,6 @@
 ---
 title: Tekton CLI (tkn)
+description: Install Tekton CLI on Ubuntu for Arm or Apple Silicon macOS so you can create and manage Tekton Pipelines resources from a terminal.
 
 author: Jason Andrews
 official_docs: https://tekton.dev/docs/cli/

--- a/content/install-guides/topdown-tool.md
+++ b/content/install-guides/topdown-tool.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Telemetry Solution (Topdown Methodology)
+description: Install the Arm Telemetry Solution on Arm Linux and test top-down performance methodology tools that work with Linux Perf.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/vnc.md
+++ b/content/install-guides/vnc.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: VNC on Arm Linux
+description: Install and configure VNC with an xfce desktop on Arm Linux so you can connect to a remote graphical development environment.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/vs-woa.md
+++ b/content/install-guides/vs-woa.md
@@ -1,5 +1,6 @@
 ---
-title: Visual Studio for Windows on Arm 
+title: Visual Studio for Windows on Arm
+description: Install Visual Studio on Windows on Arm with C, C++, and LLVM support so you can develop applications directly on Arm hardware.
 
 additional_search_terms:
 - clang

--- a/content/install-guides/vscode-tunnels.md
+++ b/content/install-guides/vscode-tunnels.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: VS Code Tunnels
+description: Install the VS Code CLI on Arm systems and configure Remote Tunnels for browser-based access to non-desktop Arm development environments.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/windows-perf-vs-extension.md
+++ b/content/install-guides/windows-perf-vs-extension.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Visual Studio Extension for WindowsPerf
+description: Install the WindowsPerf Visual Studio extension on Windows on Arm so you can capture and visualize performance data inside Visual Studio.
 
 minutes_to_complete: 10
 

--- a/content/install-guides/windows-perf-wpa-plugin.md
+++ b/content/install-guides/windows-perf-wpa-plugin.md
@@ -1,5 +1,6 @@
 ---
 title: Windows Performance Analyzer (WPA) plugin
+description: Install the WindowsPerf WPA plugin on Windows on Arm so Windows Performance Analyzer can display WindowsPerf telemetry and timeline data.
 
 minutes_to_complete: 15
 

--- a/content/install-guides/windows-sandbox-woa.md
+++ b/content/install-guides/windows-sandbox-woa.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: Windows Sandbox for Windows on Arm
+description: Enable and install Windows Sandbox on Windows on Arm so you can run isolated desktop test environments on supported Arm devices.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:

--- a/content/install-guides/wperf.md
+++ b/content/install-guides/wperf.md
@@ -2,6 +2,7 @@
 ### Title the install tools article with the name of the tool to be installed
 ### Include vendor name where appropriate
 title: WindowsPerf (wperf)
+description: Install WindowsPerf on Windows on Arm and verify PMU-based profiling so you can analyze application performance with command-line and IDE tools.
 
 ### Optional additional search terms (one per line) to assist in finding the article
 additional_search_terms:


### PR DESCRIPTION
Used metadata skill to add descriptions (for SEO purposes) to each install guide that didn't previously have one.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [ ] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [ ] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
