### PR TITLE
Add optional VGF debug information to mobile-graphics-and-gaming guides

### DIFF
--- a/content/learning-paths/mobile-graphics-and-gaming/preparing-models-for-nt/3-convert-to-vgf-and-validate.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/preparing-models-for-nt/3-convert-to-vgf-and-validate.md
@@ -14,6 +14,8 @@ This is the path to use first because it matches the model preparation workflow 
 
 ## Lower directly with the ExecuTorch VGF backend
 
+The example enables two optional debug settings. The `--emit-debug-info` Model Converter flag embeds ExecuTorch stack traces and module metadata in the VGF, while `dump_debug_info(VgfCompileSpec.DebugMode.TOSA)` preserves the corresponding TOSA debug information during lowering. You can omit both settings when you don't need debug information.
+
 Create a Python file named `export_vgf.py`:
 
 ```python
@@ -32,8 +34,9 @@ os.makedirs("executorch-model", exist_ok=True)
 
 exported_model = torch.export.load("add_sigmoid.pt2")
 
-compile_spec = VgfCompileSpec()
+compile_spec = VgfCompileSpec(compiler_flags=["--emit-debug-info"])
 compile_spec.dump_intermediate_artifacts_to("executorch-model")
+compile_spec.dump_debug_info(VgfCompileSpec.DebugMode.TOSA)
 partitioner = VgfPartitioner(compile_spec)
 
 edge_pm = to_edge_transform_and_lower(

--- a/content/learning-paths/mobile-graphics-and-gaming/preparing-models-for-nt/prepare-models-for-nt.ipynb
+++ b/content/learning-paths/mobile-graphics-and-gaming/preparing-models-for-nt/prepare-models-for-nt.ipynb
@@ -70,7 +70,9 @@
         "\n",
         "VGF is the file format used by Arm neural technology with ML Extensions for Vulkan. Through ExecuTorch, you can lower directly from a PyTorch model to a VGF model using the direct VGF backend path first. \n",
         "\n",
-        "An important note is that TOSA inspection is available later as an optional debugging step to view operations of your model. \n"
+        "An important note is that TOSA inspection is available later as an optional debugging step to view operations of your model. \n",
+        "\n",
+        "The example enables two optional debug settings. The `--emit-debug-info` Model Converter flag embeds ExecuTorch stack traces and module metadata in the VGF, while `dump_debug_info(VgfCompileSpec.DebugMode.TOSA)` preserves the corresponding TOSA debug information during lowering. You can omit both settings when you don't need debug information.\n"
       ]
     },
     {
@@ -95,8 +97,9 @@
         "exported_model = torch.export.load(\"add_sigmoid.pt2\")\n",
         "\n",
         "# VGF lowering\n",
-        "compile_spec = VgfCompileSpec()    \n",
-        "compile_spec.dump_intermediate_artifacts_to(\"executorch-model\")   # default FP compile spec\n",
+        "compile_spec = VgfCompileSpec(compiler_flags=[\"--emit-debug-info\"])\n",
+        "compile_spec.dump_intermediate_artifacts_to(\"executorch-model\")\n",
+        "compile_spec.dump_debug_info(VgfCompileSpec.DebugMode.TOSA)\n",
         "partitioner = VgfPartitioner(compile_spec)\n",
         "\n",
         "edge_pm = to_edge_transform_and_lower(\n",

--- a/content/learning-paths/mobile-graphics-and-gaming/quantize-neural-upscaling-models/3-run-ptq-and-export-vgf.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/quantize-neural-upscaling-models/3-run-ptq-and-export-vgf.md
@@ -21,6 +21,8 @@ Create a file called `quantize_and_export_vgf.py` and add the following code.
 
 This example uses CIFAR-10 as a convenient image source. It constructs a low-resolution input by downsampling an image, then trains the model to reconstruct the original image. This is a practical proxy for a real neural upscaler.
 
+The export also enables two optional debug settings. The `--emit-debug-info` Model Converter flag embeds ExecuTorch stack traces and module metadata in the VGF, while `dump_debug_info(VgfCompileSpec.DebugMode.TOSA)` preserves the corresponding TOSA debug information during lowering. You can omit both settings when you don't need debug information.
+
 ```python
 import torch
 from torch.utils.data import DataLoader
@@ -207,9 +209,13 @@ def ptq_example(device="cpu"):
     )
 
     # 8) Partition and dump a `.vgf` artifact.
-    compile_spec = VgfCompileSpec(TosaSpecification.create_from_string(tosa_spec))
+    compile_spec = VgfCompileSpec(
+        TosaSpecification.create_from_string(tosa_spec),
+        compiler_flags=["--emit-debug-info"],
+    )
     vgf_partitioner = VgfPartitioner(
         compile_spec.dump_intermediate_artifacts_to("./output/")
+        .dump_debug_info(VgfCompileSpec.DebugMode.TOSA)
     )
 
     to_edge_transform_and_lower(aten_dialect, partitioner=[vgf_partitioner])
@@ -290,8 +296,14 @@ def export_vgf_int8_ptq(
     q = convert_pt2e(q)
     aten_dialect = torch.export.export(q, args=example_input, strict=True)
 
-    compile_spec = VgfCompileSpec(TosaSpecification.create_from_string(tosa_spec))
-    vgf_partitioner = VgfPartitioner(compile_spec.dump_intermediate_artifacts_to(output_dir))
+    compile_spec = VgfCompileSpec(
+        TosaSpecification.create_from_string(tosa_spec),
+        compiler_flags=["--emit-debug-info"],
+    )
+    vgf_partitioner = VgfPartitioner(
+        compile_spec.dump_intermediate_artifacts_to(output_dir)
+        .dump_debug_info(VgfCompileSpec.DebugMode.TOSA)
+    )
     to_edge_transform_and_lower(aten_dialect, partitioner=[vgf_partitioner])
 ```
 

--- a/content/learning-paths/mobile-graphics-and-gaming/quantize-neural-upscaling-models/4-run-qat-and-export-vgf.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/quantize-neural-upscaling-models/4-run-qat-and-export-vgf.md
@@ -29,6 +29,8 @@ from torchao.quantization.pt2e import (
 
 Then add the QAT training function and example entry point. This code prepares the exported model for QAT, fine-tunes for a small number of epochs, converts to INT8, and exports to `.vgf`.
 
+The export also enables two optional debug settings. The `--emit-debug-info` Model Converter flag embeds ExecuTorch stack traces and module metadata in the VGF, while `dump_debug_info(VgfCompileSpec.DebugMode.TOSA)` preserves the corresponding TOSA debug information during lowering. You can omit both settings when you don't need debug information.
+
 ```python
 def train_model_qat(
     model: nn.Module,
@@ -109,9 +111,13 @@ def qat_example(device="cpu"):
     )
 
     # 8) Partition and dump a `.vgf` artifact.
-    compile_spec = VgfCompileSpec(TosaSpecification.create_from_string(tosa_spec))
+    compile_spec = VgfCompileSpec(
+        TosaSpecification.create_from_string(tosa_spec),
+        compiler_flags=["--emit-debug-info"],
+    )
     vgf_partitioner = VgfPartitioner(
         compile_spec.dump_intermediate_artifacts_to("./output_qat/")
+        .dump_debug_info(VgfCompileSpec.DebugMode.TOSA)
     )
 
     to_edge_transform_and_lower(aten_dialect, partitioner=[vgf_partitioner])
@@ -183,8 +189,14 @@ def export_vgf_int8_qat(
     q = convert_pt2e(qat_ready)
     aten_dialect = torch.export.export(q, args=example_input, strict=True)
 
-    compile_spec = VgfCompileSpec(TosaSpecification.create_from_string(tosa_spec))
-    vgf_partitioner = VgfPartitioner(compile_spec.dump_intermediate_artifacts_to(output_dir))
+    compile_spec = VgfCompileSpec(
+        TosaSpecification.create_from_string(tosa_spec),
+        compiler_flags=["--emit-debug-info"],
+    )
+    vgf_partitioner = VgfPartitioner(
+        compile_spec.dump_intermediate_artifacts_to(output_dir)
+        .dump_debug_info(VgfCompileSpec.DebugMode.TOSA)
+    )
     to_edge_transform_and_lower(aten_dialect, partitioner=[vgf_partitioner])
 ```
 


### PR DESCRIPTION
Document and enable optional Model Converter debug metadata and TOSA debug-information preservation across the VGF export examples.


Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/)
- [x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information. 

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
