### PR TITLE
Remove `topo --help` CLI output

### DIFF
--- a/content/learning-paths/cross-platform/deploy-containerized-workloads-with-topo/overview-and-setup.md
+++ b/content/learning-paths/cross-platform/deploy-containerized-workloads-with-topo/overview-and-setup.md
@@ -51,38 +51,7 @@ Run the following command in the terminal on your host device to confirm the ins
 topo --help
 ```
 
-The output confirms that Topo is present and describes the available commands:
-
-```output
-Topo CLI
-
-Usage:
-  topo [command]
-
-Available Commands:
-  clone       Clone a Project
-  completion  Generate the autocompletion script for the specified shell
-  configure   Configure project parameters
-  deploy      Deploy services using the compose file
-  extend      Add services from a Topo Project to the compose file
-  health      Check the target environment
-  help        Help about any command
-  init        Initialise a new project in the current directory
-  install     Install components to the target
-  projects    List available Topo Projects
-  ps          List containers on the target for the current Compose project.
-  service     Manage services in compose files
-  setup-keys  Generate SSH keys for the target and install the public key on the target
-  stop        Stop a currently running deployment
-  upgrade     Upgrade topo to the latest version
-
-Flags:
-  -h, --help            help for topo
-  -o, --output string   output format: plain or json (default "plain")
-  -v, --version         version for topo
-
-Use "topo [command] --help" for more information about a command.
-```
+If Topo is installed, the command displays the available commands and options.
 
 ## What you've accomplished and what's next
 


### PR DESCRIPTION
Topo is in the midst of making a handful of breaking changes to remove a few commands:
- `topo extend` (https://github.com/arm/topo/pull/382)
- `topo service` and `topo service remove` (https://github.com/arm/topo/pull/384)
- `topo init` (https://github.com/arm/topo/pull/383)

This change removes the hard-coded CLI output from `topo --help` from the relevant learning path to avoid content drift and describes only what is necessary.

---

Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
