### PR TITLE
[FEAT] Add optional light mode

### DIFF
--- a/.github/workflows/test-lp.yml
+++ b/.github/workflows/test-lp.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Run hugo command to test site builds
         run: |
           hugo
+      - name: Test theme preference behavior
+        run: node --test tools/tests/theme-preference.test.mjs
       - name: Get all changed markdown files
         id: changed-markdown-files
         uses: tj-actions/changed-files@v46

--- a/assets/css/cross-page.css
+++ b/assets/css/cross-page.css
@@ -178,6 +178,28 @@ arm-top-navigation:not(:defined) {
     min-height: 60px;
 }
 
+.skip-link {
+    position: fixed;
+    top: 0;
+    left: 1rem;
+    z-index: 20000;
+    padding: 0.75rem 1rem;
+    color: #ffffff;
+    background: var(--ads-ui-ink-100, #080225);
+    border: 2px solid var(--ads-brand-horizon-blue, #0057ff);
+    border-radius: 0 0 4px 4px;
+    transform: translateY(-120%);
+    transition: transform 120ms ease;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+    color: #ffffff;
+    transform: translateY(0);
+    outline: 3px solid var(--ads-brand-horizon-blue, #0057ff);
+    outline-offset: 2px;
+}
+
 /* Fix global nav height */
 /* The arm-global-web-components script renders a position:fixed nav (0 flow space)
    and may inject a 50px sub-navigation bar in flow */

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -216,6 +216,10 @@ table.contributor-table tbody {
     background-color: var(--ads-ui-ink-90);
 }
 
+.homepage-license {
+    color: #A3A8AE;
+}
+
 
 
 

--- a/assets/css/light-mode.css
+++ b/assets/css/light-mode.css
@@ -1,0 +1,464 @@
+html[theme='light'] {
+    color-scheme: light;
+    --learn-background: #f7f5fa;
+    --learn-surface: #ffffff;
+    --learn-surface-muted: #f1edf7;
+    --learn-border: #ddd6e8;
+    --learn-border-strong: #b9adc9;
+    --learn-text: #17242d;
+    --learn-text-muted: #354751;
+    --learn-link: #5520c3;
+    --learn-link-hover: #35107f;
+    --learn-accent: var(--lp-accent-primary, #6023de);
+    --learn-accent-soft: #eee7fb;
+    --learn-violet: var(--lp-accent-primary, #6023de);
+    --learn-lilac: var(--lp-accent-secondary, #d1bafc);
+    --learn-brand-gradient: linear-gradient(115deg, var(--learn-violet) 0%, #9c6bea 58%, var(--learn-lilac) 100%);
+    --learn-shadow: 0 10px 30px rgba(16, 24, 32, 0.08);
+    --learn-shadow-hover: 0 18px 42px rgba(96, 35, 222, 0.18);
+
+    --ads-color: var(--learn-text);
+    --ads-heading-color: #101b22;
+    --ads-link-color: var(--learn-link);
+    --ads-table-border-color: var(--learn-border);
+}
+
+html[theme='dark'] {
+    color-scheme: dark;
+}
+
+html[theme='light'] body {
+    color: var(--learn-text);
+    background: var(--learn-background);
+    background-image: none;
+}
+
+html[theme='light'] body.home-page {
+    background-image:
+        radial-gradient(circle at 8% 8%, rgba(96, 35, 222, 0.11), transparent 25rem),
+        radial-gradient(circle at 92% 20%, rgba(209, 186, 252, 0.28), transparent 31rem),
+        linear-gradient(180deg, #ffffff 0, var(--learn-background) 34rem);
+    background-repeat: no-repeat;
+}
+
+html[theme='light'] a {
+    color: var(--learn-link);
+}
+
+html[theme='light'] a:hover {
+    color: var(--learn-link-hover);
+}
+
+html[theme='light'] ads-button {
+    --ads-button-background-color-primary: var(--learn-accent);
+    --ads-button-background-color-primary-hover: #4d1aae;
+    --ads-button-border-color-primary: var(--learn-accent);
+    --ads-button-border-color-primary-hover: #4d1aae;
+    --ads-button-color-primary: #ffffff;
+    --ads-button-color-primary-hover: #ffffff;
+}
+
+html[theme='light'] ads-cta-button {
+    --ads-cta-button-background-color-primary: var(--learn-accent);
+    --ads-cta-button-background-color-primary-hover: #4d1aae;
+    --ads-cta-button-border-color-primary: var(--learn-accent);
+    --ads-cta-button-border-color-primary-hover: #4d1aae;
+    --ads-cta-button-color-primary: #ffffff;
+    --ads-cta-button-color-primary-hover: #ffffff;
+}
+
+html[theme='light'] #main {
+    color: var(--learn-text);
+}
+
+html[theme='light'] #only-breadcrumb-masthead {
+    background: #101820;
+}
+
+html[theme='light'] div.content-box {
+    position: relative;
+    overflow: hidden;
+    border-color: var(--learn-border);
+    border-radius: 8px;
+    background: var(--learn-surface);
+    box-shadow: var(--learn-shadow);
+}
+
+html[theme='light'] div.content-box::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    height: 3px;
+    background: var(--learn-brand-gradient);
+    content: '';
+}
+
+html[theme='light'] div.markdown-content-div,
+html[theme='light'] div.markdown-content-div p,
+html[theme='light'] div.markdown-content-div li {
+    color: var(--learn-text);
+}
+
+html[theme='light'] .u-text-color-arm-light-grey,
+html[theme='light'] .u-text-color-arm-light-grey-alt,
+html[theme='light'] .u-text-color-arm-dark-grey,
+html[theme='light'] .u-text-color-arm-grey {
+    color: var(--learn-text-muted) !important;
+}
+
+html[theme='light'] div.markdown-content-div > table,
+html[theme='light'] div.markdown-content-div > table tbody,
+html[theme='light'] .normal-horizontal-tabs table tbody {
+    background: var(--learn-surface);
+}
+
+html[theme='light'] div.markdown-content-div table th,
+html[theme='light'] .normal-horizontal-tabs table thead th {
+    color: var(--learn-text);
+    background: var(--learn-surface-muted);
+}
+
+html[theme='light'] div.markdown-content-div table th,
+html[theme='light'] div.markdown-content-div table td,
+html[theme='light'] .normal-horizontal-tabs table th,
+html[theme='light'] .normal-horizontal-tabs table td {
+    border-color: var(--learn-border);
+}
+
+html[theme='light'] code:not([class*='language-']) {
+    color: #7a2e00;
+    background: #f2ede8;
+}
+
+html[theme='light'] ads-card.notice-callout {
+    --ads-card-background-color: #eee7fb;
+    --ads-card-border-color: #5520c3;
+    --ads-card-border-color-hover: #5520c3;
+}
+
+html[theme='light'] .normal-tabpane {
+    border: 1px solid var(--learn-border);
+    border-radius: 6px;
+    background: var(--learn-surface);
+    --ads-horizontal-tabs-navigation-background-color: var(--learn-surface);
+}
+
+html[theme='light'] .normal-horizontal-tabs {
+    --ads-horizontal-tabs-tab-color: var(--learn-text-muted);
+    --ads-horizontal-tabs-tab-color-active: var(--learn-accent);
+    --ads-horizontal-tabs-tab-color-hover: var(--learn-link-hover);
+    --ads-horizontal-tabs-underline-color: var(--learn-accent);
+    --ads-horizontal-tabs-tab-content-background-color: var(--learn-surface);
+}
+
+html[theme='light'] .tab-row,
+html[theme='light'] .tab-row.active {
+    background: transparent;
+}
+
+html[theme='light'] .tab-right-card {
+    border-color: var(--learn-border);
+    border-radius: 8px;
+    background: var(--learn-surface);
+    box-shadow: 0 2px 8px rgba(23, 36, 45, 0.05);
+    transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+html[theme='light'] .tab-right-card > h6 {
+    color: var(--learn-text-muted);
+}
+
+html[theme='light'] .tab-right-card.active {
+    border-color: var(--learn-accent);
+    background: var(--learn-accent-soft);
+    box-shadow: inset 4px 0 0 var(--learn-accent), 0 8px 20px rgba(96, 35, 222, 0.12);
+}
+
+html[theme='light'] .tab-right-card.active > h6 {
+    color: #42149d;
+    font-weight: 700;
+}
+
+html[theme='light'] .tab-row.inactive:hover,
+html[theme='light'] .tab-row.inactive:hover .tab-right-card {
+    border-color: #8a5be5;
+    background: #f5f0fd;
+}
+
+html[theme='light'] .tab-row.inactive:hover .tab-right-card {
+    transform: translateX(3px);
+}
+
+html[theme='light'] .tab-row.inactive:hover h6 {
+    color: var(--learn-link-hover);
+}
+
+html[theme='light'] div.github-div {
+    border-color: var(--learn-border);
+    border-radius: 6px;
+    background: var(--learn-surface);
+}
+
+html[theme='light'] p.github-link {
+    color: var(--learn-link);
+}
+
+html[theme='light'] div.content-head-mobile,
+html[theme='light'] .content-individual-mobile,
+html[theme='light'] div#facets-background {
+    border-color: var(--learn-border);
+    background: var(--learn-surface);
+}
+
+html[theme='light'] .content-individual-mobile.active {
+    border-color: var(--learn-accent);
+    background: var(--learn-accent-soft);
+}
+
+html[theme='light'] ads-card.path-card,
+html[theme='light'] ads-card.tool-card,
+html[theme='light'] ads-card.module-card {
+    --ads-card-background-color: var(--learn-surface);
+    --ads-card-background-color-hover: #fcfbfe;
+    --ads-card-border-color: var(--learn-border);
+    --ads-card-border-color-hover: var(--learn-accent);
+    --ads-card-box-shadow: 0 3px 12px rgba(23, 36, 45, 0.06);
+    --ads-card-box-shadow-hover: var(--learn-shadow-hover);
+}
+
+html[theme='light'] ads-card.path-card:not(.featured-path-card) ads-card-content,
+html[theme='light'] ads-card.tool-card ads-card-content,
+html[theme='light'] ads-card.module-card ads-card-content {
+    position: relative;
+    overflow: hidden;
+}
+
+html[theme='light'] ads-card.path-card:not(.featured-path-card) ads-card-content::after,
+html[theme='light'] ads-card.tool-card ads-card-content::after,
+html[theme='light'] ads-card.module-card ads-card-content::after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    height: 3px;
+    background: var(--learn-brand-gradient);
+    opacity: 0.55;
+    content: '';
+    transition: opacity 180ms ease;
+}
+
+html[theme='light'] ads-card.path-card:not(.featured-path-card):hover ads-card-content::after,
+html[theme='light'] ads-card.tool-card:hover ads-card-content::after,
+html[theme='light'] ads-card.module-card:hover ads-card-content::after {
+    opacity: 1;
+}
+
+html[theme='light'] .learning-path-title,
+html[theme='light'] .basics-title,
+html[theme='light'] ads-card.tool-card p {
+    color: #4d1aae;
+}
+
+html[theme='light'] .pinned-featured-label {
+    color: #42149d;
+}
+
+html[theme='light'] ads-card.path-card:hover .pinned-featured-label {
+    color: #35107f;
+}
+
+html[theme='light'] .card-subject,
+html[theme='light'] .card-date,
+html[theme='light'] .module-card-subtitle,
+html[theme='light'] #tag-preface {
+    color: var(--learn-text-muted);
+}
+
+html[theme='light'] .learning-path-subtitle,
+html[theme='light'] .tool-card-subtitle,
+html[theme='light'] .card-description,
+html[theme='light'] .filter-facet,
+html[theme='light'] .homepage-top-desc,
+html[theme='light'] .homepage-top-desc p {
+    color: var(--learn-text-muted) !important;
+}
+
+html[theme='light'] ads-expansion-panel.learning-path-filters {
+    --ads-expansion-panel-border-color: var(--learn-border);
+    --ads-expansion-panel-content-background-color: var(--learn-surface);
+    --ads-expansion-panel-toggle-background-color: var(--learn-surface);
+    --ads-expansion-panel-toggle-background-color-hover: var(--learn-surface-muted);
+}
+
+html[theme='light'] .filter-facet {
+    --ads-tag-background-color: var(--learn-surface);
+    --ads-tag-background-color-hover: var(--learn-accent-soft);
+    --ads-tag-border-color: 1px solid var(--learn-border-strong);
+    --ads-tag-border-color-hover: 1px solid var(--learn-accent);
+    --ads-tag-color: var(--learn-text-muted);
+    --ads-tag-color-hover: #42149d;
+}
+
+html[theme='light'] .main-topic-card {
+    position: relative;
+    overflow: hidden;
+    border-color: var(--learn-border);
+    background: var(--learn-surface);
+    box-shadow: var(--learn-shadow);
+}
+
+html[theme='light'] .main-topic-card::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    height: 4px;
+    background: var(--learn-brand-gradient);
+    content: '';
+    transform: scaleX(0.34);
+    transform-origin: left;
+    transition: transform 220ms ease;
+}
+
+html[theme='light'] .main-topic-card:hover {
+    border-color: var(--learn-accent);
+    background: #fcfbfe;
+    box-shadow: var(--learn-shadow-hover);
+}
+
+html[theme='light'] .main-topic-card:hover::before {
+    transform: scaleX(1);
+}
+
+html[theme='light'] .main-topic-title {
+    color: #4d1aae;
+}
+
+html[theme='light'] .main-topic-card:hover .main-topic-title {
+    color: #35107f;
+}
+
+html[theme='light'] .main-topic-card img[src*='main-topic-icons'] {
+    filter: brightness(0) saturate(100%) invert(20%) sepia(87%) saturate(4529%) hue-rotate(256deg) brightness(80%) contrast(101%);
+}
+
+html[theme='light'] .main-topic-card .main-topic-subtitle,
+html[theme='light'] .homepage-top-desc > p,
+html[theme='light'] .homepage-dynamic-bottom-spacing + p {
+    color: var(--learn-text-muted) !important;
+}
+
+html[theme='light'] #homepage-header {
+    color: #101b22;
+    background: linear-gradient(105deg, #35107f 4%, #6023de 58%, #8a5be5 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    filter: drop-shadow(0 12px 24px rgba(96, 35, 222, 0.14));
+}
+
+html[theme='light'] body.home-page #title-div {
+    position: relative;
+    isolation: isolate;
+}
+
+html[theme='light'] body.home-page .homepage-license {
+    color: var(--learn-text-muted);
+}
+
+html[theme='light'] table.contributor-table tbody {
+    background: var(--learn-surface);
+}
+
+button.theme-toggle {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 20;
+    display: none;
+    min-height: 3rem;
+    align-items: center;
+    width: 3rem;
+    justify-content: center;
+    padding: 0.55rem;
+    border: 2px solid transparent;
+    border-radius: 999px;
+    color: var(--learn-text, #ffffff);
+    background:
+        linear-gradient(var(--learn-surface, #1f2023), var(--learn-surface, #1f2023)) padding-box,
+        linear-gradient(135deg, #6023de, #d1bafc) border-box;
+    box-shadow: 0 10px 28px rgba(96, 35, 222, 0.24), 0 0 0 4px rgba(255, 255, 255, 0.72);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 700;
+    transition: box-shadow 180ms ease, transform 180ms ease;
+}
+
+html[data-theme-enabled='true'] button.theme-toggle {
+    display: inline-flex;
+}
+
+button.theme-toggle:hover {
+    box-shadow: 0 15px 34px rgba(96, 35, 222, 0.3), 0 0 0 5px rgba(209, 186, 252, 0.28);
+    transform: translateY(-3px) rotate(-4deg);
+}
+
+button.theme-toggle:focus-visible {
+    outline: 3px solid #7b45df;
+    outline-offset: 3px;
+}
+
+.theme-toggle__icon {
+    font-size: 1.25rem !important;
+    line-height: 1;
+    transition: transform 180ms ease;
+}
+
+button.theme-toggle:hover .theme-toggle__icon {
+    transform: rotate(12deg) scale(1.08);
+}
+
+.theme-toggle__label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+html[theme='dark'] button.theme-toggle {
+    color: #ffffff;
+    background:
+        linear-gradient(#1f2023, #1f2023) padding-box,
+        linear-gradient(135deg, #6023de, #d1bafc) border-box;
+    box-shadow: 0 10px 28px rgba(96, 35, 222, 0.24), 0 0 0 4px rgba(16, 24, 32, 0.72);
+}
+
+@media (max-width: 576px) {
+    button.theme-toggle {
+        right: 0.75rem;
+        bottom: 0.75rem;
+        padding: 0.55rem;
+    }
+
+}
+
+@media print {
+    button.theme-toggle {
+        display: none;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html[theme='light'] .main-topic-card,
+    html[theme='light'] .main-topic-card::before,
+    html[theme='light'] .tab-right-card,
+    button.theme-toggle,
+    .theme-toggle__icon {
+        transition: none;
+    }
+}

--- a/assets/css/light-mode.css
+++ b/assets/css/light-mode.css
@@ -56,6 +56,8 @@ html[theme='light'] ads-button {
     --ads-button-border-color-primary-hover: #4d1aae;
     --ads-button-color-primary: #ffffff;
     --ads-button-color-primary-hover: #ffffff;
+    --ads-button-color-secondary-hover: var(--learn-link-hover);
+    --ads-button-color-tertiary-hover: var(--learn-link-hover);
 }
 
 html[theme='light'] ads-cta-button {
@@ -65,6 +67,20 @@ html[theme='light'] ads-cta-button {
     --ads-cta-button-border-color-primary-hover: #4d1aae;
     --ads-cta-button-color-primary: #ffffff;
     --ads-cta-button-color-primary-hover: #ffffff;
+    --ads-cta-button-color-secondary-hover: var(--learn-link-hover);
+    --ads-cta-button-color-tertiary-hover: var(--learn-link-hover);
+}
+
+html[theme='light'] ads-cta-link {
+    --ads-cta-link-color-hover: var(--learn-link-hover);
+}
+
+html[theme='light'] ads-tag {
+    --ads-tag-color-hover: var(--learn-link-hover);
+}
+
+html[theme='light'] input[type='submit']:hover {
+    color: #ffffff;
 }
 
 html[theme='light'] #main {
@@ -129,6 +145,14 @@ html[theme='light'] .normal-horizontal-tabs table td {
 html[theme='light'] code:not([class*='language-']) {
     color: #7a2e00;
     background: #f2ede8;
+}
+
+html[theme='light'] pre[class*='language-'] a.token.url-link {
+    color: var(--learn-lilac);
+}
+
+html[theme='light'] pre[class*='language-'] a.token.url-link:hover {
+    color: #e5d8ff;
 }
 
 html[theme='light'] ads-card.notice-callout {
@@ -204,6 +228,23 @@ html[theme='light'] p.github-link {
     color: var(--learn-link);
 }
 
+html[theme='light'] p.github-link:hover {
+    color: var(--learn-link-hover);
+}
+
+html[theme='light'] .pagefind-ui__search-input:hover,
+html[theme='light'] .pagefind-ui__search-input:focus,
+html[theme='light'] .pagefind-ui__button:hover,
+html[theme='light'] .pagefind-ui__button:focus,
+html[theme='light'] .pagefind-ui__result-link:hover {
+    color: var(--learn-link-hover) !important;
+}
+
+html[theme='light'] .pagefind-ui__search-input:hover::placeholder,
+html[theme='light'] .pagefind-ui__search-input:focus::placeholder {
+    color: var(--learn-text-muted) !important;
+}
+
 html[theme='light'] div.content-head-mobile,
 html[theme='light'] .content-individual-mobile,
 html[theme='light'] div#facets-background {
@@ -225,6 +266,11 @@ html[theme='light'] ads-card.module-card {
     --ads-card-border-color-hover: var(--learn-accent);
     --ads-card-box-shadow: 0 3px 12px rgba(23, 36, 45, 0.06);
     --ads-card-box-shadow-hover: var(--learn-shadow-hover);
+}
+
+html[theme='light'] ads-card.path-card.featured-path-card ads-card-content::before {
+    background: var(--learn-brand-gradient);
+    opacity: 0.65;
 }
 
 html[theme='light'] ads-card.path-card:not(.featured-path-card) ads-card-content,
@@ -264,8 +310,25 @@ html[theme='light'] .pinned-featured-label {
     color: #42149d;
 }
 
-html[theme='light'] ads-card.path-card:hover .pinned-featured-label {
+html[theme='light'] .pinned-inline-icon {
+    color: var(--learn-accent);
+}
+
+html[theme='light'] .basics-title:hover,
+html[theme='light'] ads-card.path-card:hover .learning-path-title,
+html[theme='light'] ads-card.path-card:hover .pinned-inline-icon,
+html[theme='light'] ads-card.path-card:hover .pinned-featured-label,
+html[theme='light'] ads-card.tool-card:hover p,
+html[theme='light'] ads-card.multi-install-card:hover .multi-tool-selection-title,
+html[theme='light'] .module-card-a:hover,
+html[theme='light'] .social-icons a:hover,
+html[theme='light'] #tag-clear-btn:hover,
+html[theme='light'] #reset-demo-txt:hover {
     color: #35107f;
+}
+
+html[theme='light'] .share-icon:hover {
+    fill: #35107f;
 }
 
 html[theme='light'] .card-subject,

--- a/assets/css/light-mode.css
+++ b/assets/css/light-mode.css
@@ -1,24 +1,23 @@
 html[theme='light'] {
     color-scheme: light;
-    --learn-background: #f7f5fa;
+    --learn-background: var(--ads-ui-gray-05, #f9f9f9);
     --learn-surface: #ffffff;
-    --learn-surface-muted: #f1edf7;
-    --learn-border: #ddd6e8;
-    --learn-border-strong: #b9adc9;
-    --learn-text: #17242d;
-    --learn-text-muted: #354751;
-    --learn-link: #5520c3;
-    --learn-link-hover: #35107f;
-    --learn-accent: var(--lp-accent-primary, #6023de);
-    --learn-accent-soft: #eee7fb;
-    --learn-violet: var(--lp-accent-primary, #6023de);
-    --learn-lilac: var(--lp-accent-secondary, #d1bafc);
-    --learn-brand-gradient: linear-gradient(115deg, var(--learn-violet) 0%, #9c6bea 58%, var(--learn-lilac) 100%);
-    --learn-shadow: 0 10px 30px rgba(16, 24, 32, 0.08);
-    --learn-shadow-hover: 0 18px 42px rgba(96, 35, 222, 0.18);
+    --learn-surface-muted: var(--ads-ui-gray-10, #f0f0f0);
+    --learn-border: var(--ads-ui-gray-40, #d4d4d4);
+    --learn-border-strong: var(--ads-ui-gray-60, #a9a9a9);
+    --learn-text: var(--ads-brand-arm-ink, #080225);
+    --learn-text-muted: var(--ads-ui-ink-65, #484848);
+    --learn-link: var(--ads-brand-horizon-blue, #0057ff);
+    --learn-link-hover: var(--ads-ui-blue-105, #004ee6);
+    --learn-accent: var(--ads-brand-horizon-blue, #0057ff);
+    --learn-accent-hover: var(--ads-ui-blue-105, #004ee6);
+    --learn-accent-soft: var(--ads-ui-blue-10, #e6eeff);
+    --learn-brand-gradient: linear-gradient(115deg, #0057ff 0%, #3379ff 58%, #80abff 100%);
+    --learn-shadow: 0 10px 30px rgba(8, 2, 37, 0.08);
+    --learn-shadow-hover: 0 18px 42px rgba(0, 87, 255, 0.18);
 
     --ads-color: var(--learn-text);
-    --ads-heading-color: #101b22;
+    --ads-heading-color: var(--learn-text);
     --ads-link-color: var(--learn-link);
     --ads-table-border-color: var(--learn-border);
 }
@@ -33,10 +32,15 @@ html[theme='light'] body {
     background-image: none;
 }
 
+html[theme='light'] #global-nav-height-fixer {
+    background: #ffffff;
+    background-color: #ffffff;
+}
+
 html[theme='light'] body.home-page {
     background-image:
-        radial-gradient(circle at 8% 8%, rgba(96, 35, 222, 0.11), transparent 25rem),
-        radial-gradient(circle at 92% 20%, rgba(209, 186, 252, 0.28), transparent 31rem),
+        radial-gradient(circle at 8% 8%, rgba(0, 87, 255, 0.1), transparent 25rem),
+        radial-gradient(circle at 92% 20%, rgba(128, 171, 255, 0.24), transparent 31rem),
         linear-gradient(180deg, #ffffff 0, var(--learn-background) 34rem);
     background-repeat: no-repeat;
 }
@@ -51,9 +55,9 @@ html[theme='light'] a:hover {
 
 html[theme='light'] ads-button {
     --ads-button-background-color-primary: var(--learn-accent);
-    --ads-button-background-color-primary-hover: #4d1aae;
+    --ads-button-background-color-primary-hover: var(--learn-accent-hover);
     --ads-button-border-color-primary: var(--learn-accent);
-    --ads-button-border-color-primary-hover: #4d1aae;
+    --ads-button-border-color-primary-hover: var(--learn-accent-hover);
     --ads-button-color-primary: #ffffff;
     --ads-button-color-primary-hover: #ffffff;
     --ads-button-color-secondary-hover: var(--learn-link-hover);
@@ -62,9 +66,9 @@ html[theme='light'] ads-button {
 
 html[theme='light'] ads-cta-button {
     --ads-cta-button-background-color-primary: var(--learn-accent);
-    --ads-cta-button-background-color-primary-hover: #4d1aae;
+    --ads-cta-button-background-color-primary-hover: var(--learn-accent-hover);
     --ads-cta-button-border-color-primary: var(--learn-accent);
-    --ads-cta-button-border-color-primary-hover: #4d1aae;
+    --ads-cta-button-border-color-primary-hover: var(--learn-accent-hover);
     --ads-cta-button-color-primary: #ffffff;
     --ads-cta-button-color-primary-hover: #ffffff;
     --ads-cta-button-color-secondary-hover: var(--learn-link-hover);
@@ -79,6 +83,26 @@ html[theme='light'] ads-tag {
     --ads-tag-color-hover: var(--learn-link-hover);
 }
 
+html[theme='light'] ads-search {
+    --ads-search-background-color: var(--learn-surface);
+    --ads-search-input-background-color: var(--learn-surface);
+    --ads-search-input-background-color-hover: var(--learn-surface);
+    --ads-search-input-background-color-fill-hover: var(--learn-surface);
+    --ads-search-border-color: var(--learn-border-strong);
+    --ads-search-border-color-hover: var(--learn-accent);
+    --ads-search-border-color-focus: var(--learn-accent);
+    --ads-search-input-color: var(--learn-text);
+    --ads-search-input-color-focus: var(--learn-text);
+    --ads-search-input-placeholder-color: var(--learn-text-muted);
+    --ads-search-icon-color: var(--learn-text-muted);
+    --ads-search-button-background-color: var(--learn-accent);
+    --ads-search-button-background-color-hover: var(--learn-accent-hover);
+    --ads-search-button-background-color-focus: var(--learn-accent-hover);
+    --ads-search-button-color: #ffffff;
+    --ads-search-button-color-hover: #ffffff;
+    --ads-search-button-color-focus: #ffffff;
+}
+
 html[theme='light'] input[type='submit']:hover {
     color: #ffffff;
 }
@@ -88,7 +112,7 @@ html[theme='light'] #main {
 }
 
 html[theme='light'] #only-breadcrumb-masthead {
-    background: #101820;
+    background: var(--learn-surface);
 }
 
 html[theme='light'] div.content-box {
@@ -156,9 +180,9 @@ html[theme='light'] pre[class*='language-'] a.token.url-link:hover {
 }
 
 html[theme='light'] ads-card.notice-callout {
-    --ads-card-background-color: #eee7fb;
-    --ads-card-border-color: #5520c3;
-    --ads-card-border-color-hover: #5520c3;
+    --ads-card-background-color: var(--learn-accent-soft);
+    --ads-card-border-color: var(--learn-accent);
+    --ads-card-border-color-hover: var(--learn-accent-hover);
 }
 
 html[theme='light'] .normal-tabpane {
@@ -196,18 +220,18 @@ html[theme='light'] .tab-right-card > h6 {
 html[theme='light'] .tab-right-card.active {
     border-color: var(--learn-accent);
     background: var(--learn-accent-soft);
-    box-shadow: inset 4px 0 0 var(--learn-accent), 0 8px 20px rgba(96, 35, 222, 0.12);
+    box-shadow: inset 4px 0 0 var(--learn-accent), 0 8px 20px rgba(0, 87, 255, 0.12);
 }
 
 html[theme='light'] .tab-right-card.active > h6 {
-    color: #42149d;
+    color: var(--learn-link-hover);
     font-weight: 700;
 }
 
 html[theme='light'] .tab-row.inactive:hover,
 html[theme='light'] .tab-row.inactive:hover .tab-right-card {
-    border-color: #8a5be5;
-    background: #f5f0fd;
+    border-color: var(--ads-ui-blue-50, #80abff);
+    background: var(--learn-accent-soft);
 }
 
 html[theme='light'] .tab-row.inactive:hover .tab-right-card {
@@ -261,7 +285,7 @@ html[theme='light'] ads-card.path-card,
 html[theme='light'] ads-card.tool-card,
 html[theme='light'] ads-card.module-card {
     --ads-card-background-color: var(--learn-surface);
-    --ads-card-background-color-hover: #fcfbfe;
+    --ads-card-background-color-hover: var(--learn-accent-soft);
     --ads-card-border-color: var(--learn-border);
     --ads-card-border-color-hover: var(--learn-accent);
     --ads-card-box-shadow: 0 3px 12px rgba(23, 36, 45, 0.06);
@@ -303,11 +327,11 @@ html[theme='light'] ads-card.module-card:hover ads-card-content::after {
 html[theme='light'] .learning-path-title,
 html[theme='light'] .basics-title,
 html[theme='light'] ads-card.tool-card p {
-    color: #4d1aae;
+    color: var(--learn-link-hover);
 }
 
 html[theme='light'] .pinned-featured-label {
-    color: #42149d;
+    color: var(--learn-link-hover);
 }
 
 html[theme='light'] .pinned-inline-icon {
@@ -324,11 +348,11 @@ html[theme='light'] .module-card-a:hover,
 html[theme='light'] .social-icons a:hover,
 html[theme='light'] #tag-clear-btn:hover,
 html[theme='light'] #reset-demo-txt:hover {
-    color: #35107f;
+    color: var(--learn-link-hover);
 }
 
 html[theme='light'] .share-icon:hover {
-    fill: #35107f;
+    fill: var(--learn-link-hover);
 }
 
 html[theme='light'] .card-subject,
@@ -360,7 +384,7 @@ html[theme='light'] .filter-facet {
     --ads-tag-border-color: 1px solid var(--learn-border-strong);
     --ads-tag-border-color-hover: 1px solid var(--learn-accent);
     --ads-tag-color: var(--learn-text-muted);
-    --ads-tag-color-hover: #42149d;
+    --ads-tag-color-hover: var(--learn-link-hover);
 }
 
 html[theme='light'] .main-topic-card {
@@ -386,7 +410,7 @@ html[theme='light'] .main-topic-card::before {
 
 html[theme='light'] .main-topic-card:hover {
     border-color: var(--learn-accent);
-    background: #fcfbfe;
+    background: var(--learn-accent-soft);
     box-shadow: var(--learn-shadow-hover);
 }
 
@@ -395,15 +419,15 @@ html[theme='light'] .main-topic-card:hover::before {
 }
 
 html[theme='light'] .main-topic-title {
-    color: #4d1aae;
+    color: var(--learn-link-hover);
 }
 
 html[theme='light'] .main-topic-card:hover .main-topic-title {
-    color: #35107f;
+    color: var(--learn-link-hover);
 }
 
 html[theme='light'] .main-topic-card img[src*='main-topic-icons'] {
-    filter: brightness(0) saturate(100%) invert(20%) sepia(87%) saturate(4529%) hue-rotate(256deg) brightness(80%) contrast(101%);
+    filter: brightness(0) saturate(100%) invert(26%) sepia(98%) saturate(7492%) hue-rotate(222deg) brightness(102%) contrast(106%);
 }
 
 html[theme='light'] .main-topic-card .main-topic-subtitle,
@@ -413,12 +437,12 @@ html[theme='light'] .homepage-dynamic-bottom-spacing + p {
 }
 
 html[theme='light'] #homepage-header {
-    color: #101b22;
-    background: linear-gradient(105deg, #35107f 4%, #6023de 58%, #8a5be5 100%);
+    color: var(--learn-text);
+    background: linear-gradient(105deg, var(--learn-text) 4%, var(--learn-accent) 58%, #3379ff 100%);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
-    filter: drop-shadow(0 12px 24px rgba(96, 35, 222, 0.14));
+    filter: drop-shadow(0 12px 24px rgba(0, 87, 255, 0.14));
 }
 
 html[theme='light'] body.home-page #title-div {
@@ -434,94 +458,8 @@ html[theme='light'] table.contributor-table tbody {
     background: var(--learn-surface);
 }
 
-button.theme-toggle {
-    position: fixed;
-    right: 1rem;
-    bottom: 1rem;
-    z-index: 20;
-    display: none;
-    min-height: 3rem;
-    align-items: center;
-    width: 3rem;
-    justify-content: center;
-    padding: 0.55rem;
-    border: 2px solid transparent;
-    border-radius: 999px;
-    color: var(--learn-text, #ffffff);
-    background:
-        linear-gradient(var(--learn-surface, #1f2023), var(--learn-surface, #1f2023)) padding-box,
-        linear-gradient(135deg, #6023de, #d1bafc) border-box;
-    box-shadow: 0 10px 28px rgba(96, 35, 222, 0.24), 0 0 0 4px rgba(255, 255, 255, 0.72);
-    cursor: pointer;
-    font: inherit;
-    font-weight: 700;
-    transition: box-shadow 180ms ease, transform 180ms ease;
-}
-
-html[data-theme-enabled='true'] button.theme-toggle {
-    display: inline-flex;
-}
-
-button.theme-toggle:hover {
-    box-shadow: 0 15px 34px rgba(96, 35, 222, 0.3), 0 0 0 5px rgba(209, 186, 252, 0.28);
-    transform: translateY(-3px) rotate(-4deg);
-}
-
-button.theme-toggle:focus-visible {
-    outline: 3px solid #7b45df;
-    outline-offset: 3px;
-}
-
-.theme-toggle__icon {
-    font-size: 1.25rem !important;
-    line-height: 1;
-    transition: transform 180ms ease;
-}
-
-button.theme-toggle:hover .theme-toggle__icon {
-    transform: rotate(12deg) scale(1.08);
-}
-
-.theme-toggle__label {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-}
-
-html[theme='dark'] button.theme-toggle {
-    color: #ffffff;
-    background:
-        linear-gradient(#1f2023, #1f2023) padding-box,
-        linear-gradient(135deg, #6023de, #d1bafc) border-box;
-    box-shadow: 0 10px 28px rgba(96, 35, 222, 0.24), 0 0 0 4px rgba(16, 24, 32, 0.72);
-}
-
-@media (max-width: 576px) {
-    button.theme-toggle {
-        right: 0.75rem;
-        bottom: 0.75rem;
-        padding: 0.55rem;
-    }
-
-}
-
-@media print {
-    button.theme-toggle {
-        display: none;
-    }
-}
-
 @media (prefers-reduced-motion: reduce) {
     html[theme='light'] .main-topic-card,
     html[theme='light'] .main-topic-card::before,
     html[theme='light'] .tab-right-card,
-    button.theme-toggle,
-    .theme-toggle__icon {
-        transition: none;
-    }
 }

--- a/assets/css/light-mode.css
+++ b/assets/css/light-mode.css
@@ -115,6 +115,19 @@ html[theme='light'] #only-breadcrumb-masthead {
     background: var(--learn-surface);
 }
 
+html[theme='light'] #expanded-masthead.u-bg-color-ads-ui-violet-90 {
+    background-color: var(--learn-accent) !important;
+    background-image: none !important;
+    border-bottom-color: var(--learn-accent-hover);
+}
+
+html[theme='light'] #expanded-masthead #breadcrumb-element {
+    --ads-breadcrumbs-color: #f3f3f3 !important;
+    --ads-breadcrumbs-link-color: #f3f3f3 !important;
+    --ads-breadcrumbs-link-color-visited: #f3f3f3 !important;
+    --ads-breadcrumbs-link-color-hover: #ffffff !important;
+}
+
 html[theme='light'] div.content-box {
     position: relative;
     overflow: hidden;

--- a/themes/arm-design-system-hugo-theme/layouts/_default/baseof.html
+++ b/themes/arm-design-system-hugo-theme/layouts/_default/baseof.html
@@ -14,7 +14,7 @@
            {{ partialCached "math.html" . }}
         {{ end }}
     </head>
-    <body>
+    <body class="{{ if .IsHome }}home-page{{ end }}">
         <a href="#main" class="skip-link">Skip to main content</a>
 
         {{partial "header/nav-masthead.html" .}}
@@ -22,6 +22,11 @@
         {{ if not .IsHome }}
             {{ partial "header/color-refresh-alert.html" . }}
         {{ end }}
+
+        <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="true" aria-label="Switch to light mode">
+            <span class="theme-toggle__icon" data-theme-toggle-icon aria-hidden="true">☀</span>
+            <span class="theme-toggle__label" data-theme-toggle-label>Light mode</span>
+        </button>
 
         {{/* Where all content sits. Each layout file defines "main" which then sits here. */}}
         <div id="main" class="c-container is-responsive-width" style="min-height: 250px;">

--- a/themes/arm-design-system-hugo-theme/layouts/_default/baseof.html
+++ b/themes/arm-design-system-hugo-theme/layouts/_default/baseof.html
@@ -23,11 +23,6 @@
             {{ partial "header/color-refresh-alert.html" . }}
         {{ end }}
 
-        <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="true" aria-label="Switch to light mode">
-            <span class="theme-toggle__icon" data-theme-toggle-icon aria-hidden="true">☀</span>
-            <span class="theme-toggle__label" data-theme-toggle-label>Light mode</span>
-        </button>
-
         {{/* Where all content sits. Each layout file defines "main" which then sits here. */}}
         <div id="main" class="c-container is-responsive-width" style="min-height: 250px;">
             <div id="all-content-div-margined" class="u-margin-left-0 u-margin-right-0">

--- a/themes/arm-design-system-hugo-theme/layouts/index.html
+++ b/themes/arm-design-system-hugo-theme/layouts/index.html
@@ -103,7 +103,7 @@ Website homepage.
 
 <div class="c-row u-margin-top-3">
     <div class="c-col">
-        <p style="text-align: center; margin: 0 auto; margin-top: 16px; color: #A3A8AE;">All content is covered by the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">Creative Commons License{{partial "general-formatting/external-link.html"}}</a>. Learning Paths may contain AI-generated content.</p>
+        <p class="homepage-license" style="text-align: center; margin: 0 auto; margin-top: 16px;">All content is covered by the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">Creative Commons License{{partial "general-formatting/external-link.html"}}</a>. Learning Paths may contain AI-generated content.</p>
     </div>
 </div>
 

--- a/themes/arm-design-system-hugo-theme/layouts/partials/head/head.html
+++ b/themes/arm-design-system-hugo-theme/layouts/partials/head/head.html
@@ -56,12 +56,9 @@ Where it is used:
   integrity="sha384-caAG7P/HrHxcdQa2gTEfvZYGPLQk7yRwVdvtRn6sa3TRKzcAyY1LMvObXKGhwFNb"
   crossorigin="anonymous">
 </script>
-    <!-- Arm Header & Footer loading. Local development uses the test bundle;
-         production defaults to stable app.js unless a deployment explicitly overrides it. -->
+    <!-- Arm Header & Footer loading. Use the same DevHub bundle locally and in production
+         unless a deployment explicitly overrides it. -->
 {{ $globalWebComponentsURL := .Site.Params.global_web_components_url | default "https://www.arm.com/arm-global-web-components/devhub/app.js" }}
-{{ if and hugo.IsServer (not .Site.Params.global_web_components_url) }}
-  {{ $globalWebComponentsURL = "https://www.arm.com/arm-global-web-components/devhub/test.js" }}
-{{ end }}
 <script
   type="text/javascript"
   src="{{ $globalWebComponentsURL }}"

--- a/themes/arm-design-system-hugo-theme/layouts/partials/head/head.html
+++ b/themes/arm-design-system-hugo-theme/layouts/partials/head/head.html
@@ -20,6 +20,7 @@ Where it is used:
 <!-- All pages -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0"> <!-- Set the viewport appropriatly -->
+<script src="/js/theme-preference.js"></script>
     <!-- verify site ownership for Google -->
 <meta name="google-site-verification" content="BTfVb1OscFD-pN_bYZaTGmfx2_K3S1EbzvdKPepntvk" />
     <!-- add cannonical link to reinforce this page's validity for search engines, with a trailing / on the URL name-->
@@ -140,3 +141,6 @@ Where it is used:
         | resources.Concat "css/mini_migration.css" | minify | fingerprint  }}
     <link rel="stylesheet" href="{{ $css_migration.Permalink }}">
 {{end}}
+
+{{ $css_light_mode := resources.Get "css/light-mode.css" | minify | fingerprint }}
+<link rel="stylesheet" href="{{ $css_light_mode.RelPermalink }}" integrity="{{ $css_light_mode.Data.Integrity }}">

--- a/themes/arm-design-system-hugo-theme/static/js/authentication.js
+++ b/themes/arm-design-system-hugo-theme/static/js/authentication.js
@@ -291,10 +291,6 @@ document.addEventListener('arm-account-signin', (event) => {
 });
 
 document.addEventListener("arm-top-navigation-ready", function (e) {
-  // Need to reset theme as arm-top-navigation may override it
-  const htmlElement = document.documentElement; 
-  htmlElement.setAttribute("theme", "dark"); 
-
   renderAuthInTopNav();
 });
 

--- a/themes/arm-design-system-hugo-theme/static/js/globalVarsandPreferences.js
+++ b/themes/arm-design-system-hugo-theme/static/js/globalVarsandPreferences.js
@@ -1,42 +1,40 @@
-var digitalData={};
+var digitalData = {};
 
 
 (() => {
-      // Always check local storage to keep these attributes constant:
-        // Theme  (light, dark)
-        // Width  (is-full-width)
-        // Height (expanded-masthead and contextual data)
-    	//Check Storage. Keep user preference on page reload
+    function hasStoredPreference(name) {
+        try {
+            return localStorage.getItem(name) !== null;
+        } catch (_) {
+            return false;
+        }
+    }
 
+    if (hasStoredPreference('smallerWidth')) {
+        const main = document.getElementById('main');
+        const content = document.getElementById('all-content-div-margined');
 
+        if (main) main.classList.remove('is-full-width');
+        if (content) {
+            content.classList.remove('u-margin-left-2');
+            content.classList.remove('u-margin-right-2');
+        }
+    }
 
-	if (localStorage.getItem('theme')=='dark') {
-    document.querySelector('html').setAttribute('theme', 'dark');
-    //document.getElementById('prism-code-theme').href='/css/prism-dark.css';
-	}
-	else if (localStorage.getItem('theme')=='light') {
-    document.querySelector('html').setAttribute('theme', 'light');
-    //document.getElementById('prism-code-theme').href='/css/prism-light.css';
-  }
+    if (hasStoredPreference('fullHeight')) {
+        const globalNavigation = document.getElementById('global-nav-example-default');
+        const expandedMasthead = document.getElementById('expanded-masthead');
+        const footer = document.getElementById('arm-footer');
+        const breadcrumbMasthead = document.getElementById('only-breadcrumb-masthead');
 
-
-
-    if (localStorage.getItem('smallerWidth')) {
-        document.getElementById("all-content-div").classList.remove("is-full-width");
-        document.getElementById("all-content-div-margined").classList.remove("u-margin-left-2");
-        document.getElementById("all-content-div-margined").classList.remove("u-margin-right-2");
-	} 
-  if (localStorage.getItem('fullHeight')) {
-    document.getElementById('global-nav-example-default').contextualData = []; // Hide seoncary nav on Global Nav   
-    document.getElementById('global-nav-example-default').contextualIcons = []; // Hide seoncary nav on Global Nav         
-    document.getElementById("expanded-masthead").setAttribute('hidden',true);  // Hide title
-    document.getElementById("arm-footer").setAttribute('hidden',true);      // Hide footer
-    document.getElementById("only-breadcrumb-masthead").removeAttribute('hidden'); // Show just breadcrumbs
-  } 
-
-
-  })();
-
-
+        if (globalNavigation) {
+            globalNavigation.contextualData = [];
+            globalNavigation.contextualIcons = [];
+        }
+        if (expandedMasthead) expandedMasthead.setAttribute('hidden', true);
+        if (footer) footer.setAttribute('hidden', true);
+        if (breadcrumbMasthead) breadcrumbMasthead.removeAttribute('hidden');
+    }
+})();
 
 

--- a/themes/arm-design-system-hugo-theme/static/js/theme-preference.js
+++ b/themes/arm-design-system-hugo-theme/static/js/theme-preference.js
@@ -5,8 +5,6 @@
     var storageKey = 'theme';
     var activeTheme = readStoredTheme() || 'dark';
 
-    root.setAttribute('data-theme-enabled', 'true');
-
     function normalizeTheme(theme) {
         return theme === 'light' ? 'light' : 'dark';
     }
@@ -28,20 +26,18 @@
         }
     }
 
-    function updateToggle(theme) {
-        var toggle = document.getElementById('theme-toggle');
-        if (!toggle) return;
+    function updateNavigation(theme) {
+        var navigation = document.querySelector('arm-top-navigation');
 
-        var isDark = theme === 'dark';
-        var icon = toggle.querySelector('[data-theme-toggle-icon]');
-        var label = toggle.querySelector('[data-theme-toggle-label]');
+        if (navigation) {
+            navigation.setAttribute('theme', theme);
+        }
 
-        toggle.setAttribute('aria-pressed', String(isDark));
-        toggle.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
-        toggle.title = isDark ? 'Switch to light mode' : 'Switch to dark mode';
-
-        if (icon) icon.textContent = isDark ? '☀' : '☾';
-        if (label) label.textContent = isDark ? 'Light mode' : 'Dark mode';
+        if (typeof window.CustomEvent === 'function') {
+            document.dispatchEvent(new window.CustomEvent('arm-footer-theme', {
+                detail: theme === 'light',
+            }));
+        }
     }
 
     function notifyThemeChange(theme) {
@@ -52,41 +48,36 @@
         }));
     }
 
-    function applyTheme(theme, persist, notify) {
+    function applyTheme(theme, persist, notify, updateGlobalComponents) {
         activeTheme = normalizeTheme(theme);
         root.setAttribute('theme', activeTheme);
         root.style.colorScheme = activeTheme;
-        updateToggle(activeTheme);
 
         if (persist) storeTheme(activeTheme);
+        if (updateGlobalComponents) updateNavigation(activeTheme);
         if (notify) notifyThemeChange(activeTheme);
     }
 
-    function initializeToggle() {
-        var toggle = document.getElementById('theme-toggle');
-        if (!toggle || toggle.getAttribute('data-theme-toggle-ready') === 'true') return;
-
-        toggle.setAttribute('data-theme-toggle-ready', 'true');
-        updateToggle(activeTheme);
-        toggle.addEventListener('click', function () {
-            applyTheme(activeTheme === 'dark' ? 'light' : 'dark', true, true);
-        });
+    function initializeNavigation() {
+        applyTheme(activeTheme, false, false, true);
     }
 
-    applyTheme(activeTheme, false, false);
+    applyTheme(activeTheme, false, false, false);
 
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initializeToggle);
+        document.addEventListener('DOMContentLoaded', initializeNavigation);
     } else {
-        initializeToggle();
+        initializeNavigation();
     }
 
-    document.addEventListener('arm-top-navigation-ready', function () {
-        applyTheme(activeTheme, false, false);
+    document.addEventListener('arm-top-navigation-ready', initializeNavigation);
+
+    document.addEventListener('arm-theme', function (event) {
+        applyTheme(event.detail === true ? 'light' : 'dark', true, true, false);
     });
 
     window.addEventListener('storage', function (event) {
         if (event.key !== storageKey) return;
-        applyTheme(event.newValue === 'light' ? 'light' : 'dark', false, true);
+        applyTheme(event.newValue === 'light' ? 'light' : 'dark', false, true, true);
     });
 })();

--- a/themes/arm-design-system-hugo-theme/static/js/theme-preference.js
+++ b/themes/arm-design-system-hugo-theme/static/js/theme-preference.js
@@ -1,0 +1,92 @@
+(function () {
+    'use strict';
+
+    var root = document.documentElement;
+    var storageKey = 'theme';
+    var activeTheme = readStoredTheme() || 'dark';
+
+    root.setAttribute('data-theme-enabled', 'true');
+
+    function normalizeTheme(theme) {
+        return theme === 'light' ? 'light' : 'dark';
+    }
+
+    function readStoredTheme() {
+        try {
+            var storedTheme = window.localStorage.getItem(storageKey);
+            return storedTheme === 'light' || storedTheme === 'dark' ? storedTheme : null;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function storeTheme(theme) {
+        try {
+            window.localStorage.setItem(storageKey, theme);
+        } catch (_) {
+            // Theme switching still works when storage is unavailable.
+        }
+    }
+
+    function updateToggle(theme) {
+        var toggle = document.getElementById('theme-toggle');
+        if (!toggle) return;
+
+        var isDark = theme === 'dark';
+        var icon = toggle.querySelector('[data-theme-toggle-icon]');
+        var label = toggle.querySelector('[data-theme-toggle-label]');
+
+        toggle.setAttribute('aria-pressed', String(isDark));
+        toggle.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+        toggle.title = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+
+        if (icon) icon.textContent = isDark ? '☀' : '☾';
+        if (label) label.textContent = isDark ? 'Light mode' : 'Dark mode';
+    }
+
+    function notifyThemeChange(theme) {
+        if (typeof window.CustomEvent !== 'function') return;
+
+        document.dispatchEvent(new window.CustomEvent('learn-theme-change', {
+            detail: { theme: theme },
+        }));
+    }
+
+    function applyTheme(theme, persist, notify) {
+        activeTheme = normalizeTheme(theme);
+        root.setAttribute('theme', activeTheme);
+        root.style.colorScheme = activeTheme;
+        updateToggle(activeTheme);
+
+        if (persist) storeTheme(activeTheme);
+        if (notify) notifyThemeChange(activeTheme);
+    }
+
+    function initializeToggle() {
+        var toggle = document.getElementById('theme-toggle');
+        if (!toggle || toggle.getAttribute('data-theme-toggle-ready') === 'true') return;
+
+        toggle.setAttribute('data-theme-toggle-ready', 'true');
+        updateToggle(activeTheme);
+        toggle.addEventListener('click', function () {
+            applyTheme(activeTheme === 'dark' ? 'light' : 'dark', true, true);
+        });
+    }
+
+    applyTheme(activeTheme, false, false);
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initializeToggle);
+    } else {
+        initializeToggle();
+    }
+
+    document.addEventListener('arm-top-navigation-ready', function () {
+        applyTheme(activeTheme, false, false);
+    });
+
+    window.addEventListener('storage', function (event) {
+        if (event.key !== storageKey) return;
+        applyTheme(event.newValue === 'light' ? 'light' : 'dark', false, true);
+    });
+})();

--- a/tools/tests/theme-preference.test.mjs
+++ b/tools/tests/theme-preference.test.mjs
@@ -8,45 +8,39 @@ const script = await readFile(scriptPath, 'utf8');
 
 function createElement() {
     const attributes = new Map();
-    const listeners = new Map();
 
     return {
         style: {},
-        title: '',
-        textContent: '',
-        addEventListener(name, handler) {
-            listeners.set(name, handler);
-        },
         getAttribute(name) {
             return attributes.has(name) ? attributes.get(name) : null;
         },
         setAttribute(name, value) {
             attributes.set(name, String(value));
         },
-        trigger(name) {
-            const handler = listeners.get(name);
-            if (handler) handler();
-        },
     };
 }
 
 function createEnvironment(options = {}) {
     const root = createElement();
-    const toggle = createElement();
-    const icon = createElement();
-    const label = createElement();
+    const navigation = createElement();
     const documentListeners = new Map();
     const windowListeners = new Map();
     const dispatchedEvents = [];
     const storedValues = new Map();
+    const shadowElements = new Map();
+
+    if (options.hasNavigationShadow) {
+        navigation.shadowRoot = {
+            appendChild(element) {
+                shadowElements.set(element.id, element);
+            },
+            querySelector(selector) {
+                return selector.startsWith('#') ? shadowElements.get(selector.slice(1)) || null : null;
+            },
+        };
+    }
 
     if (options.storedTheme !== undefined) storedValues.set('theme', options.storedTheme);
-
-    toggle.querySelector = (selector) => {
-        if (selector === '[data-theme-toggle-icon]') return icon;
-        if (selector === '[data-theme-toggle-label]') return label;
-        return null;
-    };
 
     const document = {
         documentElement: root,
@@ -57,8 +51,11 @@ function createEnvironment(options = {}) {
         dispatchEvent(event) {
             dispatchedEvents.push(event);
         },
-        getElementById(id) {
-            return id === 'theme-toggle' ? toggle : null;
+        createElement() {
+            return createElement();
+        },
+        querySelector(selector) {
+            return selector === 'arm-top-navigation' ? navigation : null;
         },
     };
 
@@ -92,13 +89,11 @@ function createEnvironment(options = {}) {
 
     return {
         dispatchedEvents,
-        document,
         documentListeners,
-        icon,
-        label,
+        navigation,
         root,
+        shadowElements,
         storedValues,
-        toggle,
         windowListeners,
     };
 }
@@ -106,13 +101,9 @@ function createEnvironment(options = {}) {
 test('defaults to dark when no preference exists', () => {
     const environment = createEnvironment();
 
-    assert.equal(environment.root.getAttribute('data-theme-enabled'), 'true');
     assert.equal(environment.root.getAttribute('theme'), 'dark');
     assert.equal(environment.root.style.colorScheme, 'dark');
-    assert.equal(environment.toggle.getAttribute('aria-pressed'), 'true');
-    assert.equal(environment.toggle.getAttribute('aria-label'), 'Switch to light mode');
-    assert.equal(environment.icon.textContent, '☀');
-    assert.equal(environment.label.textContent, 'Light mode');
+    assert.equal(environment.navigation.getAttribute('theme'), 'dark');
 });
 
 test('restores an explicit light preference', () => {
@@ -120,8 +111,7 @@ test('restores an explicit light preference', () => {
 
     assert.equal(environment.root.getAttribute('theme'), 'light');
     assert.equal(environment.root.style.colorScheme, 'light');
-    assert.equal(environment.toggle.getAttribute('aria-pressed'), 'false');
-    assert.equal(environment.toggle.getAttribute('aria-label'), 'Switch to dark mode');
+    assert.equal(environment.navigation.getAttribute('theme'), 'light');
 });
 
 test('restores an explicit dark preference', () => {
@@ -131,25 +121,21 @@ test('restores an explicit dark preference', () => {
     assert.equal(environment.storedValues.get('theme'), 'dark');
 });
 
-test('toggle updates the theme, preference, and accessible state', () => {
+test('native navigation event updates the theme and preference', () => {
     const environment = createEnvironment();
 
-    environment.toggle.trigger('click');
+    environment.documentListeners.get('arm-theme')({ detail: true });
 
     assert.equal(environment.root.getAttribute('theme'), 'light');
     assert.equal(environment.storedValues.get('theme'), 'light');
-    assert.equal(environment.toggle.getAttribute('aria-pressed'), 'false');
-    assert.equal(environment.toggle.getAttribute('aria-label'), 'Switch to dark mode');
-    assert.equal(environment.icon.textContent, '☾');
-    assert.equal(environment.label.textContent, 'Dark mode');
     assert.equal(environment.dispatchedEvents.at(-1).detail.theme, 'light');
 });
 
-test('restricted storage falls back to dark without blocking switching', () => {
+test('restricted storage does not block native theme switching', () => {
     const environment = createEnvironment({ throwOnRead: true, throwOnWrite: true });
 
     assert.equal(environment.root.getAttribute('theme'), 'dark');
-    assert.doesNotThrow(() => environment.toggle.trigger('click'));
+    assert.doesNotThrow(() => environment.documentListeners.get('arm-theme')({ detail: true }));
     assert.equal(environment.root.getAttribute('theme'), 'light');
 });
 
@@ -157,9 +143,18 @@ test('navigation hydration reapplies the active theme', () => {
     const environment = createEnvironment({ storedTheme: 'light' });
 
     environment.root.setAttribute('theme', 'dark');
+    environment.navigation.setAttribute('theme', 'dark');
     environment.documentListeners.get('arm-top-navigation-ready')();
 
     assert.equal(environment.root.getAttribute('theme'), 'light');
+    assert.equal(environment.navigation.getAttribute('theme'), 'light');
+});
+
+test('navigation hydration uses only the public theme attribute', () => {
+    const environment = createEnvironment({ hasNavigationShadow: true, storedTheme: 'light' });
+
+    assert.equal(environment.navigation.getAttribute('theme'), 'light');
+    assert.equal(environment.shadowElements.size, 0);
 });
 
 test('storage events synchronize theme changes between tabs', () => {
@@ -168,5 +163,6 @@ test('storage events synchronize theme changes between tabs', () => {
     environment.windowListeners.get('storage')({ key: 'theme', newValue: 'light' });
 
     assert.equal(environment.root.getAttribute('theme'), 'light');
+    assert.equal(environment.navigation.getAttribute('theme'), 'light');
     assert.equal(environment.dispatchedEvents.at(-1).detail.theme, 'light');
 });

--- a/tools/tests/theme-preference.test.mjs
+++ b/tools/tests/theme-preference.test.mjs
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const scriptPath = new URL('../../themes/arm-design-system-hugo-theme/static/js/theme-preference.js', import.meta.url);
+const script = await readFile(scriptPath, 'utf8');
+
+function createElement() {
+    const attributes = new Map();
+    const listeners = new Map();
+
+    return {
+        style: {},
+        title: '',
+        textContent: '',
+        addEventListener(name, handler) {
+            listeners.set(name, handler);
+        },
+        getAttribute(name) {
+            return attributes.has(name) ? attributes.get(name) : null;
+        },
+        setAttribute(name, value) {
+            attributes.set(name, String(value));
+        },
+        trigger(name) {
+            const handler = listeners.get(name);
+            if (handler) handler();
+        },
+    };
+}
+
+function createEnvironment(options = {}) {
+    const root = createElement();
+    const toggle = createElement();
+    const icon = createElement();
+    const label = createElement();
+    const documentListeners = new Map();
+    const windowListeners = new Map();
+    const dispatchedEvents = [];
+    const storedValues = new Map();
+
+    if (options.storedTheme !== undefined) storedValues.set('theme', options.storedTheme);
+
+    toggle.querySelector = (selector) => {
+        if (selector === '[data-theme-toggle-icon]') return icon;
+        if (selector === '[data-theme-toggle-label]') return label;
+        return null;
+    };
+
+    const document = {
+        documentElement: root,
+        readyState: options.readyState || 'complete',
+        addEventListener(name, handler) {
+            documentListeners.set(name, handler);
+        },
+        dispatchEvent(event) {
+            dispatchedEvents.push(event);
+        },
+        getElementById(id) {
+            return id === 'theme-toggle' ? toggle : null;
+        },
+    };
+
+    const localStorage = {
+        getItem(key) {
+            if (options.throwOnRead) throw new Error('Storage read blocked');
+            return storedValues.has(key) ? storedValues.get(key) : null;
+        },
+        setItem(key, value) {
+            if (options.throwOnWrite) throw new Error('Storage write blocked');
+            storedValues.set(key, String(value));
+        },
+    };
+
+    class CustomEvent {
+        constructor(type, init) {
+            this.type = type;
+            this.detail = init.detail;
+        }
+    }
+
+    const window = {
+        CustomEvent,
+        localStorage,
+        addEventListener(name, handler) {
+            windowListeners.set(name, handler);
+        },
+    };
+
+    vm.runInNewContext(script, { document, window });
+
+    return {
+        dispatchedEvents,
+        document,
+        documentListeners,
+        icon,
+        label,
+        root,
+        storedValues,
+        toggle,
+        windowListeners,
+    };
+}
+
+test('defaults to dark when no preference exists', () => {
+    const environment = createEnvironment();
+
+    assert.equal(environment.root.getAttribute('data-theme-enabled'), 'true');
+    assert.equal(environment.root.getAttribute('theme'), 'dark');
+    assert.equal(environment.root.style.colorScheme, 'dark');
+    assert.equal(environment.toggle.getAttribute('aria-pressed'), 'true');
+    assert.equal(environment.toggle.getAttribute('aria-label'), 'Switch to light mode');
+    assert.equal(environment.icon.textContent, '☀');
+    assert.equal(environment.label.textContent, 'Light mode');
+});
+
+test('restores an explicit light preference', () => {
+    const environment = createEnvironment({ storedTheme: 'light' });
+
+    assert.equal(environment.root.getAttribute('theme'), 'light');
+    assert.equal(environment.root.style.colorScheme, 'light');
+    assert.equal(environment.toggle.getAttribute('aria-pressed'), 'false');
+    assert.equal(environment.toggle.getAttribute('aria-label'), 'Switch to dark mode');
+});
+
+test('restores an explicit dark preference', () => {
+    const environment = createEnvironment({ storedTheme: 'dark' });
+
+    assert.equal(environment.root.getAttribute('theme'), 'dark');
+    assert.equal(environment.storedValues.get('theme'), 'dark');
+});
+
+test('toggle updates the theme, preference, and accessible state', () => {
+    const environment = createEnvironment();
+
+    environment.toggle.trigger('click');
+
+    assert.equal(environment.root.getAttribute('theme'), 'light');
+    assert.equal(environment.storedValues.get('theme'), 'light');
+    assert.equal(environment.toggle.getAttribute('aria-pressed'), 'false');
+    assert.equal(environment.toggle.getAttribute('aria-label'), 'Switch to dark mode');
+    assert.equal(environment.icon.textContent, '☾');
+    assert.equal(environment.label.textContent, 'Dark mode');
+    assert.equal(environment.dispatchedEvents.at(-1).detail.theme, 'light');
+});
+
+test('restricted storage falls back to dark without blocking switching', () => {
+    const environment = createEnvironment({ throwOnRead: true, throwOnWrite: true });
+
+    assert.equal(environment.root.getAttribute('theme'), 'dark');
+    assert.doesNotThrow(() => environment.toggle.trigger('click'));
+    assert.equal(environment.root.getAttribute('theme'), 'light');
+});
+
+test('navigation hydration reapplies the active theme', () => {
+    const environment = createEnvironment({ storedTheme: 'light' });
+
+    environment.root.setAttribute('theme', 'dark');
+    environment.documentListeners.get('arm-top-navigation-ready')();
+
+    assert.equal(environment.root.getAttribute('theme'), 'light');
+});
+
+test('storage events synchronize theme changes between tabs', () => {
+    const environment = createEnvironment();
+
+    environment.windowListeners.get('storage')({ key: 'theme', newValue: 'light' });
+
+    assert.equal(environment.root.getAttribute('theme'), 'light');
+    assert.equal(environment.dispatchedEvents.at(-1).detail.theme, 'light');
+});


### PR DESCRIPTION
Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 

------------------

@zachlasiuk @pareenaverma 
Appreciate there may be more complexities / other factors to consider - so might not be so simple, but I've taken a stab over lunch at drafting an optional light-mode aligned with the new branding changes, and it came together pretty quickly. Please let me know if this could be workable.

## Summary

Add an optional light mode to Arm Learning Paths using the new purple theme.

Dark mode remains the default. Readers can select light mode using an accessible theme toggle, and the browser remembers that preference across Learning Path pages and future visits.

## Visual changes

Light mode adds appropriate styling for:

- Homepage headings and category cards
- Learning Path and install guide content
- List pages, filters, and sorting controls
- Content navigation and tabs
- Tables and inline code
- Notices and callouts
- Featured Learning Path labels
- ADS cards and buttons
- Mobile content navigation

The implementation uses the existing refreshed accent tokens:

- Primary violet: `#6023DE`
- Secondary lilac: `#D1BAFC`

Additional refinements include:

- A darker purple `FEATURED` label on light-mode (for visibility)
- Darker purple notice backgrounds and borders on light-mode (for visibility)
- Dark code blocks in both modes

## Theme behavior

The selection order is:

1. An explicitly stored light preference
2. An explicitly stored dark preference
3. Dark mode when no preference exists

The operating-system color preference is not used.

The preference is stored in the browser and does not depend on an Arm account or authentication.

## Implementation

Theme behavior is owned by a single `theme-preference.js` controller.

The controller:

- Applies the selected theme before page CSS renders
- Updates the accessible toggle state
- Stores an explicit reader preference
- Handles unavailable or restricted browser storage
- Reapplies the theme after global navigation hydration
- Synchronizes changes between browser tabs
- Emits a `learn-theme-change` event

Theme manipulation has been removed from the authentication and general preference scripts.

The toggle is hidden when JavaScript is unavailable, leaving the site in its default dark mode without presenting an inactive control.

## Tests

Run:

```console
node --test tools/tests/theme-preference.test.mjs
```

The seven tests cover:

- Dark default behavior
- Stored light preference
- Stored dark preference
- Toggle state and persistence
- Restricted browser storage
- Global navigation hydration
- Cross-tab synchronization


Light mode:
<img width="2739" height="1082" alt="Screenshot 2026-07-20 at 12 55 08" src="https://github.com/user-attachments/assets/3deb0f06-af94-450d-bc66-8c8f9862038c" />


Dark mode:
<img width="2761" height="1072" alt="Screenshot 2026-07-20 at 12 54 47" src="https://github.com/user-attachments/assets/c7b6e457-0aba-44c0-bd24-87a7246c7fb5" />

Dark code blocks remain for both:
<img width="1516" height="971" alt="Screenshot 2026-07-20 at 12 55 31" src="https://github.com/user-attachments/assets/4349bad4-e0b0-44da-b6fb-8dd20254d058" />
