### PR TITLE
Update URL for OpenRNG

### DIFF
--- a/content/learning-paths/servers-and-cloud-computing/openrng-with-performix/_index.md
+++ b/content/learning-paths/servers-and-cloud-computing/openrng-with-performix/_index.md
@@ -39,7 +39,7 @@ operatingsystems:
 further_reading:
     - resource:
         title: OpenRNG project repository
-        link: https://gitlab.arm.com/libraries/openrng
+        link: https://github.com/arm/openrng
         type: documentation
     - resource:
         title: Find code hotspots with Arm Performix

--- a/content/learning-paths/servers-and-cloud-computing/openrng-with-performix/how-to-4.md
+++ b/content/learning-paths/servers-and-cloud-computing/openrng-with-performix/how-to-4.md
@@ -92,7 +92,7 @@ To fix this, rebuild OpenRNG from source with debug information enabled (for exa
 Clone and build OpenRNG from the project root with debug symbols enabled:
 
 ```bash
-git clone https://gitlab.arm.com/libraries/openrng.git && cd openrng
+git clone https://github.com/arm/openrng.git && cd openrng
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$PWD/install
 cmake --build build -j $(nproc -1)
 cmake --install build


### PR DESCRIPTION
This repository has been moved to Github, so update the URLs to match.