### PR TITLE
Style-based updates to Performix MCP LP + fixing rendering of inline math equations

### DIFF
--- a/.github/skills/markdown-component-edit/references/component-patterns.md
+++ b/.github/skills/markdown-component-edit/references/component-patterns.md
@@ -86,4 +86,19 @@ Rules:
 - Keep each tab roughly comparable in length and detail.
 - Avoid hiding critical sequential instructions inside tabs unless the user chooses one path.
 
+## Mathematical expressions
 
+To display a mathematical expression inline, encase the expression in `\(...\)`.
+
+For example:
+
+```md
+\(\sqrt{re^2 + im^2}\)
+```
+To display a mathematical expression in a new line, encase the expression in `$$...$$`.
+
+For example:
+
+```md
+$$re_{new} = re_z^2 - im_z^2 + re_c$$
+```

--- a/.github/skills/markdown-component-edit/references/component-patterns.md
+++ b/.github/skills/markdown-component-edit/references/component-patterns.md
@@ -88,17 +88,26 @@ Rules:
 
 ## Mathematical expressions
 
-To display a mathematical expression inline, encase the expression in `\(...\)`.
+Use `\(...\)` to display a mathematical expression inline.
 
 For example:
 
 ```md
 \(\sqrt{re^2 + im^2}\)
 ```
-To display a mathematical expression in a new line, encase the expression in `$$...$$`.
+
+Use `$$...$$` or `\[...\]` to display a mathematical expression in a block.
 
 For example:
 
 ```md
 $$re_{new} = re_z^2 - im_z^2 + re_c$$
+```
+
+or
+
+```md
+\[
+re_{new} = re_z^2 - im_z^2 + re_c
+\]
 ```

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/1-overview.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/1-overview.md
@@ -11,9 +11,11 @@ layout: learningpathall
 
 The Arm MCP Server exposes Arm Performix as a first-class tool that AI coding assistants can invoke directly. Rather than switching between your IDE and the Performix GUI to analyze results and then back again to apply code changes, an AI agent can orchestrate the entire profiling pipeline. Configuring the recipe, launching the collection run, retrieving hotspot data, and proposing optimizations can all be part of a single agentic workflow.
 
-## What the Arm Performix MCP server tool is
+## What the Arm Performix tool is
 
-Arm Performix is a performance profiling tool that simplifies the workflow of collecting CPU samples, building flame graphs, and identifying the functions that dominate application runtime. When integrated into the MCP server, it lets an AI agent orchestrate the entire profiling pipeline — configuring the recipe, launching the collection run, and retrieving the resulting hotspot data — without manual interaction with the Performix engine.
+Arm Performix is a performance profiling tool that simplifies the workflow of collecting CPU samples, building flame graphs, and identifying the functions that dominate application runtime. 
+
+When you integrate Arm Performix into the MCP server, the tool lets an AI agent orchestrate the entire profiling pipeline — configuring the recipe, launching the collection run, and retrieving the resulting hotspot data — without manual interaction with the Performix engine.
 
 You don't need to context switch between your IDE and the Performix GUI to analyze results and then back again to apply code changes. An AI agent can do all of this for you in a single agentic workflow.
 
@@ -53,7 +55,7 @@ Every decision in the loop is grounded in the hotspot data returned by the tool;
 
 To use the Arm MCP Server with an AI coding assistant, configure the assistant to connect to the MCP server. Connecting your assistant allows it to query Arm-specific tools, documentation, and capabilities exposed through the Model Context Protocol (MCP).
 
-The required configuration steps vary by AI coding assistant. Refer to the following install guides for step-by-step instructions on connecting AI coding assistants to the Arm MCP server:
+The required configuration steps vary by AI coding assistant. For step-by-step instructions on connecting AI coding assistants to the Arm MCP server, see the following install guides:
 
 - [GitHub Copilot](/install-guides/github-copilot/)
 - [Antigravity CLI](/install-guides/antigravity/)

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/1-overview.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/1-overview.md
@@ -1,28 +1,29 @@
 ---
-title: Understand AI-driven profiling with Arm Performix MCP
+title: Understand AI-driven profiling with Arm Performix MCP tool
+description: Understand how the Arm MCP Server exposes Arm Performix so an AI agent can run Code Hotspots profiling and propose evidence-based optimizations.
 weight: 2
 
 ### FIXED, DO NOT MODIFY
 layout: learningpathall
 ---
 
-## Why AI-driven profiling with Arm Performix
+## Why profile with Arm Performix using AI
 
-The Arm MCP Server exposes Arm Performix as a first-class tool that AI coding assistants can invoke directly. Rather than switching between your IDE and the Performix GUI to analyze results and then back again to apply code changes, an AI agent can orchestrate the entire profiling pipeline — configuring the recipe, launching the collection run, retrieving hotspot data, and proposing optimizations — all in a single agentic workflow.
+The Arm MCP Server exposes Arm Performix as a first-class tool that AI coding assistants can invoke directly. Rather than switching between your IDE and the Performix GUI to analyze results and then back again to apply code changes, an AI agent can orchestrate the entire profiling pipeline. Configuring the recipe, launching the collection run, retrieving hotspot data, and proposing optimizations can all be part of a single agentic workflow.
 
-## What is the Arm Performix tool in the MCP Server?
+## What the Arm Performix MCP server tool is
 
 Arm Performix is a performance profiling tool that simplifies the workflow of collecting CPU samples, building flame graphs, and identifying the functions that dominate application runtime. When integrated into the MCP server, it lets an AI agent orchestrate the entire profiling pipeline — configuring the recipe, launching the collection run, and retrieving the resulting hotspot data — without manual interaction with the Performix engine.
 
-Context switching for profiling is removed. Rather than switching between your IDE and the Performix GUI to analyze results and then back again to apply code changes, an AI agent can do all of this for you in a single agentic workflow.
+You don't need to context switch between your IDE and the Performix GUI to analyze results and then back again to apply code changes. An AI agent can do all of this for you in a single agentic workflow.
 
 ## How the MCP tool works
 
 The `apx_recipe_run` tool in the Arm MCP Server accepts a recipe name, a binary path on the remote target, and SSH connection details. It starts the Performix collection run on the configured remote target, waits for the application to finish, and then returns a structured summary of the profiling results. The summary includes the top CPU-time-consuming functions ordered by sample percentage, call stack context for each hotspot, and any relevant observations about the application's runtime behavior.
 
-The agent uses this data to cross-reference hotspot function names against the source files in your workspace, reason about why those functions are expensive, and propose specific code changes. Because the AI can see both the profiling output and the source code simultaneously, it avoids the guesswork that is common in manual profiling workflows.
+The agent uses this data to cross-reference hotspot function names against the source files in your workspace, reason about why those functions are expensive, and propose specific code changes. Because the AI can see both the profiling output and the source code simultaneously, it avoids the guesswork that's common in manual profiling workflows.
 
-**Use case:** Automating the Code Hotspots recipe on a C++ application running on an Arm Neoverse target to identify and fix the most CPU-intensive functions. In this Learning Path, the agent drives three successive optimization passes — each validated by a re-profile before moving to the next — to achieve a measured ~12x runtime improvement.
+You'll use this tool in the following sections to automate the Code Hotspots recipe on a C++ application running on an Arm Neoverse target and identify and fix the most CPU-intensive functions. The agent will drive three successive optimization passes — each validated by a re-profile before moving to the next — to achieve a measured ~12x runtime improvement.
 
 ## How to interact with the Arm MCP Server for profiling
 
@@ -30,7 +31,7 @@ The Arm MCP Server supports the same interaction styles as the rest of its tool 
 
 ### Direct AI chat
 
-You can ask your AI assistant direct questions and it will invoke the `apx_recipe_run` tool when appropriate. For example:
+You can ask your AI assistant direct questions and it'll invoke the `apx_recipe_run` tool when appropriate. For example:
 
 ```text
 Run the Code Hotspots recipe on /home/ec2-user/Mandelbrot-Example/build/mandelbrot_single_thread_debug and tell me which functions are the hottest
@@ -44,18 +45,24 @@ For repeatable workflows, a prompt file encodes the full profiling sequence as a
 
 ### Agentic workflows
 
-Tools like GitHub Copilot Agent Mode, Claude Code, Kiro, and OpenAI Codex support autonomous multi-step execution. When you combine a prompt file with an agentic workflow, the profiling step is deterministic: the agent calls `arm-mcp/apx_recipe_run` through the Arm MCP Server, which runs the Performix recipe on your target and returns the identified hotspots as structured, reproducible data. The agent then reasons over those hotspots, locating the corresponding source code, forming a hypothesis about why each function is expensive, and proposing a targeted change — before rebuilding and calling `arm-mcp/apx_recipe_run` again to measure the delta. Every decision in the loop is grounded in the hotspot data returned by the tool; the AI never guesses at performance characteristics.
+Tools such as GitHub Copilot Agent Mode, Claude Code, Kiro, and OpenAI Codex support autonomous multi-step execution. When you combine a prompt file with an agentic workflow, the profiling step is deterministic: the agent calls `arm-mcp/apx_recipe_run` through the Arm MCP Server, which runs the Performix recipe on your target and returns the identified hotspots as structured, reproducible data. The agent then reasons over those hotspots, locating the corresponding source code, forming a hypothesis about why each function is expensive, and proposing a targeted change — before rebuilding and calling `arm-mcp/apx_recipe_run` again to measure the delta.
 
-## Setting up the Arm MCP Server
+Every decision in the loop is grounded in the hotspot data returned by the tool; the AI never guesses at performance characteristics.
 
-To use the Arm MCP Server with an AI coding assistant, you need to configure the assistant to connect to the MCP server. Connecting your assistant allows it to query Arm-specific tools, documentation, and capabilities exposed through the Model Context Protocol (MCP).
+## Set up the Arm MCP Server
 
-The required configuration steps vary by AI coding assistant. Refer to the installation guides below for step-by-step instructions on connecting the following AI coding assistants to the Arm MCP server:
+To use the Arm MCP Server with an AI coding assistant, configure the assistant to connect to the MCP server. Connecting your assistant allows it to query Arm-specific tools, documentation, and capabilities exposed through the Model Context Protocol (MCP).
+
+The required configuration steps vary by AI coding assistant. Refer to the following install guides for step-by-step instructions on connecting AI coding assistants to the Arm MCP server:
 
 - [GitHub Copilot](/install-guides/github-copilot/)
-- [Gemini CLI](/install-guides/gemini/)
+- [Antigravity CLI](/install-guides/antigravity/)
 - [Kiro CLI](/install-guides/kiro-cli/)
 - [Codex CLI](/install-guides/codex-cli/)
 - [Claude Code](/install-guides/claude-code/)
 
-In the next section, you'll build the Mandelbrot example application on your remote Arm server and confirm that Arm Performix can reach the target.
+## What you've learned and what's next
+
+You've now learned what the Arm Performix tool for the Arm MCP Server is and how the tool works. You've also learned why the tool is useful and how you can interact with it.
+
+Next, you'll build the Mandelbrot example application on your remote Arm server and confirm that Arm Performix can reach the target.

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/2-setup.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/2-setup.md
@@ -61,6 +61,6 @@ Note the absolute path to the binary on the remote server. You'll need this when
 
 ## What you've accomplished and what's next
 
-You now have everything in place for profiling: a compiled, debug-enabled binary on an Arm Neoverse target that Performix can reach.
+You've now got everything in place for profiling: a compiled, debug-enabled binary on an Arm Neoverse target that Performix can reach.
 
 Next, you'll create a GitHub Copilot prompt file to drive the Code Hotspots recipe through the Arm MCP Server.

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/2-setup.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/2-setup.md
@@ -1,5 +1,6 @@
 ---
 title: Build the Mandelbrot example on Arm Neoverse
+description: Build the Mandelbrot C++ example on an Arm Neoverse target and confirm the binary path that Performix will profile through the Arm MCP Server.
 weight: 3
 
 ### FIXED, DO NOT MODIFY
@@ -8,25 +9,29 @@ layout: learningpathall
 
 ## Prepare the profiling target
 
-In this section, you'll build the Mandelbrot C++ application on your remote Arm server and confirm that Arm Performix can reach the target.
+You'll build and profile the Mandelbrot C++ application used in the [Find code hotspots with Arm Performix](/learning-paths/servers-and-cloud-computing/cpu_hotspot_performix/) Learning Path on your remote Arm server and confirm that Arm Performix can reach the target.
 
 ## About the example application
 
-This Learning Path profiles the same Mandelbrot C++ application used in the [Find code hotspots with Arm Performix](/learning-paths/servers-and-cloud-computing/cpu_hotspot_performix/) Learning Path. It generates a 1920×1080 bitmap of the Mandelbrot set by iterating a simple recurrence for each pixel and is compute-heavy enough to produce clear profiling signal without requiring a long-running workload. The single-threaded build is intentionally unoptimized so that the hotspot analysis surfaces a meaningful target for improvement.
+The application generates a 1920×1080 bitmap of the Mandelbrot set by iterating a simple recurrence for each pixel and is compute-heavy enough to produce clear profiling signal without requiring a long-running workload. The single-threaded build is intentionally unoptimized so that the hotspot analysis surfaces a meaningful target for improvement.
 
-You don't need to understand the Mandelbrot algorithm to follow this Learning Path.
+You don't need to understand the Mandelbrot algorithm to follow the Learning Path.
 
 ## Connect to your Arm target
 
-For profiling, the Learning Path targets an AWS Graviton3 metal instance (`m7g.metal`) with 64 Neoverse V1 cores. Any Arm Linux server with multiple cores works for the parallelization step, but a metal instance gives you direct access to all hardware threads without the overhead of virtualization.
+For profiling, you'll target an AWS Graviton3-based metal instance (`m7g.metal`) with 64 Neoverse V1 cores. Any Arm Linux server with multiple cores works for the parallelization step, but a metal instance gives you direct access to all hardware threads without the overhead of virtualization.
 
-You connect to the remote target via SSH through the Arm MCP Server. The `apx_recipe_run` tool accepts the target host IP address and SSH username directly as parameters, so there is no separate target configuration step required. Ensure your remote Arm server is reachable over SSH from the machine running your AI coding assistant, and follow the [Configure your MCP client](https://github.com/arm/mcp?tab=readme-ov-file#2-configure-your-mcp-client) instructions in the Arm MCP Server repository before continuing.
+Connect to the remote target via SSH through the Arm MCP Server. The `apx_recipe_run` tool accepts the target host IP address and SSH username directly as parameters, so there's no separate target configuration step required.
+
+Ensure your remote Arm server is reachable over SSH from the machine running your AI coding assistant, and follow the [Configure your MCP client](https://github.com/arm/mcp?tab=readme-ov-file#2-configure-your-mcp-client) instructions in the Arm MCP Server repository before continuing.
 
 ## Build the application on the remote server
 
-In this section you'll build the debug binary for the Mandelbrot C++ application, the sample workload you'll profile in the next section.
+Build the debug binary for the Mandelbrot C++ application, the sample workload that you'll profile in the next section.
 
-Connect to the remote server over SSH and install the required build tools. On `dnf`-based systems such as Amazon Linux 2023 or RHEL, run:
+Connect to the remote server over SSH and install the required build tools.
+
+On `dnf`-based systems such as Amazon Linux 2023 or RHEL, run:
 
 ```bash
 sudo dnf update && sudo dnf install -y git gcc-c++ make
@@ -48,10 +53,13 @@ ls -lh build/mandelbrot_single_thread_debug
 
 ## Verify the binary path for Performix
 
-Note the absolute path to the binary on the remote server. You'll need this when configuring the Code Hotspots recipe in the next section. For the default setup the path is:
+Note the absolute path to the binary on the remote server. You'll need this when configuring the Code Hotspots recipe in the next section. For the default setup, the path is:
 
 ```text
 /home/ec2-user/Mandelbrot-Example/build/mandelbrot_single_thread_debug
 ```
+## What you've accomplished and what's next
 
-You now have everything in place: a compiled, debug-enabled binary on an Arm Neoverse target that Performix can reach. In the next section, you'll create a GitHub Copilot prompt file to drive the Code Hotspots recipe through the Arm MCP Server.
+You now have everything in place for profiling: a compiled, debug-enabled binary on an Arm Neoverse target that Performix can reach.
+
+Next, you'll create a GitHub Copilot prompt file to drive the Code Hotspots recipe through the Arm MCP Server.

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/2-setup.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/2-setup.md
@@ -19,7 +19,7 @@ You don't need to understand the Mandelbrot algorithm to follow the Learning Pat
 
 ## Connect to your Arm target
 
-For profiling, you'll target an AWS Graviton3-based metal instance (`m7g.metal`) with 64 Neoverse V1 cores. Any Arm Linux server with multiple cores works for the parallelization step, but a metal instance gives you direct access to all hardware threads without the overhead of virtualization.
+For profiling, you'll target an AWS Graviton3-based metal instance (`m7g.metal`) with 64 Neoverse V1 cores. Any Arm Linux server with multiple cores works, but a metal instance gives you direct access to all hardware threads without the overhead of virtualization.
 
 Connect to the remote target via SSH through the Arm MCP Server. The `apx_recipe_run` tool accepts the target host IP address and SSH username directly as parameters, so there's no separate target configuration step required.
 
@@ -58,6 +58,7 @@ Note the absolute path to the binary on the remote server. You'll need this when
 ```text
 /home/ec2-user/Mandelbrot-Example/build/mandelbrot_single_thread_debug
 ```
+
 ## What you've accomplished and what's next
 
 You now have everything in place for profiling: a compiled, debug-enabled binary on an Arm Neoverse target that Performix can reach.

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/3-run-hotspot.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/3-run-hotspot.md
@@ -1,5 +1,6 @@
 ---
 title: Run Code Hotspots with an AI agent
+description: Use a GitHub Copilot prompt file to run the Arm Performix Code Hotspots recipe through the Arm MCP Server and review structured hotspot output.
 weight: 4
 
 ### FIXED, DO NOT MODIFY
@@ -8,15 +9,15 @@ layout: learningpathall
 
 ## Execute profiling through the Arm MCP Server
 
-In this section, you'll use a GitHub Copilot prompt file to drive the Code Hotspots recipe through the Arm MCP Server. The agent confirms your target details, runs the recipe autonomously, and returns structured profiling results.
+You'll use a GitHub Copilot prompt file to drive the Code Hotspots recipe through the Arm MCP Server. The agent confirms your target details, runs the recipe autonomously, and returns structured profiling results.
 
 ## Use the Arm MCP arm-hotspots-optimization prompt file
 
 {{% notice Note %}}
-The section uses Visual Studio Code with GitHub Copilot. If you prefer a different AI assistant, see [Configure other AI agents](#configure-other-ai-agents) at the end of this section for equivalent configurations for Kiro and OpenAI Codex.
+If you prefer a different AI assistant than Visual Studio Code with GitHub Copilot, see [Configure other AI agents](#configure-other-ai-agents) at the end of this section for equivalent configurations for Kiro and OpenAI Codex.
 {{% /notice %}}
 
-The Arm MCP Server repository includes a ready-made prompt file called `arm-hotspots-optimization` that guides an AI agent through the full Code Hotspots workflow: baseline profiling, hotspot identification, targeted code changes, and re-profiling to confirm the improvement. You don't need to write this file yourself, you copy it from the repository.
+The Arm MCP Server repository includes a ready-made prompt file called `arm-hotspots-optimization` that guides an AI agent through the full Code Hotspots workflow: baseline profiling, hotspot identification, targeted code changes, and re-profiling to confirm the improvement. You don't need to write this file yourself. You can copy it from the repository.
 
 Open the Mandelbrot-Example repository in Visual Studio Code on your local machine. Create the directory `.github/prompts/` if it doesn't already exist:
 
@@ -43,27 +44,29 @@ With GitHub Copilot connected to the Arm MCP Server, open Copilot Chat in Agent 
 
 Copilot reads the prompt file and walks you through a series of confirmation questions before running anything. Answer each question in turn:
 
-**Step 1:** Select where the workload is running — choose **Remote machine (SSH)** for an Arm cloud instance.
+First, select where the workload is running — choose **Remote machine (SSH)** for an Arm cloud instance.
 
 ![GitHub Copilot agent chat asking where the workload is running, with menu choices for localhost or remote machine (SSH)#center](images/mcp-performix-setup1.png "Agent prompt: select workload location")
 
-**Step 2:** Enter the absolute path to the binary on the remote server.
+Next, enter the absolute path to the binary on the remote server.
 
 ![GitHub Copilot agent chat prompting the user to enter the absolute path to the executable or workload command#center](images/mcp-performix-setup2.png "Agent prompt: enter binary path")
 
-**Step 3:** Enter the SSH username used to connect to the target machine.
+Then, enter the SSH username used to connect to the target machine.
 
 ![GitHub Copilot agent chat asking what SSH username should be used to connect to the target machine#center](images/mcp-performix-setup3.png "Agent prompt: enter SSH username")
 
-**Step 4:** Enter the IP address or hostname of your remote Arm machine.
+Finally, enter the IP address or hostname of your remote Arm machine.
 
 ![GitHub Copilot agent chat asking for the IP address of the remote Arm machine#center](images/mcp-performix-setup4.png "Agent prompt: enter remote IP address")
 
-Once you've answered all four questions, the agent calls `arm-mcp/apx_recipe_run` to start the Code Hotspots recipe and waits for the Mandelbrot binary to finish. The single-threaded build takes approximately one to two minutes to run.
+After you've answered all four questions, the agent calls `arm-mcp/apx_recipe_run` to start the Code Hotspots recipe and waits for the Mandelbrot binary to finish. The single-threaded build takes approximately one to two minutes to run.
 
 ## Read the agent output
 
-Once the profiling run completes, the agent returns a structured summary. The output looks similar to the following:
+After the profiling run completes, the agent returns a structured summary.
+
+The output is similar to:
 
 ```text
 Code Hotspots recipe completed. Top functions by sample percentage:
@@ -115,17 +118,9 @@ Proposed optimizations (not yet applied):
      and auto-vectorization of the tight iteration loop.
 ```
 
-The agent has surfaced the same hotspots that a manual Performix session would identify — `__complex_abs` and `hypotf64` dominating through the inner loop in `Mandelbrot::getIterations`, plus significant `std::complex` operator overhead from the debug build — without you needing to open the Performix GUI, configure the recipe, or manually inspect the flame graph.
+The agent has surfaced the same hotspots that a manual Performix session would identify: `__complex_abs` and `hypotf64` dominating through the inner loop in `Mandelbrot::getIterations`, plus significant `std::complex` operator overhead from the debug build. You don't need to open the Performix GUI, configure the recipe, or manually inspect the flame graph.
 
-## What you've accomplished and what's next
-
-You've used the Arm MCP `arm-hotspots-optimization` prompt file — invoked with `/arm-hotspots-optimization` — to drive the Arm Performix Code Hotspots recipe end-to-end through the Arm MCP Server. The agent confirmed your target details, ran the recipe autonomously, and identified `getIterations` as the dominant hotspot. It found that ~33% of total CPU time is spent inside the sqrt-based escape condition check (`__complex_abs` and `hypotf64`), and noted significant `std::complex` operator overhead from the debug build. It proposed three targeted optimizations: eliminating the sqrt, replacing `std::complex` with raw double arithmetic, and enabling compiler optimizations.
-
-In the next section, you'll apply those optimizations one at a time, rebuilding and re-profiling after each change to confirm the improvement with real data.
-
----
-
-## Configure other AI agents
+## (Optional) Configure other AI agents
 
 The same profiling workflow works with other agentic AI assistants. The core prompt logic is identical across tools; only the file location and invocation format changes.
 
@@ -156,3 +151,11 @@ You can view the full prompt at [github.com/arm/mcp](https://github.com/arm/mcp/
 ```bash
 codex /prompts:arm-hotspots-optimization
 ```
+
+## What you've accomplished and what's next
+
+You've used the Arm MCP `arm-hotspots-optimization` prompt file — invoked with `/arm-hotspots-optimization` — to drive the Arm Performix Code Hotspots recipe end-to-end through the Arm MCP Server.
+
+The agent confirmed your target details, ran the recipe autonomously, and identified `getIterations` as the dominant hotspot. It found that ~33% of total CPU time is spent inside the sqrt-based escape condition check (`__complex_abs` and `hypotf64`), and noted significant `std::complex` operator overhead from the debug build. It proposed three targeted optimizations: eliminating the sqrt, replacing `std::complex` with raw double arithmetic, and enabling compiler optimizations.
+
+Next, you'll apply those optimizations one at a time, rebuilding and re-profiling after each change to confirm the improvement with real data.

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/3-run-hotspot.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/3-run-hotspot.md
@@ -154,7 +154,7 @@ codex /prompts:arm-hotspots-optimization
 
 ## What you've accomplished and what's next
 
-You've used the Arm MCP `arm-hotspots-optimization` prompt file — invoked with `/arm-hotspots-optimization` — to drive the Arm Performix Code Hotspots recipe end-to-end through the Arm MCP Server.
+You've now used the Arm MCP `arm-hotspots-optimization` prompt file — invoked with `/arm-hotspots-optimization` — to drive the Arm Performix Code Hotspots recipe end-to-end through the Arm MCP Server.
 
 The agent confirmed your target details, ran the recipe autonomously, and identified `getIterations` as the dominant hotspot. It found that ~33% of total CPU time is spent inside the sqrt-based escape condition check (`__complex_abs` and `hypotf64`), and noted significant `std::complex` operator overhead from the debug build. It proposed three targeted optimizations: eliminating the sqrt, replacing `std::complex` with raw double arithmetic, and enabling compiler optimizations.
 

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
@@ -37,7 +37,9 @@ and compare with the previous run. Has the proportion of samples in
 __complex_abs and hypotf64 changed?
 ```
 
-The agent calls `arm-mcp/apx_recipe_run` again and returns the comparison. The `std::__complex_abs` and `hypotf64` symbols disappear from the hotspot list entirely. Both functions are gone because the squared-magnitude check never calls them. The hotspot distribution shifts: `getIterations` drops from 28.5% to 18.4% self-time, and the freed CPU budget is now visible in `std::complex` operator symbols. The overall sample count is slightly lower, but the profile structure reveals that `std::complex` operator overhead is now the next bottleneck to address.
+The agent calls `arm-mcp/apx_recipe_run` again and returns the comparison. The `std::__complex_abs` and `hypotf64` symbols disappear from the hotspot list entirely. Both functions are gone because the squared-magnitude check never calls them.
+
+The hotspot distribution shifts: `getIterations` drops from 28.5% to 18.4% self-time, and the freed CPU budget is now visible in `std::complex` operator symbols. The overall sample count is slightly lower, but the profile structure reveals that `std::complex` operator overhead is now the next bottleneck to address.
 
 ### Replace `std::complex<double>` with raw double arithmetic
 
@@ -59,11 +61,15 @@ Code Hotspots recipe and compare with the previous run. Have the
 std::complex operator symbols disappeared from the hotspot list?
 ```
 
-The agent calls `arm-mcp/apx_recipe_run` and returns the comparison. Every `std::complex` function—`__muldc3`, `operator*=`, `operator+=`, `operator+`, `operator*`, `__rep`—is gone from the profile. Total profile sample count drops from approximately 48,750 (baseline) to approximately 11,457, a reduction of ~76% and a measured ~4x speedup.
+The agent calls `arm-mcp/apx_recipe_run` and returns the comparison. Every `std::complex` function—`__muldc3`, `operator*=`, `operator+=`, `operator+`, `operator*`, `__rep`—is gone from the profile. 
+
+Total profile sample count drops from approximately 48,750 (baseline) to approximately 11,457, a reduction of ~76% and a measured ~4x speedup.
 
 ### Enable compiler optimizations with `-O3`
 
-Both previous changes were applied to the debug binary, compiled with `-O0` (no optimization). At `-O0`, the compiler doesn't inline any function calls, which is why `std::complex` operators appeared separately in the profile even after the algorithmic fix. Building with `-O3` lets the compiler inline `getIterations` into `draw`, unroll the inner loop, and auto-vectorize the scalar double arithmetic using the Arm NEON/ASIMD unit.
+Both previous changes were applied to the debug binary, compiled with `-O0` (no optimization). At `-O0`, the compiler doesn't inline any function calls, which is why `std::complex` operators appeared separately in the profile even after the algorithmic fix. 
+
+Building with `-O3` lets the compiler inline `getIterations` into `draw`, unroll the inner loop, and auto-vectorize the scalar double arithmetic using the Arm NEON/ASIMD unit.
 
 Ask the agent to rebuild with the release target and re-profile. If it hasn't already suggested this step, use the following prompt:
 

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
@@ -23,7 +23,7 @@ The agent will typically surface these optimizations itself based on the profili
 
 ### Eliminate the sqrt in the escape check
 
-The inner loop in `Mandelbrot::getIterations` calls `std::abs(z)` on every iteration to check whether the point has escaped. `std::abs` for `std::complex<double>` computes \(\sqrt{re^2 + im^2}\) via `hypotf64` — a full square root on every iteration. The escape condition \(abs(z) > THRESHOLD\) is mathematically equivalent to \(re^2 + im^2 > THRESHOLD^2\), so the square root is never needed.
+The inner loop in `Mandelbrot::getIterations` calls `std::abs(z)` on every iteration to check whether the point has escaped. `std::abs` for `std::complex<double>` computes $\sqrt{re^2 + im^2}$ via `hypotf64` — a full square root on every iteration. The escape condition $abs(z) > THRESHOLD$ is mathematically equivalent to $re^2 + im^2 > THRESHOLD^2$, so the square root is never needed.
 
 Ask the agent to apply the fix, rebuild, and re-profile in one step. If the agent hasn't already proposed this change, use the following prompt:
 
@@ -45,7 +45,7 @@ The hotspot distribution shifts: `getIterations` drops from 28.5% to 18.4% self-
 
 With `hypotf64` and `__complex_abs` removed, the profile now shows `std::complex` operator symbols (`operator+`, `operator*=`, `operator*`, `operator+=`, `__muldc3`, `__rep`) collectively consuming the majority of CPU time. These are all function-call overhead: the debug build disables inlining, so every arithmetic operation on `std::complex<double>` dispatches through the C++ standard library machinery.
 
-The fix is to replace `std::complex<double>` in `getIterations` with plain `double` variables for the real and imaginary parts. The Mandelbrot iteration \(z_{n+1} = z_n^2 + c\) expands algebraically to:
+The fix is to replace `std::complex<double>` in `getIterations` with plain `double` variables for the real and imaginary parts. The Mandelbrot iteration $z_{n+1} = z_n^2 + c$ expands algebraically to:
 
 $$re_{new} = re_z^2 - im_z^2 + re_c$$
 $$im_{new} = 2 \cdot re_z \cdot im_z + im_c$$

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
@@ -1,5 +1,6 @@
 ---
 title: Optimize code with AI-driven profiling feedback
+description: Apply AI-suggested C++ optimizations from Performix hotspot results and re-profile each change to validate the measured speedup on Arm Neoverse.
 weight: 5
 
 ### FIXED, DO NOT MODIFY
@@ -17,10 +18,10 @@ In the previous section, the agent identified three optimization opportunities:
 Rather than making these changes manually, you can ask the agent to apply each one for you. Because the Arm MCP Server connects to your remote target over SSH, the agent can edit the source files directly on the server, rebuild, and re-profile — all in a single turn. You'll validate each change by asking the agent to compare the new profiling results against the previous run before moving on.
 
 {{% notice Note %}}
-The agent will typically surface these optimizations itself based on the profiling results, without you needing to prompt it explicitly. The prompts shown in each section below are for explicit reference — you can use them if the agent hasn't already proposed the change, or to direct it to a specific optimization.
+The agent will typically surface these optimizations itself based on the profiling results, without you needing to prompt it explicitly. The following prompts are for explicit reference — you can use them if the agent hasn't already proposed the change, or to direct it to a specific optimization.
 {{% /notice %}}
 
-## Optimization 1: Eliminate the sqrt in the escape check
+### Eliminate the sqrt in the escape check
 
 The inner loop in `Mandelbrot::getIterations` calls `std::abs(z)` on every iteration to check whether the point has escaped. `std::abs` for `std::complex<double>` computes $\sqrt{re^2 + im^2}$ via `hypotf64` — a full square root on every iteration. The escape condition `abs(z) > THRESHOLD` is mathematically equivalent to `re² + im² > THRESHOLD²`, so the square root is never needed.
 
@@ -38,7 +39,7 @@ __complex_abs and hypotf64 changed?
 
 The agent calls `arm-mcp/apx_recipe_run` again and returns the comparison. The `std::__complex_abs` and `hypotf64` symbols disappear from the hotspot list entirely. Both functions are gone because the squared-magnitude check never calls them. The hotspot distribution shifts: `getIterations` drops from 28.5% to 18.4% self-time, and the freed CPU budget is now visible in `std::complex` operator symbols. The overall sample count is slightly lower, but the profile structure reveals that `std::complex` operator overhead is now the next bottleneck to address.
 
-## Optimization 2: Replace `std::complex<double>` with raw double arithmetic
+### Replace `std::complex<double>` with raw double arithmetic
 
 With `hypotf64` and `__complex_abs` removed, the profile now shows `std::complex` operator symbols (`operator+`, `operator*=`, `operator*`, `operator+=`, `__muldc3`, `__rep`) collectively consuming the majority of CPU time. These are all function-call overhead: the debug build disables inlining, so every arithmetic operation on `std::complex<double>` dispatches through the C++ standard library machinery.
 
@@ -60,7 +61,7 @@ std::complex operator symbols disappeared from the hotspot list?
 
 The agent calls `arm-mcp/apx_recipe_run` and returns the comparison. Every `std::complex` function—`__muldc3`, `operator*=`, `operator+=`, `operator+`, `operator*`, `__rep`—is gone from the profile. Total profile sample count drops from approximately 48,750 (baseline) to approximately 11,457, a reduction of ~76% and a measured ~4x speedup.
 
-## Optimization 3: Enable compiler optimizations with `-O3`
+### Enable compiler optimizations with `-O3`
 
 Both previous changes were applied to the debug binary, compiled with `-O0` (no optimization). At `-O0`, the compiler doesn't inline any function calls, which is why `std::complex` operators appeared separately in the profile even after the algorithmic fix. Building with `-O3` lets the compiler inline `getIterations` into `draw`, unroll the inner loop, and auto-vectorize the scalar double arithmetic using the Arm NEON/ASIMD unit.
 
@@ -78,14 +79,9 @@ The agent calls `arm-mcp/apx_recipe_run` on the new binary path and returns the 
 
 The only remaining hotspot is `Mandelbrot::draw` itself at ~98.6% of samples, which now includes both the iteration and colorizing passes. The colorizing pass calls `pow(255, hue)` per pixel — visible as `powf64` at ~0.7% — but this is a small fraction of total time at this scale.
 
-## Summary
+## What you've accomplished
 
-In this Learning Path, you combined the Arm MCP Server's `apx_recipe_run` tool with an AI agent to drive the complete Code Hotspots workflow. Starting from a single-threaded C++ baseline, the agent:
-
-- Ran the Code Hotspots recipe through a GitHub Copilot prompt file and retrieved structured profiling results, identifying `getIterations` and the sqrt-based escape check as the dominant hotspots
-- Eliminated `__complex_abs` and `hypotf64` by replacing `abs(z) > THRESHOLD` with a squared-magnitude check, removing ~33% of CPU overhead
-- Replaced `std::complex<double>` with plain `double` arithmetic, removing all std::complex operator call overhead and delivering a ~4x speedup over the original baseline
-- Enabled `-O3` to let the compiler inline `getIterations`, unroll the loop, and auto-vectorize, delivering a further 3x improvement
+You've now applied AI-suggested optimizations to the Mandelbrot application.
 
 The cumulative result, measured by profile sample counts, was a reduction from approximately 48,750 baseline samples to approximately 3,997 — a ~12x speedup — through three rounds of code changes, each validated by a re-profile before moving to the next.
 

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
@@ -81,7 +81,7 @@ The only remaining hotspot is `Mandelbrot::draw` itself at ~98.6% of samples, wh
 
 ## What you've accomplished
 
-You've now applied AI-suggested optimizations to the Mandelbrot application.
+You've now applied AI-suggested optimizations — such as replacing `std::complex<double>` with plain `double` arithmetic, enabling `-03` for compiler optimizations, and eliminating sqrt in the escape check — to the Mandelbrot application.
 
 The cumulative result, measured by profile sample counts, was a reduction from approximately 48,750 baseline samples to approximately 3,997 — a ~12x speedup — through three rounds of code changes, each validated by a re-profile before moving to the next.
 

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
@@ -23,7 +23,7 @@ The agent will typically surface these optimizations itself based on the profili
 
 ### Eliminate the sqrt in the escape check
 
-The inner loop in `Mandelbrot::getIterations` calls `std::abs(z)` on every iteration to check whether the point has escaped. `std::abs` for `std::complex<double>` computes $\sqrt{re^2 + im^2}$ via `hypotf64` — a full square root on every iteration. The escape condition `abs(z) > THRESHOLD` is mathematically equivalent to `re² + im² > THRESHOLD²`, so the square root is never needed.
+The inner loop in `Mandelbrot::getIterations` calls `std::abs(z)` on every iteration to check whether the point has escaped. `std::abs` for `std::complex<double>` computes \(\sqrt{re^2 + im^2}\) via `hypotf64` — a full square root on every iteration. The escape condition \(abs(z) > THRESHOLD\) is mathematically equivalent to \(re^2 + im^2 > THRESHOLD^2\), so the square root is never needed.
 
 Ask the agent to apply the fix, rebuild, and re-profile in one step. If the agent hasn't already proposed this change, use the following prompt:
 
@@ -45,7 +45,7 @@ The hotspot distribution shifts: `getIterations` drops from 28.5% to 18.4% self-
 
 With `hypotf64` and `__complex_abs` removed, the profile now shows `std::complex` operator symbols (`operator+`, `operator*=`, `operator*`, `operator+=`, `__muldc3`, `__rep`) collectively consuming the majority of CPU time. These are all function-call overhead: the debug build disables inlining, so every arithmetic operation on `std::complex<double>` dispatches through the C++ standard library machinery.
 
-The fix is to replace `std::complex<double>` in `getIterations` with plain `double` variables for the real and imaginary parts. The Mandelbrot iteration $z_{n+1} = z_n^2 + c$ expands algebraically to:
+The fix is to replace `std::complex<double>` in `getIterations` with plain `double` variables for the real and imaginary parts. The Mandelbrot iteration \(z_{n+1} = z_n^2 + c\) expands algebraically to:
 
 $$re_{new} = re_z^2 - im_z^2 + re_c$$
 $$im_{new} = 2 \cdot re_z \cdot im_z + im_c$$

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
@@ -81,7 +81,7 @@ The only remaining hotspot is `Mandelbrot::draw` itself at ~98.6% of samples, wh
 
 ## What you've accomplished
 
-You've now applied AI-suggested optimizations — such as replacing `std::complex<double>` with plain `double` arithmetic, enabling `-03` for compiler optimizations, and eliminating sqrt in the escape check — to the Mandelbrot application.
+You've now applied AI-suggested optimizations — such as replacing `std::complex<double>` with plain `double` arithmetic, enabling `-O3` for compiler optimizations, and eliminating sqrt in the escape check — to the Mandelbrot application.
 
 The cumulative result, measured by profile sample counts, was a reduction from approximately 48,750 baseline samples to approximately 3,997 — a ~12x speedup — through three rounds of code changes, each validated by a re-profile before moving to the next.
 

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/4-optimize.md
@@ -18,7 +18,7 @@ In the previous section, the agent identified three optimization opportunities:
 Rather than making these changes manually, you can ask the agent to apply each one for you. Because the Arm MCP Server connects to your remote target over SSH, the agent can edit the source files directly on the server, rebuild, and re-profile — all in a single turn. You'll validate each change by asking the agent to compare the new profiling results against the previous run before moving on.
 
 {{% notice Note %}}
-The agent will typically surface these optimizations itself based on the profiling results, without you needing to prompt it explicitly. The following prompts are for explicit reference — you can use them if the agent hasn't already proposed the change, or to direct it to a specific optimization.
+The agent will typically surface these optimizations itself based on the profiling results, without you needing to prompt it explicitly. The following prompts are for explicit reference. You can use them if the agent hasn't already proposed the change, or to direct it to a specific optimization.
 {{% /notice %}}
 
 ### Eliminate the sqrt in the escape check

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/_index.md
@@ -19,9 +19,57 @@ prerequisites:
     - Access to Arm Performix configured with the remote Arm target. See the [Arm Performix install guide](/install-guides/performix/) for setup instructions
     - Basic understanding of C++
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-07T16:22:08Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: a81d31a804debf71196a478bdf388c9e58b6dab67a9e881b916f3d0169d9555d
+  summary_generated_at: '2026-07-07T16:22:08Z'
+  summary_source_hash: a81d31a804debf71196a478bdf388c9e58b6dab67a9e881b916f3d0169d9555d
+  faq_generated_at: '2026-07-07T16:22:08Z'
+  faq_source_hash: a81d31a804debf71196a478bdf388c9e58b6dab67a9e881b916f3d0169d9555d
+  summary: >-
+    You'll combine the Arm MCP Server's `apx_recipe_run` tool with an AI agent to drive the complete Code Hotspots workflow to profile on Arm Neoverse. First, you'll build an intentionally unoptimized Mandelbrot
+    C++ application on a remote Arm Linux target, then use a GitHub Copilot prompt file to run
+    the Performix Code Hotspots recipe. The agent confirms target details, executes collection,
+    and returns a flame graph with structured hotspot data to pinpoint the hottest functions.
+    Guided by the agent, you'll apply concrete code changes, such as math simplifications and enabling
+    a higher optimization level, directly on the server over SSH. Then, you'll re-run the recipe to compare
+    results. The end-to-end flow keeps profiling, interpretation, and edits within a single AI-assisted
+    loop.
+  faqs:
+  - question: Which prompt file should I use to run the Code Hotspots recipe?
+    answer: >-
+      Use the `arm-hotspots-optimization` prompt file from the Arm MCP Server repository with GitHub
+      Copilot. It directs the agent to confirm the remote target, run the recipe, and return structured
+      profiling results.
+  - question: What result should I expect after the profiling run completes?
+    answer: >-
+      Expect a flame graph and a hotspot summary that highlights the hottest functions in the
+      Mandelbrot application. Use these outputs to guide which code changes to apply first.
+  - question: Should I compile the Mandelbrot example with optimizations before profiling?
+    answer: >-
+      No. The single-threaded, unoptimized build is intentional so the hotspot analysis produces
+      a clear signal. The agent later proposes enabling -O3 as part of the optimization pass.
+  - question: How do I know the agent is targeting the correct machine?
+    answer: >-
+      The agent explicitly confirms your remote target details before running the Code Hotspots
+      recipe. Review this confirmation and proceed only if it matches your intended Arm target.
+  - question: What should I check if the Code Hotspots run fails to start?
+    answer: >-
+      Confirm that Arm Performix is configured with your remote Arm target and that the MCP Server
+      can reach it over SSH. Also verify that the Mandelbrot application builds on the target
+      system.
+# END generated_summary_faq
+
 author: Pareena Verma
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 

--- a/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/performix-mcp-agent/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Identify code hotspots using Arm Performix through the Arm MCP Server
+title: Identify and optimize code hotspots using Arm Performix through the Arm MCP Server
 
 description: Learn how to use an AI agent and the Performix tool through the Arm MCP Server to run the Code Hotspots recipe on a C++ application, interpret flame graph results, and apply targeted optimizations on Arm Neoverse.
 
@@ -34,7 +34,7 @@ generated_summary_faq:
   faq_generated_at: '2026-07-07T16:22:08Z'
   faq_source_hash: a81d31a804debf71196a478bdf388c9e58b6dab67a9e881b916f3d0169d9555d
   summary: >-
-    You'll combine the Arm MCP Server's `apx_recipe_run` tool with an AI agent to drive the complete Code Hotspots workflow to profile on Arm Neoverse. First, you'll build an intentionally unoptimized Mandelbrot
+    You'll combine the Arm MCP Server's `apx_recipe_run` tool with an AI agent to run the complete Code Hotspots workflow on an Arm Neoverse target. First, you'll build an intentionally unoptimized Mandelbrot
     C++ application on a remote Arm Linux target, then use a GitHub Copilot prompt file to run
     the Performix Code Hotspots recipe. The agent confirms target details, executes collection,
     and returns a flame graph with structured hotspot data to pinpoint the hottest functions.
@@ -55,7 +55,7 @@ generated_summary_faq:
   - question: Should I compile the Mandelbrot example with optimizations before profiling?
     answer: >-
       No. The single-threaded, unoptimized build is intentional so the hotspot analysis produces
-      a clear signal. The agent later proposes enabling -O3 as part of the optimization pass.
+      a clear signal. The agent later proposes enabling `-O3` as part of the optimization pass.
   - question: How do I know the agent is targeting the correct machine?
     answer: >-
       The agent explicitly confirms your remote target details before running the Code Hotspots

--- a/themes/arm-design-system-hugo-theme/layouts/partials/math.html
+++ b/themes/arm-design-system-hugo-theme/layouts/partials/math.html
@@ -3,7 +3,7 @@
   MathJax = {
     tex: {
       displayMath: [['\\[', '\\]'], ['$$', '$$']],  // block
-      inlineMath: [['\\(', '\\)']]                  // inline
+      inlineMath: [['\\(', '\\)'], ['$', '$']]                  // inline
     },
     loader:{
       load: ['ui/safe']


### PR DESCRIPTION
Part of my sporadic updates to existing LPs.

Made some skill-based style and structure updates, added per-page metadata descriptions, summary, and FAQs. 

Also fixed an issue with the rendering of inline mathematical equations. Updated metadata formatting skill to account for mathematical equations.

Before:
<img width="1033" height="75" alt="math-rendering-before" src="https://github.com/user-attachments/assets/80d6ba7a-742f-4c73-8dc3-34b39f15185b" />

After:
<img width="1036" height="80" alt="math-rendering-after" src="https://github.com/user-attachments/assets/bc9d282d-4736-4f68-a982-4fd8d80619ae" />


I recommend allowing only `$..$` and `$$...$$` for equations in `math.html` for ease of use, but I didn't want to make that change in case it broke something. That could potentially be a separate PR.

Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [ ] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [ ] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
