### PR TITLE
Adding 21 summaries and faqs for servers and cloud computing + minor fixes 

### DIFF
--- a/.github/skills/writing-style-review/SKILL.md
+++ b/.github/skills/writing-style-review/SKILL.md
@@ -77,6 +77,7 @@ Use this skill for granular prose, voice, readability, terminology, and style re
 - Use `avoid` instead of `try not to`.
 - Use `such as` instead of `like`.
 - Use `after` or `when` instead of `once`.
+- Avoid slashes unless part of a technical term. Replace slashes with "and" or "or" as adequate.
 
 ## Tone cleanup
 

--- a/content/learning-paths/servers-and-cloud-computing/codebuild/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/codebuild/_index.md
@@ -14,9 +14,51 @@ prerequisites:
     - An [AWS account](/learning-paths/servers-and-cloud-computing/csp/aws/) for accessing AWS cloud services.
     - An [Arm based instance](/learning-paths/servers-and-cloud-computing/csp/) from a cloud service provider or any Arm server, laptop, or single-board computer running [Docker](/install-guides/docker/) used to run the created images
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:41:54Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: e7ea48aaea0e25f624ea1d77c6252b0e537fdaeca3aacca560d7bc9d103bbbb3
+  summary_generated_at: '2026-07-27T18:41:54Z'
+  summary_source_hash: e7ea48aaea0e25f624ea1d77c6252b0e537fdaeca3aacca560d7bc9d103bbbb3
+  faq_generated_at: '2026-07-27T18:41:54Z'
+  faq_source_hash: e7ea48aaea0e25f624ea1d77c6252b0e537fdaeca3aacca560d7bc9d103bbbb3
+  summary: >-
+    You'll use AWS CodeBuild and a GitHub repository to build AArch64 Docker images on AWS Graviton.
+    You'll publish the images to Docker Hub and Amazon ECR Public Gallery, then pull and run them on an Arm
+    Linux machine with Docker. Finally, you'll verify the architecture with `uname -m` and compare the
+    images from both registries.
+  faqs:
+  - question: How do I confirm I’m on an Arm AArch64 machine before running the images?
+    answer: >-
+      Run `uname -m` on the target Linux system. The expected output is `aarch64`. If you see a different
+      value, you're not on a 64-bit Arm machine.
+  - question: How do I know the CodeBuild job is finished and images are ready to use?
+    answer: >-
+      When the CodeBuild project completes successfully, you can pull the images from Docker Hub
+      or Amazon ECR Public Gallery and run them on an Arm machine with Docker.
+  - question: Which registry should I pull from?
+    answer: >-
+     Both registries provide the same images. Choose Docker Hub or Amazon ECR Public Gallery based on which registry fits your environment.
+  - question: What result should I expect when I run the container to verify the build?
+    answer: >-
+      Running `uname -m` inside the container should return `aarch64`, and the output should match
+      regardless of which registry you used. The example also shows that CodeBuild built the image
+      on Amazon Linux 2.
+  - question: Do I need to select an Arm or Graviton environment in CodeBuild to target AArch64?
+    answer: >-
+      Yes. Select an Arm-based environment in CodeBuild to build AArch64 Docker images from a
+      GitHub-hosted project.
+# END generated_summary_faq
+
 author: Jason Andrews
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -50,4 +92,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/codec/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/codec/_index.md
@@ -33,13 +33,13 @@ generated_summary_faq:
   summary: >-
     You'll build the open-source x265 (HEVC) encoder on an Arm server and run it on sample videos.
     You'll install GCC, CMake, and supporting packages, obtain the referenced Arm-optimized libx265
-    source with Neoverse NEON support, and compile it. You'll then run repeatable tests while varying
+    source with Neoverse Neon support, and compile it. You'll then run repeatable tests while varying
     the resolution and encoder preset to compare encoding behavior on Arm.
   faqs:
   - question: Which x265 source should I use to get Arm-specific optimizations?
     answer: >-
       Use the `libx265` repository referenced in the steps on Bitbucket, which includes Arm Neoverse
-      NEON support. Follow the clone or checkout instructions provided in the path to ensure you
+      Neon support. Follow the clone or checkout instructions provided in the path to ensure you
       build the optimized tree.
   - question: What should I verify after installing the required packages?
     answer: >-
@@ -53,7 +53,7 @@ generated_summary_faq:
   - question: How do I know the build used Arm NEON optimizations?
     answer: >-
       Build the Bitbucket-based source referenced in the steps on an Arm server to enable the
-      NEON-supported paths. If configuration targets a non-Arm platform, recheck that you are
+      NEON-supported paths. If configuration targets a non-Arm platform, recheck that you're
       building on the intended Arm instance.
   - question: What result should I expect when an encoding run finishes?
     answer: >-

--- a/content/learning-paths/servers-and-cloud-computing/codec/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/codec/_index.md
@@ -16,9 +16,54 @@ prerequisites:
 - An [Arm based instance](/learning-paths/servers-and-cloud-computing/csp/) from an appropriate
   cloud service provider. This Learning Path has been verified on AWS EC2 and Oracle cloud services, running `Ubuntu Linux 20.04.`
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:42:45Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 908a750f2a891a0c4c9d1183c2130ac5ac0fdcfb4a45185cef6ed6da47c9aaa9
+  summary_generated_at: '2026-07-27T18:42:45Z'
+  summary_source_hash: 908a750f2a891a0c4c9d1183c2130ac5ac0fdcfb4a45185cef6ed6da47c9aaa9
+  faq_generated_at: '2026-07-27T18:42:45Z'
+  faq_source_hash: 908a750f2a891a0c4c9d1183c2130ac5ac0fdcfb4a45185cef6ed6da47c9aaa9
+  summary: >-
+    You'll build the open-source x265 (HEVC) encoder on an Arm server and run it on sample videos.
+    You'll install GCC, CMake, and supporting packages, obtain the referenced Arm-optimized libx265
+    source with Neoverse NEON support, and compile it. You'll then run repeatable tests while varying
+    the resolution and encoder preset to compare encoding behavior on Arm.
+  faqs:
+  - question: Which x265 source should I use to get Arm-specific optimizations?
+    answer: >-
+      Use the `libx265` repository referenced in the steps on Bitbucket, which includes Arm Neoverse
+      NEON support. Follow the clone or checkout instructions provided in the path to ensure you
+      build the optimized tree.
+  - question: What should I verify after installing the required packages?
+    answer: >-
+      Confirm the package installation completes without errors and that the listed tools are
+      available on your system. Then proceed to the configure and build steps as shown in the
+      path.
+  - question: How should I structure the benchmarking across resolutions and presets?
+    answer: >-
+      Keep the input video constant and vary only the resolution and the encoder preset between
+      runs. Use the same process for each run so results are comparable.
+  - question: How do I know the build used Arm NEON optimizations?
+    answer: >-
+      Build the Bitbucket-based source referenced in the steps on an Arm server to enable the
+      NEON-supported paths. If configuration targets a non-Arm platform, recheck that you are
+      building on the intended Arm instance.
+  - question: What result should I expect when an encoding run finishes?
+    answer: >-
+      The encoder should complete and produce output consistent with the chosen resolution and preset.
+      Record the run’s output information so you can compare it with other configurations.
+# END generated_summary_faq
+
 author: Pareena Verma
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -64,4 +109,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/codec1/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/codec1/_index.md
@@ -18,19 +18,16 @@ generated_summary_faq:
   faq_source_hash: c0643a788cdb0b3e33fe645fbb61d99a1899806e3ee197541c1eb8134b2876c1
   summary: >-
     You'll build the AV1 and VP9 reference codecs from source on Arm Linux and run them on sample
-    videos. You'll compile libxaom and libvpx with common development tools, then vary resolution
-    and encoding settings to compare runs. The workflow covers Arm Neoverse optimizations that use
-    Neon and SVE2 and supports basic performance benchmarking.
+    videos. You'll compile libxaom and libvpx implementations — that have been optimized using Neon and SVE2 — with common development tools. Then, you'll vary resolution
+    and encoding settings to compare runs and benchmark performance.
   faqs:
   - question: Which source repositories should I use for AV1 and VP9?
     answer: >-
       For AV1, use the `libxaom` reference implementation with Arm-optimized code available on
-      Google Git. For VP9, use the `libvpx` repository from the Chromium WebM project as shown in
-      the steps.
+      Google Git. For VP9, use the `libvpx` repository from the Chromium WebM project.
   - question: Do I need to pass special flags to enable Neon or SVE2 optimizations?
     answer: >-
-      The implementations include optimizations for Arm Neoverse that use Neon and SVE2. The path
-      does not list extra flags to set; follow the build steps on an Arm Linux system and proceed
+      The implementations include optimizations for Arm Neoverse that use Neon and SVE2. You don't need to set extra flags. Follow the build steps on an Arm Linux system
       to run and benchmark.
   - question: What should I expect after a successful build?
     answer: >-
@@ -44,7 +41,7 @@ generated_summary_faq:
   - question: What should I check if the build fails early?
     answer: >-
       Verify that required development tools, including CMake and the GNU compiler, are available.
-      Ensure you can access the referenced repositories and that you are building on an Arm Linux
+      Ensure you can access the referenced repositories and that you're building on an Arm Linux
       system.
 # END generated_summary_faq
 

--- a/content/learning-paths/servers-and-cloud-computing/codec1/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/codec1/_index.md
@@ -2,9 +2,55 @@
 title: Run the AV1 and VP9 codecs on Arm Linux
 description: Learn how to build and run the AV1 and VP9 video codecs on Arm Linux systems with performance benchmarking across various resolutions and encoding configurations.
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:43:40Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: c0643a788cdb0b3e33fe645fbb61d99a1899806e3ee197541c1eb8134b2876c1
+  summary_generated_at: '2026-07-27T18:43:40Z'
+  summary_source_hash: c0643a788cdb0b3e33fe645fbb61d99a1899806e3ee197541c1eb8134b2876c1
+  faq_generated_at: '2026-07-27T18:43:40Z'
+  faq_source_hash: c0643a788cdb0b3e33fe645fbb61d99a1899806e3ee197541c1eb8134b2876c1
+  summary: >-
+    You'll build the AV1 and VP9 reference codecs from source on Arm Linux and run them on sample
+    videos. You'll compile libxaom and libvpx with common development tools, then vary resolution
+    and encoding settings to compare runs. The workflow covers Arm Neoverse optimizations that use
+    Neon and SVE2 and supports basic performance benchmarking.
+  faqs:
+  - question: Which source repositories should I use for AV1 and VP9?
+    answer: >-
+      For AV1, use the `libxaom` reference implementation with Arm-optimized code available on
+      Google Git. For VP9, use the `libvpx` repository from the Chromium WebM project as shown in
+      the steps.
+  - question: Do I need to pass special flags to enable Neon or SVE2 optimizations?
+    answer: >-
+      The implementations include optimizations for Arm Neoverse that use Neon and SVE2. The path
+      does not list extra flags to set; follow the build steps on an Arm Linux system and proceed
+      to run and benchmark.
+  - question: What should I expect after a successful build?
+    answer: >-
+      A successful build produces libraries and codec executables that run on your Arm Linux system.
+      Confirm you can encode or decode the example videos without errors before moving on to benchmarking.
+  - question: How should I choose resolutions and settings for benchmarking?
+    answer: >-
+      Use example videos and vary resolution and encoding parameters to create comparable test
+      runs. Keep inputs consistent across runs and record the command lines so you can repeat
+      and compare results.
+  - question: What should I check if the build fails early?
+    answer: >-
+      Verify that required development tools, including CMake and the GNU compiler, are available.
+      Ensure you can access the referenced repositories and that you are building on an Arm Linux
+      system.
+# END generated_summary_faq
+
 author: Odin Shen
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -56,4 +102,3 @@ weight: 1
 layout: learningpathall
 learning_path_main_page: "yes"
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/couchbase-on-gcp/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/couchbase-on-gcp/_index.md
@@ -16,9 +16,55 @@ prerequisites:
   - A [Google Cloud Platform (GCP)](https://cloud.google.com/free) account with billing enabled  
   - Basic familiarity with [Couchbase](https://www.couchbase.com/)
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:44:09Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 0a7d76b8c944a50073c7524813acf83948155c7c61d9c92f9202eae1192c9600
+  summary_generated_at: '2026-07-27T18:44:09Z'
+  summary_source_hash: 0a7d76b8c944a50073c7524813acf83948155c7c61d9c92f9202eae1192c9600
+  faq_generated_at: '2026-07-27T18:44:09Z'
+  faq_source_hash: 0a7d76b8c944a50073c7524813acf83948155c7c61d9c92f9202eae1192c9600
+  summary: >-
+    You'll deploy Couchbase Server on an Arm-based Google Cloud C4A virtual machine and validate the
+    setup for benchmarking. You'll provision a C4A instance, expose the Couchbase Web Console with a
+    firewall rule, install Couchbase on a SUSE-based Arm64 VM, initialize the cluster, and create a
+    test bucket. By the end, you'll confirm the node is healthy and the bucket is ready for read/write
+    benchmarking with external tools.
+  faqs:
+  - question: What result should I expect when I open `http://<VM_IP>:8091`?
+    answer: >-
+      You should see the Couchbase Web Console for initial setup or login. After completing the
+      setup, the Servers page should show your node as healthy and your test bucket should appear
+      in the Buckets view.
+  - question: I can’t reach the Couchbase Web Console on port 8091—what should I check?
+    answer: >-
+      Create a GCP firewall rule that allows TCP port 8091 and applies to your instance. Confirm
+      that the VM is running, note its external IP, and try again.
+  - question: Which package manager should I use to follow the installation steps?
+    answer: >-
+      The steps use zypper for SUSE-based systems. Follow the commands as shown to refresh repositories,
+      update the system, and install required tools before adding Couchbase.
+  - question: How do I know the environment is ready for benchmarking?
+    answer: >-
+      Confirm that the web console responds on port 8091, cluster initialization is complete, the
+      node shows healthy status, and a test bucket exists. These checks indicate that the deployment
+      is ready for workload testing.
+  - question: When should I run YCSB workloads against Couchbase?
+    answer: >-
+      Run YCSB after you verify console access, complete cluster setup, and create a bucket. The
+      specific YCSB commands are not listed here, so use your verified bucket name and credentials
+      when you proceed.
+# END generated_summary_faq
+
 author: Pareena Verma
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -55,4 +101,3 @@ weight: 1
 layout: "learningpathall"
 learning_path_main_page: "yes"
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/couchbase-on-gcp/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/couchbase-on-gcp/_index.md
@@ -34,17 +34,17 @@ generated_summary_faq:
     You'll deploy Couchbase Server on an Arm-based Google Cloud C4A virtual machine and validate the
     setup for benchmarking. You'll provision a C4A instance, expose the Couchbase Web Console with a
     firewall rule, install Couchbase on a SUSE-based Arm64 VM, initialize the cluster, and create a
-    test bucket. By the end, you'll confirm the node is healthy and the bucket is ready for read/write
+    test bucket. By the end, you'll confirm the node is healthy and the bucket is ready for read and write
     benchmarking with external tools.
   faqs:
   - question: What result should I expect when I open `http://<VM_IP>:8091`?
     answer: >-
       You should see the Couchbase Web Console for initial setup or login. After completing the
-      setup, the Servers page should show your node as healthy and your test bucket should appear
+      setup, the **Servers** page should show your node as healthy and your test bucket should appear
       in the Buckets view.
-  - question: I can’t reach the Couchbase Web Console on port 8091—what should I check?
+  - question: I can’t reach the Couchbase Web Console on port 8091 — what should I check?
     answer: >-
-      Create a GCP firewall rule that allows TCP port 8091 and applies to your instance. Confirm
+      Create a GCP firewall rule that allows TCP port `8091` and applies to your instance. Confirm
       that the VM is running, note its external IP, and try again.
   - question: Which package manager should I use to follow the installation steps?
     answer: >-
@@ -52,13 +52,13 @@ generated_summary_faq:
       update the system, and install required tools before adding Couchbase.
   - question: How do I know the environment is ready for benchmarking?
     answer: >-
-      Confirm that the web console responds on port 8091, cluster initialization is complete, the
+      Confirm that the web console responds on port `8091`, cluster initialization is complete, the
       node shows healthy status, and a test bucket exists. These checks indicate that the deployment
       is ready for workload testing.
   - question: When should I run YCSB workloads against Couchbase?
     answer: >-
       Run YCSB after you verify console access, complete cluster setup, and create a bucket. The
-      specific YCSB commands are not listed here, so use your verified bucket name and credentials
+      specific YCSB commands aren't listed here, so use your verified bucket name and credentials
       when you proceed.
 # END generated_summary_faq
 

--- a/content/learning-paths/servers-and-cloud-computing/cplusplus_compilers_flags/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/cplusplus_compilers_flags/_index.md
@@ -14,9 +14,53 @@ prerequisites:
     - Basic understanding of C++.
     - Basic understanding of compilers.
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:45:15Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 22f845b8ea4dbb9ffc63fafb76c17c79aedde14a28417d49e1ab0833bbbc1eba
+  summary_generated_at: '2026-07-27T18:45:15Z'
+  summary_source_hash: 22f845b8ea4dbb9ffc63fafb76c17c79aedde14a28417d49e1ab0833bbbc1eba
+  faq_generated_at: '2026-07-27T18:45:15Z'
+  faq_source_hash: 22f845b8ea4dbb9ffc63fafb76c17c79aedde14a28417d49e1ab0833bbbc1eba
+  summary: >-
+    You'll compile and tune a C++ application with `g++` on an Arm Neoverse-based Linux system.
+    You'll inspect the CPU with `lscpu`, choose `-march` for portability or `-mcpu` for
+    processor-specific tuning, and consider size-sensitive container builds. You'll build and run
+    the example, then justify your flag choices based on portability, binary size, or performance.
+  faqs:
+  - question: How do I confirm the Arm CPU model on the instance before choosing flags?
+    answer: >-
+      Run `lscpu | grep -i model` and look for a `Model name` line such as `Neoverse-*`. If `lscpu`
+      omits the model name, use the tip in the step to read the CPU part number.
+  - question: Which compiler flag should I use for portability versus CPU-specific tuning?
+    answer: >-
+      Use `-march=` with a value that matches the lowest Arm architecture across your target
+      systems for portability. Use `-mcpu=` to tune for a specific processor when you plan to run only on
+      that CPU.
+  - question: Do I have to use an AWS Graviton 4 instance?
+    answer: >-
+      No. Any Neoverse-based system running Ubuntu 24.04 LTS works, including the examples mentioned.
+      The workflow assumes an Arm-native environment on such a system.
+  - question: What should I do if I’m deploying in a memory-constrained container?
+    answer: >-
+      Optimize for size as outlined in the example step. Choose compiler options that reduce binary
+      size and accept the trade-offs they introduce.
+  - question: What result should I expect after building and running the example?
+    answer: >-
+      The program should compile and run on the Arm instance. A portable build using `-march` is
+      intended to run on other Arm servers that meet that baseline, while a CPU-tuned build targets
+      the specified processor.
+# END generated_summary_faq
+
 author: Kieran Hejmadi
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -48,4 +92,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/cplusplus_compilers_flags/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/cplusplus_compilers_flags/_index.md
@@ -11,8 +11,8 @@ learning_objectives:
     - Use compiler flags to manage optimizations.
 
 prerequisites:
-    - Basic understanding of C++.
-    - Basic understanding of compilers.
+    - Basic understanding of C++
+    - Basic understanding of compilers
 
 # START generated_summary_faq
 generated_summary_faq:
@@ -30,9 +30,9 @@ generated_summary_faq:
   faq_source_hash: 22f845b8ea4dbb9ffc63fafb76c17c79aedde14a28417d49e1ab0833bbbc1eba
   summary: >-
     You'll compile and tune a C++ application with `g++` on an Arm Neoverse-based Linux system.
-    You'll inspect the CPU with `lscpu`, choose `-march` for portability or `-mcpu` for
+    You'll inspect the CPU with `lscpu`, choose between `-march` for portability and `-mcpu` for
     processor-specific tuning, and consider size-sensitive container builds. You'll build and run
-    the example, then justify your flag choices based on portability, binary size, or performance.
+    the example, then learn to make flag choices based on portability, binary size, and performance.
   faqs:
   - question: How do I confirm the Arm CPU model on the instance before choosing flags?
     answer: >-
@@ -43,7 +43,7 @@ generated_summary_faq:
       Use `-march=` with a value that matches the lowest Arm architecture across your target
       systems for portability. Use `-mcpu=` to tune for a specific processor when you plan to run only on
       that CPU.
-  - question: Do I have to use an AWS Graviton 4 instance?
+  - question: Do I have to use an AWS Graviton 4-based instance?
     answer: >-
       No. Any Neoverse-based system running Ubuntu 24.04 LTS works, including the examples mentioned.
       The workflow assumes an Arm-native environment on such a system.

--- a/content/learning-paths/servers-and-cloud-computing/cpp-profile-guided-optimisation/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/cpp-profile-guided-optimisation/_index.md
@@ -11,8 +11,8 @@ learning_objectives:
     - Apply profile-guided optimization to build performance-tuned binaries.
 
 prerequisites:
-    - Basic C++ understanding.
-    - Access to an Arm-based Linux machine.
+    - Basic C++ understanding
+    - Access to an Arm-based Linux machine
 
 # START generated_summary_faq
 generated_summary_faq:
@@ -32,8 +32,8 @@ generated_summary_faq:
     You'll apply profile-guided optimization (PGO) to a C++ microbenchmark on an Arm-based Linux
     system with Google Benchmark. You'll build an instrumented binary with `-fprofile-generate`, run
     it to create `.gcda` files, and recompile with `-fprofile-use`. You'll compare benchmark timings
-    before and after PGO, inspect the generated artifacts, and integrate PGO into a Makefile or
-    continuous integration workflow.
+    before and after PGO, inspect the generated artifacts, and integrate PGO into either a Makefile or a
+    continuous integration Github Actions workflow.
   faqs:
   - question: Which compiler flags do I use to collect and then apply profile data?
     answer: >-

--- a/content/learning-paths/servers-and-cloud-computing/cpp-profile-guided-optimisation/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/cpp-profile-guided-optimisation/_index.md
@@ -14,9 +14,55 @@ prerequisites:
     - Basic C++ understanding.
     - Access to an Arm-based Linux machine.
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:46:17Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 4e7de348514d0b5a742fa47bb85a2a5814fa9bd587478e7ef08365d16273f6bf
+  summary_generated_at: '2026-07-27T18:46:17Z'
+  summary_source_hash: 4e7de348514d0b5a742fa47bb85a2a5814fa9bd587478e7ef08365d16273f6bf
+  faq_generated_at: '2026-07-27T18:46:17Z'
+  faq_source_hash: 4e7de348514d0b5a742fa47bb85a2a5814fa9bd587478e7ef08365d16273f6bf
+  summary: >-
+    You'll apply profile-guided optimization (PGO) to a C++ microbenchmark on an Arm-based Linux
+    system with Google Benchmark. You'll build an instrumented binary with `-fprofile-generate`, run
+    it to create `.gcda` files, and recompile with `-fprofile-use`. You'll compare benchmark timings
+    before and after PGO, inspect the generated artifacts, and integrate PGO into a Makefile or
+    continuous integration workflow.
+  faqs:
+  - question: Which compiler flags do I use to collect and then apply profile data?
+    answer: >-
+      Build the instrumented binary with `-fprofile-generate`, run it to collect runtime data, then
+      rebuild with `-fprofile-use`. This two-step cycle enables the compiler to use the collected
+      profile during optimization.
+  - question: What files should appear after I run the instrumented binary?
+    answer: >-
+      The run generates profile data files with a `.gcda` extension in the same directory. Use these
+      files as inputs for the subsequent `-fprofile-use` build.
+  - question: How do I know Google Benchmark is working for the example?
+    answer: >-
+      Google Benchmark runs managed iterations and reports timing results for the benchmarked
+      function. You should see timing output you can compare across the non-PGO and PGO builds.
+  - question: What should I check if the optimized build doesn’t seem to use PGO?
+    answer: >-
+      Verify that you ran the instrumented binary and that `.gcda` files exist in the build
+      directory. Then confirm that the recompile used `-fprofile-use` in the same location where the
+      the run generated the profile files.
+  - question: Where should I apply PGO when adding it to a Makefile or GitHub Actions workflow?
+    answer: >-
+      Use PGO for performance-critical code that runtime behavior strongly influences. Avoid
+      applying it broadly to early-stage code or highly variable workloads because the extra build
+      steps add time and may not yield stable benefits.
+# END generated_summary_faq
+
 author: Kieran Hejmadi
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -52,4 +98,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/cpu_hotspot_performix/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/cpu_hotspot_performix/_index.md
@@ -14,9 +14,53 @@ prerequisites:
     - Access to Arm Performix
     - Basic understanding of C++
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:46:41Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 58dba071f70b4f85b87b3bd27b3a7ba3ff985f80079a42e05b797a998aeaf104
+  summary_generated_at: '2026-07-27T18:46:41Z'
+  summary_source_hash: 58dba071f70b4f85b87b3bd27b3a7ba3ff985f80079a42e05b797a998aeaf104
+  faq_generated_at: '2026-07-27T18:46:41Z'
+  faq_source_hash: 58dba071f70b4f85b87b3bd27b3a7ba3ff985f80079a42e05b797a998aeaf104
+  summary: >-
+    You'll profile a C++ Mandelbrot renderer on Arm Neoverse with Arm Performix and use flame graphs
+    to find hot code. You'll build the 1920×1080 bitmap example, capture a Code Hotspots baseline,
+    connect hot functions to source and call paths, edit the hottest loops, and profile it again.
+    By the end, you'll use flame graph evidence to target optimization work.
+  faqs:
+  - question: What result should I expect after running the Code Hotspots recipe?
+    answer: >-
+      Expect a flame graph that highlights the hottest functions in the run. The Mandelbrot example
+      typically surfaces `Mandelbrot::getIterations` and its `__hypot` call path in the stack if they
+      dominate CPU time.
+  - question: Where is the output bitmap written when running under Arm Performix?
+    answer: >-
+      The code writes to the relative path `./images/green.bmp`. Confirm the working directory used
+      by Arm Performix so the image appears where you expect, or adjust the path in the code.
+  - question: Which source file shows the baseline program flow I should compare against?
+    answer: >-
+      Open `src/main_single_thread.cpp`. It drives the Mandelbrot computation that generates the
+      1920×1080 bitmap used for profiling.
+  - question: How do I read the flame graph to decide what to change first?
+    answer: >-
+      Wider frames represent more sampled CPU time. Start with the widest frames near the top
+      of the stack and trace down the call path to find the exact functions to modify.
+  - question: How do I validate that my changes improved the hot path?
+    answer: >-
+      Rebuild the program and run the Code Hotspots recipe again. Compare the new flame graph
+      to the baseline; a reduction in the previous hotspot’s width indicates the change had an
+      effect.
+# END generated_summary_faq
+
 author: Kieran Hejmadi
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -52,4 +96,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/csp/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/csp/_index.md
@@ -2,9 +2,57 @@
 title: Get started with Arm-based cloud instances
 description: Learn how to start an Arm-based virtual machine instance from major cloud service providers and verify the Arm architecture is being used.
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:47:21Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 9e94b69eabf35677c48db812bb85ea9cef184efc078a826b96954f540a45e915
+  summary_generated_at: '2026-07-27T18:47:21Z'
+  summary_source_hash: 9e94b69eabf35677c48db812bb85ea9cef184efc078a826b96954f540a45e915
+  faq_generated_at: '2026-07-27T18:47:21Z'
+  faq_source_hash: 9e94b69eabf35677c48db812bb85ea9cef184efc078a826b96954f540a45e915
+  summary: >-
+    You'll launch Arm-based virtual machines across major cloud providers and verify that each uses
+    an Arm processor. You'll use each provider's console to choose an appropriate family and instance
+    type, including AWS Graviton, Azure Cobalt 100 or Ampere, Google Cloud Axion C4A, Oracle Cloud
+    Ampere, and Alibaba Cloud Arm-based ECS options. By the end, you'll recognize the instance details
+    that confirm an Arm deployment.
+  faqs:
+  - question: Which option identifies an Arm-based VM on my cloud provider?
+    answer: >-
+      On AWS, select Graviton-based EC2 instance types. On Azure, choose Cobalt 100 or Ampere
+      VMs. On Google Cloud, use the Axion C4A series; on Oracle Cloud and Alibaba Cloud, choose
+      Ampere- or Arm-based ECS options.
+  - question: Where do I select the Arm series on Google Cloud, and which machine type does this
+      guide use?
+    answer: >-
+      In the Google Cloud Console, select **Compute Engine**, **VM Instances**, and **Create**.
+      Set **Series** to **C4A**, then choose the `c4a-standard-4` machine type with 4 vCPUs and
+      16 GB of memory.
+  - question: How do I confirm the instance is running on Arm after creation?
+    answer: >-
+      Check the instance details in your cloud console and confirm the processor family or machine
+      type matches the Arm option you selected, such as Graviton, Cobalt 100, C4A, or Ampere.
+      If it shows a different family, return to the creation settings and choose the Arm series.
+  - question: On Microsoft Azure, should I choose Cobalt 100 or Ampere?
+    answer: >-
+      Both are Arm-based VM generations on Azure. The latest generation is Cobalt 100, while the
+      previous generation is Ampere; choose the one that fits your needs.
+  - question: What should I expect to see once provisioning finishes, and what should I verify
+      before continuing?
+    answer: >-
+      The new VM appears in the provider console with a running status. Verify the machine type
+      or series reflects the Arm-based family you selected before proceeding.
+# END generated_summary_faq
+
 author: Ronan Synnott
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -65,4 +113,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/csp/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/csp/_index.md
@@ -17,22 +17,22 @@ generated_summary_faq:
   faq_generated_at: '2026-07-27T18:47:21Z'
   faq_source_hash: 9e94b69eabf35677c48db812bb85ea9cef184efc078a826b96954f540a45e915
   summary: >-
-    You'll launch Arm-based virtual machines across major cloud providers and verify that each uses
+    You'll launch Arm-based virtual machines (VMs) across major cloud providers and verify that each uses
     an Arm processor. You'll use each provider's console to choose an appropriate family and instance
-    type, including AWS Graviton, Azure Cobalt 100 or Ampere, Google Cloud Axion C4A, Oracle Cloud
-    Ampere, and Alibaba Cloud Arm-based ECS options. By the end, you'll recognize the instance details
+    type, including Amazon Elastic Compute Cloud (EC2), Azure Cobalt 100-based VMs or Ampere, Google Cloud Axion C4A, Oracle Cloud
+    Ampere, and Alibaba Cloud Arm-based Elastic Compute Service (ECS) options. By the end, you'll recognize the instance details
     that confirm an Arm deployment.
   faqs:
   - question: Which option identifies an Arm-based VM on my cloud provider?
     answer: >-
-      On AWS, select Graviton-based EC2 instance types. On Azure, choose Cobalt 100 or Ampere
-      VMs. On Google Cloud, use the Axion C4A series; on Oracle Cloud and Alibaba Cloud, choose
+      On AWS, select Graviton-based EC2 instance types. On Azure, choose Cobalt 100-based or Ampere
+      VMs. On Google Cloud, use the Axion C4A series. On Oracle Cloud and Alibaba Cloud, choose
       Ampere- or Arm-based ECS options.
   - question: Where do I select the Arm series on Google Cloud, and which machine type does this
       guide use?
     answer: >-
       In the Google Cloud Console, select **Compute Engine**, **VM Instances**, and **Create**.
-      Set **Series** to **C4A**, then choose the `c4a-standard-4` machine type with 4 vCPUs and
+      Set **Series** to **C4A**, then choose the `c4a-standard-4` machine type with four vCPUs and
       16 GB of memory.
   - question: How do I confirm the instance is running on Arm after creation?
     answer: >-

--- a/content/learning-paths/servers-and-cloud-computing/deepseek-cpu/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/deepseek-cpu/_index.md
@@ -29,26 +29,26 @@ generated_summary_faq:
   faq_generated_at: '2026-07-27T18:48:20Z'
   faq_source_hash: f600fcba0adea12ff1b8b092e75de553577d940dc3bf632e9a247cec22d364a4
   summary: >-
-    You'll build llama.cpp on an Arm-based Ubuntu server, download a pre-quantized DeepSeek-R1 model
-    from Hugging Face, and run it for CPU inference. You'll launch a persistent llama.cpp server with
+    You'll build `llama.cpp` on an Arm-based Ubuntu server, download a pre-quantized DeepSeek-R1 model
+    from Hugging Face, and run it for CPU inference. You'll launch a persistent `llama.cpp` server with
     an OpenAI-compatible API, deploy a chatbot with the DeepSeek-R1 671B LLM, and send requests from
-    the same or another machine. You'll confirm the setup with API responses and basic benchmarks.
+    the same or another machine. You'll then confirm the setup with API responses and basic benchmarks.
   faqs:
   - question: What do I need before running the 671B model?
     answer: >-
       Use an Arm server running Ubuntu 24.04 LTS with at least 64 cores, 512 GB of RAM, and 400
-      GB of disk space. The path uses an AWS Graviton4 r8g.24xlarge instance for testing.
+      GB of disk space. The Learning Path was tested on an AWS Graviton4 `r8g.24xlarge` instance.
   - question: Which DeepSeek-R1 model should I download?
     answer: >-
-      Download a pre-quantized DeepSeek-R1 model from Hugging Face as specified in the steps.
-      Quantization enables efficient CPU inference with llama.cpp.
+      Download a pre-quantized DeepSeek-R1 model from Hugging Face.
+      Quantization enables efficient CPU inference with `llama.cpp`.
   - question: How do I know the llama.cpp server binary is available?
     answer: >-
-      Running `make` during the build step creates the server executable. If it is missing,
+      Running `make` during the build step creates the server executable. If it's missing,
       repeat the build step before starting the server.
   - question: How do I access the model repeatedly without restarting it?
     answer: >-
-      Start the llama.cpp server and use its OpenAI-compatible API to submit multiple requests.
+      Start the `llama.cpp` server and use its OpenAI-compatible API to submit multiple requests.
       You can also send requests from another machine to the host running the server.
   - question: Why do I install jq?
     answer: >-

--- a/content/learning-paths/servers-and-cloud-computing/deepseek-cpu/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/deepseek-cpu/_index.md
@@ -52,7 +52,7 @@ generated_summary_faq:
       You can also send requests from another machine to the host running the server.
   - question: Why do I install jq?
     answer: >-
-      The examples use `jq` to work with JSON. It helps format and parse responses returned
+      The examples use `jq` to work with JSON. `jq` helps format and parse responses returned
       by the OpenAI-compatible API calls.
 # END generated_summary_faq
 

--- a/content/learning-paths/servers-and-cloud-computing/deepseek-cpu/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/deepseek-cpu/_index.md
@@ -14,10 +14,52 @@ learning_objectives:
 prerequisites:
     - An [Arm-based instance](/learning-paths/servers-and-cloud-computing/csp/) from a cloud provider or an on-premise Arm server. This Learning Path was tested on an AWS Graviton4 r8g.24xlarge instance.
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:48:20Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: f600fcba0adea12ff1b8b092e75de553577d940dc3bf632e9a247cec22d364a4
+  summary_generated_at: '2026-07-27T18:48:20Z'
+  summary_source_hash: f600fcba0adea12ff1b8b092e75de553577d940dc3bf632e9a247cec22d364a4
+  faq_generated_at: '2026-07-27T18:48:20Z'
+  faq_source_hash: f600fcba0adea12ff1b8b092e75de553577d940dc3bf632e9a247cec22d364a4
+  summary: >-
+    You'll build llama.cpp on an Arm-based Ubuntu server, download a pre-quantized DeepSeek-R1 model
+    from Hugging Face, and run it for CPU inference. You'll launch a persistent llama.cpp server with
+    an OpenAI-compatible API, deploy a chatbot with the DeepSeek-R1 671B LLM, and send requests from
+    the same or another machine. You'll confirm the setup with API responses and basic benchmarks.
+  faqs:
+  - question: What do I need before running the 671B model?
+    answer: >-
+      Use an Arm server running Ubuntu 24.04 LTS with at least 64 cores, 512 GB of RAM, and 400
+      GB of disk space. The path uses an AWS Graviton4 r8g.24xlarge instance for testing.
+  - question: Which DeepSeek-R1 model should I download?
+    answer: >-
+      Download a pre-quantized DeepSeek-R1 model from Hugging Face as specified in the steps.
+      Quantization enables efficient CPU inference with llama.cpp.
+  - question: How do I know the llama.cpp server binary is available?
+    answer: >-
+      Running `make` during the build step creates the server executable. If it is missing,
+      repeat the build step before starting the server.
+  - question: How do I access the model repeatedly without restarting it?
+    answer: >-
+      Start the llama.cpp server and use its OpenAI-compatible API to submit multiple requests.
+      You can also send requests from another machine to the host running the server.
+  - question: Why do I install jq?
+    answer: >-
+      The examples use `jq` to work with JSON. It helps format and parse responses returned
+      by the OpenAI-compatible API calls.
+# END generated_summary_faq
+
 author:
     - Tianyu Li
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -62,4 +104,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/deepspeed-on-axion/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/deepspeed-on-axion/_index.md
@@ -17,9 +17,53 @@ prerequisites:
   - A [Google Cloud Platform (GCP)](https://cloud.google.com/free) account with billing enabled
   - Basic familiarity with Python and machine learning concepts
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:49:11Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: ee3e7ea8337b8506e30d93aaf2dbe144e5838a6740c8eff8447617f8c75629c7
+  summary_generated_at: '2026-07-27T18:49:11Z'
+  summary_source_hash: ee3e7ea8337b8506e30d93aaf2dbe144e5838a6740c8eff8447617f8c75629c7
+  faq_generated_at: '2026-07-27T18:49:11Z'
+  faq_source_hash: ee3e7ea8337b8506e30d93aaf2dbe144e5838a6740c8eff8447617f8c75629c7
+  summary: >-
+    You'll provision a Google Cloud C4A Axion Arm virtual machine running SUSE Linux, set up Python
+    3.11, and install PyTorch and DeepSpeed for CPU training and benchmarking. You'll verify the
+    `aarch64` architecture and Neoverse-V2 cores with `uname` and `lscpu`, create a dedicated virtual
+    environment, and run a baseline model followed by a larger benchmark. You'll confirm correct
+    execution from the training logs and benchmark output.
+  faqs:
+  - question: How do I know the VM is Arm64 and running on Axion cores?
+    answer: >-
+      Run `uname -m` and confirm that the output is `aarch64`. Then run `lscpu` and check that the
+      model name reports `Neoverse-V2`.
+  - question: Which Google Cloud VM configuration should I use for the steps?
+    answer: >-
+      Use the `c4a-standard-4` machine type with 4 vCPUs and 16 GB of memory. This configuration
+      hosts the PyTorch and DeepSpeed workloads.
+  - question: Which Python version do I need and what is the virtual environment called?
+    answer: >-
+      Install Python 3.11 and create a virtual environment for the project. The path uses an environment
+      named `deepspeed-env`.
+  - question: I opened a new SSH session. What should I do before running workloads?
+    answer: >-
+      Re-activate the `deepspeed-env` virtual environment and navigate to the `~/deepspeed-demo`
+      directory. This ensures the correct dependencies and paths are active.
+  - question: What result should I expect from the baseline and benchmark runs?
+    answer: >-
+      The baseline model should run without errors and print training logs, confirming that PyTorch
+      and DeepSpeed are correctly installed. The larger benchmark runs longer and lets you observe
+      CPU scaling behavior by reviewing its logs and runtime characteristics.
+# END generated_summary_faq
+
 author: Pareena Verma
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 

--- a/content/learning-paths/servers-and-cloud-computing/deepspeed-on-axion/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/deepspeed-on-axion/_index.md
@@ -32,7 +32,7 @@ generated_summary_faq:
   faq_generated_at: '2026-07-27T18:49:11Z'
   faq_source_hash: ee3e7ea8337b8506e30d93aaf2dbe144e5838a6740c8eff8447617f8c75629c7
   summary: >-
-    You'll provision a Google Cloud C4A Arm virtual machine running SUSE Linux, set up Python
+    You'll provision a Google Cloud C4A Arm VM running SUSE Linux, set up Python
     3.11, and install PyTorch and DeepSpeed for CPU training and benchmarking. You'll verify the
     `aarch64` architecture and Neoverse-V2 cores with `uname` and `lscpu`, create a dedicated virtual
     environment, and run a baseline model followed by a larger benchmark. From the training logs and benchmark output, you'll confirm correct

--- a/content/learning-paths/servers-and-cloud-computing/deepspeed-on-axion/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/deepspeed-on-axion/_index.md
@@ -8,10 +8,10 @@ minutes_to_complete: 30
 who_is_this_for: This is an introductory topic for DevOps engineers, ML engineers, and software developers who want to run AI training and benchmarking workloads using PyTorch and DeepSpeed on SUSE Linux Enterprise Server (SLES) Arm64, validate CPU-based neural network execution, and benchmark AI performance on Arm processors.
 
 learning_objectives:
-    - Install and configure PyTorch and DeepSpeed on Arm-based Google Cloud C4A Axion VMs 
-    - Create and execute neural network training workloads using PyTorch
-    - Benchmark CPU-based AI workloads on Arm64 processors
-    - Validate scalable AI execution and workload performance on Google Axion Arm VMs
+    - Install and configure PyTorch and DeepSpeed on Arm-based Google Cloud C4A Axion virtual machines (VMs). 
+    - Create and execute neural network training workloads using PyTorch.
+    - Benchmark CPU-based AI workloads on Arm64 processors.
+    - Validate scalable AI execution and workload performance on Google Axion Arm VMs.
 
 prerequisites:
   - A [Google Cloud Platform (GCP)](https://cloud.google.com/free) account with billing enabled
@@ -32,11 +32,11 @@ generated_summary_faq:
   faq_generated_at: '2026-07-27T18:49:11Z'
   faq_source_hash: ee3e7ea8337b8506e30d93aaf2dbe144e5838a6740c8eff8447617f8c75629c7
   summary: >-
-    You'll provision a Google Cloud C4A Axion Arm virtual machine running SUSE Linux, set up Python
+    You'll provision a Google Cloud C4A Arm virtual machine running SUSE Linux, set up Python
     3.11, and install PyTorch and DeepSpeed for CPU training and benchmarking. You'll verify the
     `aarch64` architecture and Neoverse-V2 cores with `uname` and `lscpu`, create a dedicated virtual
-    environment, and run a baseline model followed by a larger benchmark. You'll confirm correct
-    execution from the training logs and benchmark output.
+    environment, and run a baseline model followed by a larger benchmark. From the training logs and benchmark output, you'll confirm correct
+    execution.
   faqs:
   - question: How do I know the VM is Arm64 and running on Axion cores?
     answer: >-

--- a/content/learning-paths/servers-and-cloud-computing/disk-io-benchmark/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/disk-io-benchmark/_index.md
@@ -15,9 +15,54 @@ prerequisites:
     - An [Arm-based instance](/learning-paths/servers-and-cloud-computing/csp/) from a cloud service provider or an Arm Linux server.
     - Familiarity with Linux.
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:49:30Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: a1ec216948e7cfd4fc52815196bb3b99ab4e76c9c756aa9e9a8e3216ef5e7ce4
+  summary_generated_at: '2026-07-27T18:49:30Z'
+  summary_source_hash: a1ec216948e7cfd4fc52815196bb3b99ab4e76c9c756aa9e9a8e3216ef5e7ce4
+  faq_generated_at: '2026-07-27T18:49:30Z'
+  faq_source_hash: a1ec216948e7cfd4fc52815196bb3b99ab4e76c9c756aa9e9a8e3216ef5e7ce4
+  summary: >-
+    You'll characterize storage on an Arm-based Linux system by analyzing a real workload and running
+    comparable `fio` profiles. You'll identify I/O size, read/write mix, access pattern, target IOPS,
+    and throughput, then attach SSD-backed devices and monitor them with `iostat`, `iotop`, and
+    `pidstat`. By the end, you'll compare device behavior and interpret `fio` results alongside system
+    metrics.
+  faqs:
+  - question: How do I know the additional volumes are attached correctly before running `fio`?
+    answer: >-
+      After attaching the volumes in the cloud console, the instance should expose two new block
+      devices. Verify that the expected device identifiers are available so you can target them
+      in tests.
+  - question: Which `fio` job parameters should I choose to reflect my workload?
+    answer: >-
+      Base your job on the attributes you observed from the real workload: I/O size, read/write
+      ratio, sequential versus random access, target IOPS, and throughput. Keep the profile consistent
+      when comparing devices.
+  - question: What should I look for in `fio` output to compare devices?
+    answer: >-
+      Focus on reported IOPS and throughput for the selected job profile. Compare those values
+      across runs to see how each block device behaves under the same conditions.
+  - question: When should I run `iostat`, `iotop`, and `pidstat` during this process?
+    answer: >-
+      Run them while the workload and `fio` jobs are active to observe device utilization and per-process
+      activity. Use these observations to spot contention and guide the next test configuration.
+  - question: Do I need to use the exact instance type shown in the example?
+    answer: >-
+      The example uses an Arm-based cloud instance to illustrate the workflow. You can follow
+      the same steps on an Arm Linux server or another Arm-based instance.
+# END generated_summary_faq
+
 author: Kieran Hejmadi
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -49,4 +94,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/distributed-inference-with-llama-cpp/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/distributed-inference-with-llama-cpp/_index.md
@@ -32,7 +32,7 @@ generated_summary_faq:
   faq_generated_at: '2026-07-27T18:50:08Z'
   faq_source_hash: 3d6c5f380d7f7b4436573d6b432a42f267747d6a45c9ffca759c2048b7a94230
   summary: >-
-    You'll run distributed CPU inference with llama.cpp on AWS Graviton4 instances. You'll convert
+    You'll run distributed CPU inference with `llama.cpp` on AWS Graviton4 instances. You'll convert
     Meta's Llama 3.1 70B safetensors shards to one GGUF file, quantize the weights to 4-bit, configure
     worker RPC backends and a master through a comma-separated `worker_ips` list, and verify
     connectivity with `telnet`. You'll then launch distributed inference across the Arm servers.

--- a/content/learning-paths/servers-and-cloud-computing/distributed-inference-with-llama-cpp/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/distributed-inference-with-llama-cpp/_index.md
@@ -17,11 +17,54 @@ prerequisites:
     - Familiarity with the Learning Path [Deploy a Large Language Model (LLM) chatbot with llama.cpp using KleidiAI on Arm servers](/learning-paths/servers-and-cloud-computing/llama-cpu/)
     - Familiarity with AWS
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:50:08Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 3d6c5f380d7f7b4436573d6b432a42f267747d6a45c9ffca759c2048b7a94230
+  summary_generated_at: '2026-07-27T18:50:08Z'
+  summary_source_hash: 3d6c5f380d7f7b4436573d6b432a42f267747d6a45c9ffca759c2048b7a94230
+  faq_generated_at: '2026-07-27T18:50:08Z'
+  faq_source_hash: 3d6c5f380d7f7b4436573d6b432a42f267747d6a45c9ffca759c2048b7a94230
+  summary: >-
+    You'll run distributed CPU inference with llama.cpp on AWS Graviton4 instances. You'll convert
+    Meta's Llama 3.1 70B safetensors shards to one GGUF file, quantize the weights to 4-bit, configure
+    worker RPC backends and a master through a comma-separated `worker_ips` list, and verify
+    connectivity with `telnet`. You'll then launch distributed inference across the Arm servers.
+  faqs:
+  - question: How do I pass the worker node addresses to the master?
+    answer: >-
+      Export the `worker_ips` environment variable with a comma-separated list of `host:port` entries,
+      for example, `172.31.110.11:50052,172.31.110.12:50052`. Run this on the master node before
+      starting inference.
+  - question: How do I verify the master can reach a worker before running a distributed job?
+    answer: >-
+      From the master, run `telnet <worker_ip> 50052`. A successful connection confirms that the
+      backend server on the worker is reachable.
+  - question: Which model format should I use with llama.cpp in this path?
+    answer: >-
+      Convert Meta’s safetensors files for Llama 3.1 70B to a single GGUF file, then quantize
+      to 4-bit GGUF. Use the quantized GGUF for inference.
+  - question: How do I confirm the quantization step worked?
+    answer: >-
+      The process should create a new 4-bit GGUF weights file that is smaller than the 16-bit GGUF.
+      Use this 4-bit file for the distributed run.
+  - question: How many nodes are used in the example and what roles do they serve?
+    answer: >-
+      The example uses three AWS Graviton4 instances: one master node and two worker nodes. The
+      master coordinates inference while the workers run the RPC backend.
+# END generated_summary_faq
+
 author: 
     - Aryan Bhusari
     - Joe Stech
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -51,4 +94,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/django-on-gcp/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/django-on-gcp/_index.md
@@ -6,7 +6,7 @@ description: Learn how to deploy a production-grade Django REST API on Google Ku
 who_is_this_for: This is an introductory topic for DevOps engineers and software developers who want to deploy, operate, and benchmark a production-grade Django REST API on Google Kubernetes Engine (GKE) running on Arm64 Axion processors, integrated with managed Google Cloud data services
 
 learning_objectives:
-  - Provision Arm-based Axion compute on Google Cloud using virtual machines and GKE node pools
+  - Provision Arm-based Axion compute on Google Cloud using virtual machines (VMs) and GKE node pools
   - Package a Django REST API into an Arm-native Docker container
   - Push container images to Google Artifact Registry
   - Deploy Django on GKE using Kubernetes manifests (Deployment, Service, ConfigMap, Secrets)
@@ -36,7 +36,7 @@ generated_summary_faq:
   faq_generated_at: '2026-07-27T18:50:52Z'
   faq_source_hash: 6675df4c91126b157dcbf39c96a773130f1a95e2f5680913979da96f6f6c97cd
   summary: >-
-    You'll deploy a Django REST API on Google Cloud Axion C4A. You'll create a SUSE Linux Enterprise
+    You'll deploy a Django REST API on a Google Cloud Axion C4A virtual machine. You'll create a SUSE Linux Enterprise
     Server VM, install Python and Django, and verify the development server. You'll then containerize
     the application for Google Kubernetes Engine, connect Cloud SQL PostgreSQL over private IP and
     Memorystore Redis, expose the service with a LoadBalancer, and measure throughput and p95 latency
@@ -44,7 +44,7 @@ generated_summary_faq:
   faqs:
   - question: Which Axion C4A VM configuration should I use for the initial setup?
     answer: >-
-      The steps use `c4a-standard-4`, which provides four vCPUs and 16 GB of memory. Create the
+      Use `c4a-standard-4`, which provides 4 vCPUs and 16 GB of memory. Create the
       instance from Compute Engine in the Google Cloud Console.
   - question: How do I open and verify access to the Django development server?
     answer: >-
@@ -55,9 +55,9 @@ generated_summary_faq:
       You should see a `manage.py` file and a project module directory containing `settings.py`,
       `urls.py`, `asgi.py`, and `wsgi.py`. Running the development server should serve a Django page from the
       VM on port 8000.
-  - question: Which Linux distribution and Python version do the installation steps use?
+  - question: Which Linux distribution and Python version do I use?
     answer: >-
-      The steps use SUSE Linux Enterprise Server (SLES) and install Python 3.11 with zypper. Verify
+      Use SUSE Linux Enterprise Server (SLES) and install Python 3.11 with zypper. Verify
       the installation with `python3.11 --version` before creating the Django project.
   - question: How is state handled when deploying to GKE later in the path?
     answer: >-

--- a/content/learning-paths/servers-and-cloud-computing/django-on-gcp/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/django-on-gcp/_index.md
@@ -21,9 +21,54 @@ prerequisites:
   - Basic familiarity with [Django](https://www.djangoproject.com/)
   - Basic understanding of containers and Kubernetes concepts
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:50:52Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 6675df4c91126b157dcbf39c96a773130f1a95e2f5680913979da96f6f6c97cd
+  summary_generated_at: '2026-07-27T18:50:52Z'
+  summary_source_hash: 6675df4c91126b157dcbf39c96a773130f1a95e2f5680913979da96f6f6c97cd
+  faq_generated_at: '2026-07-27T18:50:52Z'
+  faq_source_hash: 6675df4c91126b157dcbf39c96a773130f1a95e2f5680913979da96f6f6c97cd
+  summary: >-
+    You'll deploy a Django REST API on Google Cloud Axion C4A. You'll create a SUSE Linux Enterprise
+    Server VM, install Python and Django, and verify the development server. You'll then containerize
+    the application for Google Kubernetes Engine, connect Cloud SQL PostgreSQL over private IP and
+    Memorystore Redis, expose the service with a LoadBalancer, and measure throughput and p95 latency
+    with ApacheBench against Gunicorn on Arm.
+  faqs:
+  - question: Which Axion C4A VM configuration should I use for the initial setup?
+    answer: >-
+      The steps use `c4a-standard-4`, which provides four vCPUs and 16 GB of memory. Create the
+      instance from Compute Engine in the Google Cloud Console.
+  - question: How do I open and verify access to the Django development server?
+    answer: >-
+      Create a firewall rule that allows inbound TCP traffic on port 8000 to your VM. After starting
+      the server, browse to the VM’s external IP on port 8000 to confirm it responds.
+  - question: What should I see after creating the Django project?
+    answer: >-
+      You should see a `manage.py` file and a project module directory containing `settings.py`,
+      `urls.py`, `asgi.py`, and `wsgi.py`. Running the development server should serve a Django page from the
+      VM on port 8000.
+  - question: Which Linux distribution and Python version do the installation steps use?
+    answer: >-
+      The steps use SUSE Linux Enterprise Server (SLES) and install Python 3.11 with zypper. Verify
+      the installation with `python3.11 --version` before creating the Django project.
+  - question: How is state handled when deploying to GKE later in the path?
+    answer: >-
+      The deployment integrates Cloud SQL (PostgreSQL) over private IP and Memorystore (Redis)
+      for caching and sessions. Kubernetes manifests use objects such as ConfigMap and Secrets
+      to configure the application.
+# END generated_summary_faq
+
 author: Pareena Verma
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -79,4 +124,3 @@ weight: 1
 layout: "learningpathall"
 learning_path_main_page: yes
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/django-on-gcp/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/django-on-gcp/_index.md
@@ -36,7 +36,7 @@ generated_summary_faq:
   faq_generated_at: '2026-07-27T18:50:52Z'
   faq_source_hash: 6675df4c91126b157dcbf39c96a773130f1a95e2f5680913979da96f6f6c97cd
   summary: >-
-    You'll deploy a Django REST API on a Google Cloud Axion C4A virtual machine. You'll create a SUSE Linux Enterprise
+    You'll deploy a Django REST API on a Google Cloud Axion C4A VM. You'll create a SUSE Linux Enterprise
     Server VM, install Python and Django, and verify the development server. You'll then containerize
     the application for Google Kubernetes Engine, connect Cloud SQL PostgreSQL over private IP and
     Memorystore Redis, expose the service with a LoadBalancer, and measure throughput and p95 latency

--- a/content/learning-paths/servers-and-cloud-computing/django/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/django/_index.md
@@ -15,7 +15,7 @@ prerequisites:
     - One of either an [Arm based instance](/learning-paths/servers-and-cloud-computing/csp/) from a cloud service provider, an on-premises Arm server, or a Linux virtual machine on your Arm device
     - Sudo access to install dependencies and to modify system configuration files
     - Familiarity with SSH and Linux terminal, and basic system administration tasks
-    - Both [Nginx](/learning-paths/servers-and-cloud-computing/nginx/) and [PostgreSQL](/learning-paths/servers-and-cloud-computing/postgresql/) installed
+    - Both [NGINX](/learning-paths/servers-and-cloud-computing/nginx/) and [PostgreSQL](/learning-paths/servers-and-cloud-computing/postgresql/) installed
 
 # START generated_summary_faq
 generated_summary_faq:

--- a/content/learning-paths/servers-and-cloud-computing/django/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/django/_index.md
@@ -17,9 +17,54 @@ prerequisites:
     - Be comfortable with SSH/Linux terminal and basic system administration tasks.
     - To install both [Nginx](/learning-paths/servers-and-cloud-computing/nginx/) and [PostgreSQL](/learning-paths/servers-and-cloud-computing/postgresql/)
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:51:37Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: c316c81de911ecd7f8e517f4ae5e5006d66a637199b8952fe195a74f3456a5e0
+  summary_generated_at: '2026-07-27T18:51:37Z'
+  summary_source_hash: c316c81de911ecd7f8e517f4ae5e5006d66a637199b8952fe195a74f3456a5e0
+  faq_generated_at: '2026-07-27T18:51:37Z'
+  faq_source_hash: c316c81de911ecd7f8e517f4ae5e5006d66a637199b8952fe195a74f3456a5e0
+  summary: >-
+    You'll create a minimal Django project on an Arm-based Linux machine and prepare it for deployment
+    with PostgreSQL and Nginx. You'll initialize the project, verify the development server, configure
+    the PostgreSQL backend and matching database user, then connect the application to Nginx. By the
+    end, you'll have a working Django application backed by PostgreSQL and deployed on Ubuntu 22.04 LTS.
+  faqs:
+  - question: Which Linux distribution do the steps assume?
+    answer: >-
+      The steps use Ubuntu 22.04 LTS. Follow the same instructions whether you connect to a remote
+      Arm server over SSH or use a local Arm VM or machine.
+  - question: What files should I see after running `django-admin startproject myproject`?
+    answer: >-
+      Expect a `myproject` directory containing `manage.py` and a `myproject` package with
+      `__init__.py`, `asgi.py`, `settings.py`, `urls.py`, and `wsgi.py`. The structure matches the tree shown in the
+      steps.
+  - question: Which DATABASES settings do I need to change for PostgreSQL?
+    answer: >-
+      Set `ENGINE` to `django.db.backends.postgresql` and provide `NAME`, `USER`, `PASSWORD`, `HOST`, and
+      `PORT`. Use `localhost` or your machine’s IP address for `HOST` and keep `PORT` as `5432` unless configured
+      otherwise.
+  - question: How do I create the PostgreSQL database and user to match my Django settings?
+    answer: >-
+      Open the PostgreSQL prompt with `sudo -u postgres psql`, then create the database and user
+      using the same values you set in `settings.py`. Ensure the user has the required password
+      and access to the specified database.
+  - question: When should I configure Nginx in this workflow?
+    answer: >-
+      Configure Nginx after confirming the Django project runs and the PostgreSQL connection works.
+      Proceed to the deployment steps to integrate Nginx with the application.
+# END generated_summary_faq
+
 author: Diego Russo
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -61,4 +106,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/django/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/django/_index.md
@@ -12,10 +12,10 @@ learning_objectives:
     - Verify that the Django application is working correctly
 
 prerequisites:
-    - At least either an [Arm based instance](/learning-paths/servers-and-cloud-computing/csp/) from a cloud service provider, on-premises Arm server, or a Linux virtual machine on your Arm device.
-    - Sudo access to install dependencies and to modify system configuration files.
-    - Be comfortable with SSH/Linux terminal and basic system administration tasks.
-    - To install both [Nginx](/learning-paths/servers-and-cloud-computing/nginx/) and [PostgreSQL](/learning-paths/servers-and-cloud-computing/postgresql/)
+    - One of either an [Arm based instance](/learning-paths/servers-and-cloud-computing/csp/) from a cloud service provider, an on-premises Arm server, or a Linux virtual machine on your Arm device
+    - Sudo access to install dependencies and to modify system configuration files
+    - Familiarity with SSH and Linux terminal, and basic system administration tasks
+    - Both [Nginx](/learning-paths/servers-and-cloud-computing/nginx/) and [PostgreSQL](/learning-paths/servers-and-cloud-computing/postgresql/) installed
 
 # START generated_summary_faq
 generated_summary_faq:
@@ -33,8 +33,8 @@ generated_summary_faq:
   faq_source_hash: c316c81de911ecd7f8e517f4ae5e5006d66a637199b8952fe195a74f3456a5e0
   summary: >-
     You'll create a minimal Django project on an Arm-based Linux machine and prepare it for deployment
-    with PostgreSQL and Nginx. You'll initialize the project, verify the development server, configure
-    the PostgreSQL backend and matching database user, then connect the application to Nginx. By the
+    with PostgreSQL and NGINX. You'll initialize the project, verify the development server, and configure
+    the PostgreSQL backend and matching database user. Then, you'll connect the application to NGINX. By the
     end, you'll have a working Django application backed by PostgreSQL and deployed on Ubuntu 22.04 LTS.
   faqs:
   - question: Which Linux distribution do the steps assume?
@@ -56,10 +56,10 @@ generated_summary_faq:
       Open the PostgreSQL prompt with `sudo -u postgres psql`, then create the database and user
       using the same values you set in `settings.py`. Ensure the user has the required password
       and access to the specified database.
-  - question: When should I configure Nginx in this workflow?
+  - question: When should I configure NGINX in this workflow?
     answer: >-
-      Configure Nginx after confirming the Django project runs and the PostgreSQL connection works.
-      Proceed to the deployment steps to integrate Nginx with the application.
+      Configure NGINX after confirming the Django project runs and the PostgreSQL connection works.
+      Proceed to the deployment steps to integrate NGINX with the application.
 # END generated_summary_faq
 
 author: Diego Russo

--- a/content/learning-paths/servers-and-cloud-computing/dlrm/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/dlrm/_index.md
@@ -33,8 +33,7 @@ generated_summary_faq:
     repository, use PyTorch 2.9.0+cpu with Arm-focused optimizations, and execute the benchmark.
     You'll then inspect the output to confirm a successful run and review the results.
   faqs:
-  - question: How do I know I’ve installed `rclone` correctly, and do I need to configure it before
-      downloading?
+  - question: How do I know I’ve installed `rclone` correctly, and do I need to configure it before downloading?
     answer: >-
       After the install script reports that `rclone` installed successfully, run `rclone config`
       before downloading the data and model weights.

--- a/content/learning-paths/servers-and-cloud-computing/dlrm/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/dlrm/_index.md
@@ -13,12 +13,56 @@ learning_objectives:
 prerequisites:
     - Any [Arm-based instance](/learning-paths/servers-and-cloud-computing/csp/) from a cloud service provider (CSP), or an on-premise Arm server with at least 400GB of RAM and 800 GB of disk space.
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:51:58Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 82716c2de19d18a154c85d03b7f2ec01839284262914f7bb3ad04b18a105379d
+  summary_generated_at: '2026-07-27T18:51:58Z'
+  summary_source_hash: 82716c2de19d18a154c85d03b7f2ec01839284262914f7bb3ad04b18a105379d
+  faq_generated_at: '2026-07-27T18:51:58Z'
+  faq_source_hash: 82716c2de19d18a154c85d03b7f2ec01839284262914f7bb3ad04b18a105379d
+  summary: >-
+    You'll prepare an Arm Neoverse V2 server, download the DLRM dataset and model weights with `rclone`,
+    and run a modified MLPerf DLRM benchmark. You'll create dedicated directories, clone the provided
+    repository, use PyTorch 2.9.0+cpu with Arm-focused optimizations, and execute the benchmark.
+    You'll then inspect the output to confirm a successful run and review the results.
+  faqs:
+  - question: How do I know I’ve installed `rclone` correctly, and do I need to configure it before
+      downloading?
+    answer: >-
+      After the install script reports that `rclone` installed successfully, run `rclone config`
+      before downloading the data and model weights.
+  - question: Which directories should contain the downloaded dataset and model weights?
+    answer: >-
+      Create data and model directories under your home directory, for example `$HOME/data` and
+      `$HOME/model`. Download the dataset into `data` and the model weights into `model`.
+  - question: Which PyTorch build does the benchmark use?
+    answer: >-
+      The benchmark uses PyTorch 2.9.0+cpu with optimizations for recommendation models on Arm.
+      Use the build referenced by the provided scripts.
+  - question: How do I know the benchmark finished correctly, and where do I view the results?
+    answer: >-
+      The run prints benchmark progress and produces results you can inspect after completion.
+      Review the script output and confirm that the run completed without errors.
+  - question: What should I check if the download or benchmark fails partway through?
+    answer: >-
+      Verify the instance meets the stated resource requirements and that sufficient RAM and disk
+      space are available. Also confirm that the dataset and model weights reached the expected
+      directories before rerunning.
+# END generated_summary_faq
+
 author: 
     - Phalani Paladugu
     - Annie Tallund
     - Pareena Verma
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -53,4 +97,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/docker-mcp-toolkit/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/docker-mcp-toolkit/_index.md
@@ -23,9 +23,56 @@ prerequisites:
     - A machine with at least 8 GB RAM (16 GB recommended)
     - Basic familiarity with Docker, C++, and SIMD intrinsics concepts
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:52:34Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 80785022032bf4e3c65da682e698940a212ee1ee77386698889a9fafbed9f823
+  summary_generated_at: '2026-07-27T18:52:34Z'
+  summary_source_hash: 80785022032bf4e3c65da682e698940a212ee1ee77386698889a9fafbed9f823
+  faq_generated_at: '2026-07-27T18:52:34Z'
+  faq_source_hash: 80785022032bf4e3c65da682e698940a212ee1ee77386698889a9fafbed9f823
+  summary: >-
+    You'll use Docker MCP Toolkit, the Arm MCP Server, and GitHub Copilot in VS Code to migrate an
+    x86-optimized C++ container to Arm64. You'll configure the MCP servers and Gateway, use a provided
+    prompt to find x86-specific code and propose Arm Neon conversions, update the Dockerfile, and
+    build the container with `docker buildx`. Finally, you'll run the container and verify Arm64
+    execution with NEON.
+  faqs:
+  - question: How do I know the MCP_DOCKER server is running and connected to Copilot?
+    answer: >-
+      In VS Code, select **Extensions**, then **MCP_DOCKER** and **Start Server**.
+      When it is running, GitHub Copilot can invoke the configured MCP servers through the MCP
+      Gateway.
+  - question: Which repository do I clone, and where should I run the commands?
+    answer: >-
+      Clone `https://github.com/JoeStech/docker-blog-arm-migration` and change into that directory.
+      Open it in VS Code and run the build and run commands from the repository root.
+  - question: What should I change in the Dockerfile for Arm64 builds?
+    answer: >-
+      Update two areas for Arm compatibility, including adding Arm64 support in the base image.
+      Follow the migration steps to apply the remaining `Dockerfile` adjustments identified
+      during the review.
+  - question: How do I trigger the migration with Copilot, and what should I expect it to do?
+    answer: >-
+      Open GitHub Copilot Chat in VS Code and paste the provided migration prompt. Copilot uses
+      the Arm MCP Server tools to scan for x86-specific dependencies and AVX2 intrinsics, propose
+      Neon equivalents, and can prepare a pull request via the GitHub MCP Server.
+  - question: What result should I expect when I run the Arm64 container?
+    answer: >-
+      The benchmark output shows Arm64 execution with NEON optimizations and prints
+      benchmark details. Look for lines such as the architecture notice, the matrix size, and
+      a result sum to confirm a successful run.
+# END generated_summary_faq
+
 author: Ajeet Singh Raina
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -72,4 +119,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/docker-mcp-toolkit/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/docker-mcp-toolkit/_index.md
@@ -18,7 +18,7 @@ learning_objectives:
 
 prerequisites:
     - Docker Desktop 4.59 or later with MCP Toolkit enabled
-    - VS Code with the GitHub Copilot extension
+    - Visual Studio Code (VS Code) with the GitHub Copilot extension
     - A GitHub account with a personal access token
     - A machine with at least 8 GB RAM (16 GB recommended)
     - Basic familiarity with Docker, C++, and SIMD intrinsics concepts
@@ -47,25 +47,25 @@ generated_summary_faq:
   - question: How do I know the MCP_DOCKER server is running and connected to Copilot?
     answer: >-
       In VS Code, select **Extensions**, then **MCP_DOCKER** and **Start Server**.
-      When it is running, GitHub Copilot can invoke the configured MCP servers through the MCP
+      When it's running, GitHub Copilot can invoke the configured MCP servers through the MCP
       Gateway.
   - question: Which repository do I clone, and where should I run the commands?
     answer: >-
       Clone `https://github.com/JoeStech/docker-blog-arm-migration` and change into that directory.
-      Open it in VS Code and run the build and run commands from the repository root.
+      Open the repository in VS Code and run the build and run commands from the repository root.
   - question: What should I change in the Dockerfile for Arm64 builds?
     answer: >-
-      Update two areas for Arm compatibility, including adding Arm64 support in the base image.
-      Follow the migration steps to apply the remaining `Dockerfile` adjustments identified
-      during the review.
+      Add Arm64 support in the base image and update compiler flags. 
+      Follow the migration steps to apply `Dockerfile` adjustments identified
+      during review.
   - question: How do I trigger the migration with Copilot, and what should I expect it to do?
     answer: >-
       Open GitHub Copilot Chat in VS Code and paste the provided migration prompt. Copilot uses
-      the Arm MCP Server tools to scan for x86-specific dependencies and AVX2 intrinsics, propose
-      Neon equivalents, and can prepare a pull request via the GitHub MCP Server.
+      the Arm MCP Server tools to scan for x86-specific dependencies and AVX2 intrinsics and propose
+      Neon equivalents. Copilot can also prepare a pull request using the GitHub MCP Server.
   - question: What result should I expect when I run the Arm64 container?
     answer: >-
-      The benchmark output shows Arm64 execution with NEON optimizations and prints
+      The benchmark output shows Arm64 execution with Neon optimizations and prints
       benchmark details. Look for lines such as the architecture notice, the matrix size, and
       a result sum to confirm a successful run.
 # END generated_summary_faq

--- a/content/learning-paths/servers-and-cloud-computing/dotnet-migration-nopcommerce/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/dotnet-migration-nopcommerce/_index.md
@@ -38,11 +38,9 @@ generated_summary_faq:
     You'll learn how to migrate a .NET nopCommerce application to an
     Arm-based virtual machine powered by Azure Cobalt 100, create a reproducible baseline, and apply
     measured runtime tuning. First, you'll pin a specific nopCommerce release, verify a clean build,
-    and capture an endpoint baseline on Arm to control for drift. By running dependency discovery and generating SBOM, you'll surface direct, transitive, and native payloads early to reduce surprises during
-    deployment. You'll compare and choose a containerization path between a Dockerfile workflow, and a .NET
+    and capture an endpoint baseline on Arm to control for drift. By running dependency discovery and generating SBOM, you'll surface direct, transitive, and native payloads. You'll compare and choose a containerization path between a Dockerfile workflow and a .NET
     SDK publish with multi-architecture delivery guardrails. Finally, you'll apply
-    architecture-conditional runtime settings and validate them against fixed workloads so you
-    can keep or discard changes based on repeatable results.
+    architecture-conditional runtime settings and validate them against fixed workloads.
   faqs:
   - question: How should I choose the Azure VM configuration for the baseline?
     answer: >-

--- a/content/learning-paths/servers-and-cloud-computing/dotnet-migration/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/dotnet-migration/_index.md
@@ -13,7 +13,7 @@ learning_objectives:
     - Evaluate the performance of different .NET versions
 
 prerequisites:
-    - A Microsoft Azure account with permissions to deploy virtual machines
+    - A Microsoft Azure account with permissions to deploy virtual machines (VMs)
     - .NET SDK 8.0 or later 
     - Basic knowledge of C and C#
     - GCC installed (Linux) or access to a cross-compiler
@@ -34,14 +34,13 @@ generated_summary_faq:
   faq_generated_at: '2026-07-27T18:52:59Z'
   faq_source_hash: 08d8f0c86625ef41476d3a8b24bad9b0a0820797022ef847bf9bb17a976726a7
   summary: >-
-    You'll migrate a .NET OrchardCore CMS application to an Azure Cobalt 100 Arm-based virtual
-    machine. You'll provision Ubuntu 24.04, build and run the application, add a native C component
+    You'll migrate a .NET OrchardCore CMS application to an Azure Cobalt 100 Arm-based VM. You'll provision Ubuntu 24.04, build and run the application, add a native C component
     that C# calls through `DllImport`, and configure an architecture-agnostic `AnyCPU` build for Arm
     and x86. You'll then review .NET version choices and confirm the expected native output.
   faqs:
   - question: Which network port should I open to reach the OrchardCore app on the VM?
     answer: >-
-      Open port 8080 to the internet as part of the VM setup. After starting the app, connect
+      Open port `8080` to the internet as part of the VM setup. After starting the app, connect
       to the VM’s public IP on port 8080.
   - question: What artifact should I get when I compile the C code into a shared library?
     answer: >-
@@ -55,10 +54,10 @@ generated_summary_faq:
     answer: >-
       Use .NET’s `AnyCPU` configuration. It provides an architecture-agnostic managed build that
       runs on both architectures.
-  - question: Which .NET versions does this path highlight for support status on Arm?
+  - question: What .NET versions should I keep track of?
     answer: >-
-      .NET 8 (current LTS, support until Nov 2026), .NET 9 (STS, support until Nov 2026), and
-      .NET 10 (next LTS, preview). These versions frame the version-by-version discussion.
+      .NET 8 is the current Long-Term Support (LTS) version until Nov 2026, .NET 9 is the Short-Term Support (STS) version until Nov 2026, and
+      .NET 10 is the next LTS in preview. .NET versions 3.1, 5, 6, and 7 have reached End-of-Life (EOL).
 # END generated_summary_faq
 
 author: Joe Stech

--- a/content/learning-paths/servers-and-cloud-computing/dotnet-migration/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/dotnet-migration/_index.md
@@ -19,9 +19,51 @@ prerequisites:
     - GCC installed (Linux) or access to a cross-compiler
     - OrchardCore application created using the .NET CLI or Visual Studio
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:52:59Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 08d8f0c86625ef41476d3a8b24bad9b0a0820797022ef847bf9bb17a976726a7
+  summary_generated_at: '2026-07-27T18:52:59Z'
+  summary_source_hash: 08d8f0c86625ef41476d3a8b24bad9b0a0820797022ef847bf9bb17a976726a7
+  faq_generated_at: '2026-07-27T18:52:59Z'
+  faq_source_hash: 08d8f0c86625ef41476d3a8b24bad9b0a0820797022ef847bf9bb17a976726a7
+  summary: >-
+    You'll migrate a .NET OrchardCore CMS application to an Azure Cobalt 100 Arm-based virtual
+    machine. You'll provision Ubuntu 24.04, build and run the application, add a native C component
+    that C# calls through `DllImport`, and configure an architecture-agnostic `AnyCPU` build for Arm
+    and x86. You'll then review .NET version choices and confirm the expected native output.
+  faqs:
+  - question: Which network port should I open to reach the OrchardCore app on the VM?
+    answer: >-
+      Open port 8080 to the internet as part of the VM setup. After starting the app, connect
+      to the VM’s public IP on port 8080.
+  - question: What artifact should I get when I compile the C code into a shared library?
+    answer: >-
+      The `gcc` command produces a shared object named `libmylib.so`. This is the library the C# code
+      will load.
+  - question: How do I verify the C library call worked from C#?
+    answer: >-
+      Call the function via `DllImport` and check the application’s console output for `Hello from
+      the C library!`. Seeing that line confirms that the native call executed.
+  - question: Which build option should I use so the same build runs on both Arm and x86?
+    answer: >-
+      Use .NET’s `AnyCPU` configuration. It provides an architecture-agnostic managed build that
+      runs on both architectures.
+  - question: Which .NET versions does this path highlight for support status on Arm?
+    answer: >-
+      .NET 8 (current LTS, support until Nov 2026), .NET 9 (STS, support until Nov 2026), and
+      .NET 10 (next LTS, preview). These versions frame the version-by-version discussion.
+# END generated_summary_faq
+
 author: Joe Stech
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -59,4 +101,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/dynatrace-azure/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/dynatrace-azure/_index.md
@@ -7,7 +7,7 @@ minutes_to_complete: 30
 who_is_this_for: This is an introductory topic for developers, DevOps engineers, and platform engineers who want to implement infrastructure and application monitoring using Dynatrace on Arm-based cloud environments.
 
 learning_objectives:
-    - Deploy Dynatrace OneAgent on Azure Cobalt 100 Arm64 virtual machines
+    - Deploy Dynatrace OneAgent on Azure Cobalt 100-based Arm64 virtual machines (VMs)
     - Configure Dynatrace ActiveGate for secure monitoring communication
     - Monitor system resources, processes, and services using Dynatrace
     - Validate application monitoring using a sample NGINX workload
@@ -33,7 +33,7 @@ generated_summary_faq:
   faq_generated_at: '2026-07-27T18:53:34Z'
   faq_source_hash: 4ef29931bf19dc95bb586440796381725c271ef1b953dcf46d00ad9617eabbb1
   summary: >-
-    You'll deploy Dynatrace OneAgent on an Azure Cobalt 100 Arm64 virtual machine and configure
+    You'll deploy Dynatrace OneAgent on an Azure Cobalt 100-based Arm64 virtual machine and configure
     Dynatrace ActiveGate for secure communication with Dynatrace SaaS. You'll provision a Dpsv6 VM,
     allow TCP port 9999 in its Network Security Group, install both components on Ubuntu 24.04 LTS,
     and validate monitoring with a sample NGINX workload. By the end, you'll have host-level visibility
@@ -45,8 +45,7 @@ generated_summary_faq:
       Choose the method that best fits your workflow.
   - question: Which Azure VM series should I select for this walkthrough?
     answer: >-
-      Use a general-purpose Dpsv6 series virtual machine based on Azure Cobalt 100. The steps
-      focus on that series.
+      Use a general-purpose Dpsv6 series VM based on Azure Cobalt 100. 
   - question: Which Linux image and architecture do I need for installing OneAgent and ActiveGate?
     answer: >-
       Use Ubuntu 24.04 LTS Arm64. Both Dynatrace OneAgent and ActiveGate operate natively on Arm64

--- a/content/learning-paths/servers-and-cloud-computing/dynatrace-azure/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/dynatrace-azure/_index.md
@@ -18,9 +18,53 @@ prerequisites:
   - Familiarity with SSH and remote server access
   - Basic understanding of cloud infrastructure and monitoring concepts
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:53:34Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 4ef29931bf19dc95bb586440796381725c271ef1b953dcf46d00ad9617eabbb1
+  summary_generated_at: '2026-07-27T18:53:34Z'
+  summary_source_hash: 4ef29931bf19dc95bb586440796381725c271ef1b953dcf46d00ad9617eabbb1
+  faq_generated_at: '2026-07-27T18:53:34Z'
+  faq_source_hash: 4ef29931bf19dc95bb586440796381725c271ef1b953dcf46d00ad9617eabbb1
+  summary: >-
+    You'll deploy Dynatrace OneAgent on an Azure Cobalt 100 Arm64 virtual machine and configure
+    Dynatrace ActiveGate for secure communication with Dynatrace SaaS. You'll provision a Dpsv6 VM,
+    allow TCP port 9999 in its Network Security Group, install both components on Ubuntu 24.04 LTS,
+    and validate monitoring with a sample NGINX workload. By the end, you'll have host-level visibility
+    and a route for Dynatrace communication through ActiveGate.
+  faqs:
+  - question: Can I create the Cobalt 100 VM with the CLI or IaC instead of the Azure Portal?
+    answer: >-
+      Yes. There are several ways to create a Cobalt 100 VM, but this path uses the Azure Portal.
+      Choose the method that best fits your workflow.
+  - question: Which Azure VM series should I select for this walkthrough?
+    answer: >-
+      Use a general-purpose Dpsv6 series virtual machine based on Azure Cobalt 100. The steps
+      focus on that series.
+  - question: Which Linux image and architecture do I need for installing OneAgent and ActiveGate?
+    answer: >-
+      Use Ubuntu 24.04 LTS Arm64. Both Dynatrace OneAgent and ActiveGate operate natively on Arm64
+      (aarch64).
+  - question: Do I need to open any ports for ActiveGate, and where do I configure it?
+    answer: >-
+      Yes. Open TCP port 9999 in the Azure Network Security Group attached to the VM’s network
+      interface or subnet to allow Dynatrace communication to ActiveGate.
+  - question: How do I confirm that monitoring works, including the sample NGINX workload?
+    answer: >-
+      After installation, OneAgent connects to your Dynatrace SaaS environment and starts monitoring
+      system processes and services. Deploy the sample NGINX workload and check that NGINX appears
+      among the monitored processes and system metrics update.
+# END generated_summary_faq
+
 author: Pareena Verma
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -65,4 +109,3 @@ weight: 1
 layout: "learningpathall"
 learning_path_main_page: "yes"
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/ecs/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/ecs/_index.md
@@ -15,9 +15,53 @@ prerequisites:
     - An AWS account
     - A computer with Docker, AWS CLI, and Terraform installed
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:54:28Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: ef5f9e7c8844b20b9044b43f4758bc1d74374521093d7738a7f8832d21f1dcac
+  summary_generated_at: '2026-07-27T18:54:28Z'
+  summary_source_hash: ef5f9e7c8844b20b9044b43f4758bc1d74374521093d7738a7f8832d21f1dcac
+  faq_generated_at: '2026-07-27T18:54:28Z'
+  faq_source_hash: ef5f9e7c8844b20b9044b43f4758bc1d74374521093d7738a7f8832d21f1dcac
+  summary: >-
+    You'll deploy a containerized application on Amazon Elastic Container Service (ECS) with AWS
+    Fargate and Graviton processors. You'll create an ECS cluster and task, run it on Arm-based
+    infrastructure without managing EC2 instances, and then automate the workflow with Terraform.
+    The Terraform configuration creates an Amazon Elastic Container Registry (ECR) repository and
+    deploys an Nginx task to ECS on Graviton.
+  faqs:
+  - question: Do I need to provision EC2 instances for this deployment?
+    answer: >-
+      No. Fargate is a serverless option for ECS, so you do not provision or maintain EC2 instances;
+      the tasks run on Fargate.
+  - question: What result should I expect after I create and run the ECS task?
+    answer: >-
+      The task should start on the Fargate cluster and show a running status in ECS. That confirms
+      the container runs on AWS Graviton-backed infrastructure.
+  - question: Where do the container images live in this workflow?
+    answer: >-
+      You create an Amazon Elastic Container Registry (ECR) repository and use it as the source
+      for images referenced by your ECS task. This lets ECS pull the image when the task starts.
+  - question: What does the Terraform configuration in `main.tf` create?
+    answer: >-
+      It automates the same deployment steps by defining AWS resources such as an ECR repository
+      and ECS components to run an Nginx task on Fargate with AWS Graviton processors.
+  - question: What should I check if my ECS task stays in PENDING or fails to run?
+    answer: >-
+      Verify that the cluster and task definition target the Fargate launch type and that required
+      AWS resources and permissions from earlier steps exist. Also check that the container image
+      is available in the ECR repository you created.
+# END generated_summary_faq
+
 author: Jason Andrews
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -51,4 +95,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # Indicates this should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/ecs/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/ecs/_index.md
@@ -1,14 +1,14 @@
 ---
-title: "Deploy containers on Amazon ECS with AWS Graviton processors"
-description: Learn how to create an AWS ECS cluster with Fargate and AWS Graviton processors, then create and run containerized tasks on Arm infrastructure.
+title: Deploy containers on Amazon ECS with AWS Graviton processors
+description: Learn how to create an Amazon ECS cluster with Fargate and AWS Graviton processors, then create and run containerized tasks on Arm infrastructure.
 
 minutes_to_complete: 60
 
 who_is_this_for: This is an introductory topic for developers who want to use AWS Graviton processors with Amazon Elastic Container Service (ECS).
 
 learning_objectives:
-    - Create an AWS ECS cluster with Fargate and AWS Graviton processors
-    - Create and run an AWS ECS task
+    - Create an Amazon ECS cluster with Fargate and AWS Graviton processors
+    - Create and run an Amazon ECS task
     - Use Terraform to automate deployment of an ECS cluster
 
 prerequisites:
@@ -30,28 +30,27 @@ generated_summary_faq:
   faq_generated_at: '2026-07-27T18:54:28Z'
   faq_source_hash: ef5f9e7c8844b20b9044b43f4758bc1d74374521093d7738a7f8832d21f1dcac
   summary: >-
-    You'll deploy a containerized application on Amazon Elastic Container Service (ECS) with AWS
+    You'll deploy a containerized application on Amazon ECS with AWS
     Fargate and Graviton processors. You'll create an ECS cluster and task, run it on Arm-based
-    infrastructure without managing EC2 instances, and then automate the workflow with Terraform.
+    AWS Fargate infrastructure, and then automate the workflow with Terraform.
     The Terraform configuration creates an Amazon Elastic Container Registry (ECR) repository and
-    deploys an Nginx task to ECS on Graviton.
+    deploys an NGINX task to ECS on Graviton.
   faqs:
-  - question: Do I need to provision EC2 instances for this deployment?
+  - question: Do I need to manually provision EC2 instances for this deployment?
     answer: >-
-      No. Fargate is a serverless option for ECS, so you do not provision or maintain EC2 instances;
-      the tasks run on Fargate.
+      No. Fargate is a serverless option for ECS, so you don't manually provision or maintain EC2 instances.
   - question: What result should I expect after I create and run the ECS task?
     answer: >-
       The task should start on the Fargate cluster and show a running status in ECS. That confirms
       the container runs on AWS Graviton-backed infrastructure.
-  - question: Where do the container images live in this workflow?
+  - question: What is the source for container images in this workflow?
     answer: >-
-      You create an Amazon Elastic Container Registry (ECR) repository and use it as the source
+      Create an Amazon ECR repository and use it as the source
       for images referenced by your ECS task. This lets ECS pull the image when the task starts.
   - question: What does the Terraform configuration in `main.tf` create?
     answer: >-
       It automates the same deployment steps by defining AWS resources such as an ECR repository
-      and ECS components to run an Nginx task on Fargate with AWS Graviton processors.
+      and ECS components to run an NGINX task on Fargate with AWS Graviton processors.
   - question: What should I check if my ECS task stays in PENDING or fails to run?
     answer: >-
       Verify that the cluster and task definition target the Fargate launch type and that required

--- a/content/learning-paths/servers-and-cloud-computing/ecs/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/ecs/_index.md
@@ -75,7 +75,7 @@ operatingsystems:
     - Linux
 tools_software_languages:
     - Terraform
-    - AWS Elastic Container Service (ECS)
+    - Amazon Elastic Container Service (ECS)
 
 # ================================================================================
 #       FIXED, DO NOT MODIFY

--- a/content/learning-paths/servers-and-cloud-computing/ecs/terraform.md
+++ b/content/learning-paths/servers-and-cloud-computing/ecs/terraform.md
@@ -13,7 +13,7 @@ You can also automate the deployment of containerized applications on AWS ECS wi
 
 This section incrementally constructs a Terraform file named `main.tf` to automate the same steps for deployment of Nginx on ECS.
 
-## Create a repository in AWS ECS for container images
+## Create a repository in Amazon ECR for container images
 
 ECR is an AWS service for sharing and deploying container applications. 
 
@@ -140,7 +140,7 @@ Push the container image to the new repository using `docker push` as in the pre
 docker push [your account number].dkr.ecr.us-east-2.amazonaws.com/myapp
 ```
 
-Refresh the repository's page to verify you’ve successfully pushed the image to the AWS ECR repository.
+Refresh the repository's page to verify you’ve successfully pushed the image to the Amazon ECR repository.
 
 ![ecs34 #center](./images/ecs34.png)
 
@@ -173,7 +173,7 @@ Navigate to Amazon ECS Clusters and verify that you can see the changes:
 
 ![ecs35 #center](./images/ecs35.png)
 
-## Configure an AWS ECS task 
+## Configure an Amazon ECS task 
 
 To run the image, you can launch it as an ECS container.
 
@@ -185,8 +185,6 @@ These specifications include:
 * Application image
 * CPU and RAM resources
 * Container launch types such as EC2 or Fargate
-
-An AWS ECS workload has two main launch types: EC2 and Fargate.
 
 Fargate is an AWS orchestration tool. It allows you to give AWS the role of managing your container life cycle and the hosting infrastructure. Fargate is serverless, which means you don’t need to provision your container using EC2 instances (virtual machines). 
 

--- a/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_index.md
@@ -74,7 +74,7 @@ armips:
     - Neoverse
 tools_software_languages:
     - Kubernetes
-    - AWS Elastic Kubernetes Service (EKS)
+    - Amazon Elastic Kubernetes Service (EKS)
 operatingsystems:
     - Linux
 

--- a/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_index.md
@@ -16,9 +16,52 @@ prerequisites:
     - A computer with [Amazon eksctl CLI](/install-guides/eksctl) and [kubectl](/install-guides/kubectl/)installed.
     - Docker installed on local computer [Docker](/install-guides/docker)
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-27T18:55:08Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: e32bdb090c422d1fb5bb1f9bd3af56c55fdf8989e6a7fe6a101e90dcb6f3eadd
+  summary_generated_at: '2026-07-27T18:55:08Z'
+  summary_source_hash: e32bdb090c422d1fb5bb1f9bd3af56c55fdf8989e6a7fe6a101e90dcb6f3eadd
+  faq_generated_at: '2026-07-27T18:55:08Z'
+  faq_source_hash: e32bdb090c422d1fb5bb1f9bd3af56c55fdf8989e6a7fe6a101e90dcb6f3eadd
+  summary: >-
+    You'll build `amd64` and `arm64` container images with Docker Buildx, publish a multi-architecture
+    manifest, and deploy it to a hybrid Amazon EKS cluster. You'll configure Arm-based Graviton and
+    x86 nodes, publish both variants under one image tag, and verify that Kubernetes selects the right
+    image for each node. By the end, one deployment will run across both architectures in the cluster.
+  faqs:
+  - question: Which platforms should I target when I build the images?
+    answer: >-
+      Build two variants: `amd64` for x86 and `arm64` for Arm-based (Graviton) nodes. These two images
+      form the basis for your multi-architecture manifest.
+  - question: When should I create the Docker manifest, and what should it include?
+    answer: >-
+      Create the manifest after you build the per-architecture images. It should reference both
+      the `amd64` and `arm64` images under a single tag.
+  - question: How do I know if my EKS cluster has both Arm and x86 nodes before I deploy?
+    answer: >-
+      Confirm that the cluster includes `arm64` and `amd64` node groups. Use `kubectl` to inspect
+      node details and verify that both architectures are present.
+  - question: What result should I expect when I deploy the multi-arch image to the cluster?
+    answer: >-
+      Kubernetes schedules pods onto either node type, and each node pulls the correct image variant
+      from the multi-arch tag. You should see the same application running across both architectures.
+  - question: What should I check if my workload only runs on one architecture?
+    answer: >-
+      Verify that the cluster includes both `arm64` and `amd64` nodes and that your manifest lists
+      both image variants. Also check that your deployment uses the multi-architecture image tag, not
+      an architecture-specific one.
+# END generated_summary_faq
+
 author: Pranay Bakre
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 
@@ -51,4 +94,3 @@ weight: 1                       # _index.md always has weight of 1 to order corr
 layout: "learningpathall"       # All files under learning paths have this same wrapper
 learning_path_main_page: "yes"  # This should be surfaced when looking for related content. Only set for _index.md of learning path content.
 ---
-

--- a/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks-multi-arch/_index.md
@@ -4,7 +4,7 @@ description: Learn how to use docker buildx and docker manifest to build and dep
 
 minutes_to_complete: 60
 
-who_is_this_for: This is an advanced topic for software developers who want to understand how to build and deploy a multi-architecture application with x86/amd64 and arm64-based container images on Amazon EKS
+who_is_this_for: This is an advanced topic for software developers who want to understand how to build and deploy a multi-architecture application with x86/amd64 and arm64-based container images on Amazon Elastic Kubernetes Service (EKS).
 
 learning_objectives: 
     - Build x86/amd64 and arm64 container images with docker buildx and docker manifest
@@ -38,7 +38,7 @@ generated_summary_faq:
   faqs:
   - question: Which platforms should I target when I build the images?
     answer: >-
-      Build two variants: `amd64` for x86 and `arm64` for Arm-based (Graviton) nodes. These two images
+      Build two variants: `amd64` for x86 and `arm64` for Arm-based nodes powered by Graviton. These two images
       form the basis for your multi-architecture manifest.
   - question: When should I create the Docker manifest, and what should it include?
     answer: >-

--- a/content/learning-paths/servers-and-cloud-computing/eks/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Deploy WordPress with MySQL on Elastic Kubernetes Service (EKS)"
+title: Deploy WordPress with MySQL on Arm-based instances using Amazon EKS
 description: Learn how to provision an Amazon EKS cluster on Arm-based Graviton instances and deploy a WordPress application with MySQL database.
 
 minutes_to_complete: 60
@@ -33,8 +33,8 @@ generated_summary_faq:
   faqs:
   - question: Can I use any machine to complete the steps?
     answer: >-
-      Yes. You can use any desktop, laptop, or virtual machine that has the AWS CLI, EKS CLI,
-      and Kubernetes CLI installed and working.
+      Yes. You can use any desktop, laptop, or virtual machine that has the AWS CLI, `eksctl`,
+      and `kubectl` installed and working.
   - question: How do I confirm the CLIs and my AWS credentials are ready?
     answer: >-
       Make sure you can run the `aws`, `eksctl`, and `kubectl` commands. Configure your AWS access key

--- a/content/learning-paths/servers-and-cloud-computing/eks/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks/_index.md
@@ -14,9 +14,49 @@ learning_objectives:
 prerequisites:
     - An Amazon Web Services (AWS) [account](https://aws.amazon.com/)
 
+# START generated_summary_faq
+generated_summary_faq:
+  template_version: summary-faq-v3
+  generated_at: '2026-07-28T15:05:40Z'
+  generator: ai
+  ai_assisted: true
+  ai_review_required: true
+  model: gpt-5
+  prompt_template: summary-faq-v3
+  source_hash: 6a3058af47e4fe4890928a8e2505a7833a0e1936977e092d3036bdbead2ce680
+  summary_generated_at: '2026-07-28T15:05:40Z'
+  summary_source_hash: 6a3058af47e4fe4890928a8e2505a7833a0e1936977e092d3036bdbead2ce680
+  faq_generated_at: '2026-07-28T15:05:40Z'
+  faq_source_hash: 6a3058af47e4fe4890928a8e2505a7833a0e1936977e092d3036bdbead2ce680
+  summary: >-
+   You’ll provision an Amazon EKS cluster on AWS Graviton instances and deploy WordPress with MySQL. You’ll validate access to the AWS CLI, `eksctl`, and `kubectl`, configure AWS credentials, and create Kubernetes manifests for the database and application. You’ll apply the manifests with `kubectl`, confirm that the workloads run, and finish with a basic, auditable WordPress deployment on EKS.
+  faqs:
+  - question: Can I use any machine to complete the steps?
+    answer: >-
+      Yes. You can use any desktop, laptop, or virtual machine that has the AWS CLI, EKS CLI,
+      and Kubernetes CLI installed and working.
+  - question: How do I confirm the CLIs and my AWS credentials are ready?
+    answer: >-
+      Make sure you can run the `aws`, `eksctl`, and `kubectl` commands. Configure your AWS access key
+      ID and secret access key so programmatic requests succeed.
+  - question: Which YAML files do I need to deploy WordPress and what do they do?
+    answer: >-
+      Create `kustomization.yaml`, `mysql-deployment.yaml`, and `wordpress-deployment.yaml`. The `kustomization.yaml`
+      sets the MySQL password and selects the two deployment files as resources.
+  - question: How do I set the MySQL database password for the deployment?
+    answer: >-
+      Edit `kustomization.yaml` and set the `secretGenerator` literal password to your chosen value
+      (`password=YourPassword`). This creates a Kubernetes Secret named `mysql-pass`.
+  - question: What should I look for after applying the manifests?
+    answer: >-
+      Expect Kubernetes to create a Secret for the MySQL password and start the WordPress and
+      MySQL workloads. Use `kubectl` to check that the WordPress and MySQL workloads appear and transition to a running
+      state.
+# END generated_summary_faq
+
 author: Jason Andrews
 
-generate_summary_faq: true
+generate_summary_faq: false
 rerun_summary: false
 rerun_faqs: false
 

--- a/content/learning-paths/servers-and-cloud-computing/eks/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/eks/_index.md
@@ -30,7 +30,7 @@ armips:
 operatingsystems:
     - Linux
 tools_software_languages:
-    - AWS Elastic Kubernetes Service (EKS)
+    - Amazon Elastic Kubernetes Service (EKS)
     - Kubernetes
     - SQL
     - MySQL


### PR DESCRIPTION
Continuing the series of adding summaries and faqs to existing LPs. Adding to LPs alphabetically from codebuild to eks-multi-arch. Tweaked a couple references to EKS and ECS in the EKS and ECS LPs

Also updated the style skill to include a callout for the use of slashes (/) in an effort to establish a bit more parity with the Arm tech writing style wherever it makes sense. We should avoid using slashes unless they're part of a technical term or name. Identified some LPs worth refactoring, but that'll be a separate PR at some point 

Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [ ] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [ ] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
