### PR TITLE
Updated ROS 2 LP1 based on review feedback

### DIFF
--- a/content/learning-paths/cross-platform/ros2-zenoh-arm/control-robot.md
+++ b/content/learning-paths/cross-platform/ros2-zenoh-arm/control-robot.md
@@ -32,13 +32,19 @@ Use the key bindings displayed in the terminal to drive the robot while you obse
 
 ## Publish a velocity command
 
-You can also publish a single command that sets the forward velocity to `0.2 m/s`:
+You can also publish forward velocity at `0.2 m/s` and a fixed rate of 10 Hz:
 
 ```bash
-ros2 topic pub --once /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.2}}"
+ros2 topic pub --rate 10 /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.2}}"
 ```
 
-The command uses the same `/cmd_vel` interface as teleoperation and Navigation2.
+Let the command run for approximately three seconds, then press `Ctrl+C` to stop the publisher. Explicitly stop the robot by publishing a zero-velocity command:
+
+```bash
+ros2 topic pub --once /cmd_vel geometry_msgs/msg/Twist "{}"
+```
+
+These commands use the same `/cmd_vel` interface as teleoperation and Navigation2.
 
 ## Verify movement with odometry
 

--- a/content/learning-paths/cross-platform/ros2-zenoh-arm/enable-shared-memory.md
+++ b/content/learning-paths/cross-platform/ros2-zenoh-arm/enable-shared-memory.md
@@ -93,6 +93,33 @@ just iftop_lo
 
 `.zenoh` files should appear under `/dev/shm` for Zenoh processes using shared memory. The large loopback flows should also disappear because the data now moves through memory.
 
+## Restore the environment for the next Learning Path
+
+Keep the shared-memory configuration enabled. In Terminal 2, press `Ctrl+C` to stop the temporary wall-time simulation if it is still running.
+
+Keep the Zenoh router running in Terminal 1. If it has stopped, restart it from a sourced terminal:
+
+```bash
+source ~/workshop_env.bash
+just router
+```
+
+In Terminal 2, source the environment if needed and start the normal headless simulation:
+
+```bash
+source ~/workshop_env.bash
+just rox_simu no_gui
+```
+
+In Terminal 3, source the environment if needed and restart Navigation2:
+
+```bash
+source ~/workshop_env.bash
+just rox_nav2
+```
+
+Confirm that the router is running, the simulation starts without errors, and Navigation2 reports `Managed nodes are active`. Leave these three processes running for the next Learning Path.
+
 ## Verify the complete Learning Path
 
 Use this checklist to confirm the final environment:

--- a/content/learning-paths/cross-platform/ros2-zenoh-arm/start-containers.md
+++ b/content/learning-paths/cross-platform/ros2-zenoh-arm/start-containers.md
@@ -15,6 +15,8 @@ You use two Docker containers built from the same image:
 
 Each container provides an Ubuntu desktop that you can access in a web browser. This Learning Path uses only the `robot` container, but starting both containers prepares the environment for the rest of the series.
 
+This setup is more than a container exercise. Gazebo, simulated camera and LiDAR data, Navigation2, RViz, and `rmw_zenoh` run together as a representative Physical AI robotics workload on Arm.
+
 The environment uses official `arm64` binaries without architecture-specific modifications.
 
 Run the host commands on your Arm server. After you open the browser desktop, run commands with an `ubuntu@robot` prompt in the `robot` container.
@@ -71,6 +73,10 @@ Open the browser desktops and sign in with the password `ubuntu`:
 
 - Robot container: `http://<server_ip>:6080/`
 - Control container: `http://<server_ip>:6081/`
+
+{{% notice Important %}}
+Do not expose ports `6080`, `6081`, or `7447` directly to the public internet. Use a private network, VPN, SSH tunnel, or restrictive firewall or security-group rules so that only trusted clients can reach these services.
+{{% /notice %}}
 
 ![Browser showing the Ubuntu desktop running inside the robot container through noVNC.](images/robot-desktop.png)
 

--- a/content/learning-paths/embedded-and-microcontrollers/ros2-zenoh-arm/control-robot.md
+++ b/content/learning-paths/embedded-and-microcontrollers/ros2-zenoh-arm/control-robot.md
@@ -32,13 +32,19 @@ Use the key bindings displayed in the terminal to drive the robot while you obse
 
 ## Publish a velocity command
 
-You can also publish a single command that sets the forward velocity to `0.2 m/s`:
+You can also publish forward velocity at `0.2 m/s` and a fixed rate of 10 Hz:
 
 ```bash
-ros2 topic pub --once /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.2}}"
+ros2 topic pub --rate 10 /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.2}}"
 ```
 
-The command uses the same `/cmd_vel` interface as teleoperation and Navigation2.
+Let the command run for approximately three seconds, then press `Ctrl+C` to stop the publisher. Explicitly stop the robot by publishing a zero-velocity command:
+
+```bash
+ros2 topic pub --once /cmd_vel geometry_msgs/msg/Twist "{}"
+```
+
+These commands use the same `/cmd_vel` interface as teleoperation and Navigation2.
 
 ## Verify movement with odometry
 

--- a/content/learning-paths/embedded-and-microcontrollers/ros2-zenoh-arm/enable-shared-memory.md
+++ b/content/learning-paths/embedded-and-microcontrollers/ros2-zenoh-arm/enable-shared-memory.md
@@ -93,6 +93,33 @@ just iftop_lo
 
 `.zenoh` files should appear under `/dev/shm` for Zenoh processes using shared memory. The large loopback flows should also disappear because the data now moves through memory.
 
+## Restore the environment for the next Learning Path
+
+Keep the shared-memory configuration enabled. In Terminal 2, press `Ctrl+C` to stop the temporary wall-time simulation if it is still running.
+
+Keep the Zenoh router running in Terminal 1. If it has stopped, restart it from a sourced terminal:
+
+```bash
+source ~/workshop_env.bash
+just router
+```
+
+In Terminal 2, source the environment if needed and start the normal headless simulation:
+
+```bash
+source ~/workshop_env.bash
+just rox_simu no_gui
+```
+
+In Terminal 3, source the environment if needed and restart Navigation2:
+
+```bash
+source ~/workshop_env.bash
+just rox_nav2
+```
+
+Confirm that the router is running, the simulation starts without errors, and Navigation2 reports `Managed nodes are active`. Leave these three processes running for the next Learning Path.
+
 ## Verify the complete Learning Path
 
 Use this checklist to confirm the final environment:

--- a/content/learning-paths/embedded-and-microcontrollers/ros2-zenoh-arm/start-containers.md
+++ b/content/learning-paths/embedded-and-microcontrollers/ros2-zenoh-arm/start-containers.md
@@ -15,6 +15,8 @@ You use two Docker containers built from the same image:
 
 Each container provides an Ubuntu desktop that you can access in a web browser. This Learning Path uses only the `robot` container, but starting both containers prepares the environment for the rest of the series.
 
+This setup is more than a container exercise. Gazebo, simulated camera and LiDAR data, Navigation2, RViz, and `rmw_zenoh` run together as a representative Physical AI robotics workload on Arm.
+
 The environment uses official `arm64` binaries without architecture-specific modifications.
 
 Run the host commands on your Arm server. After you open the browser desktop, run commands with an `ubuntu@robot` prompt in the `robot` container.
@@ -71,6 +73,10 @@ Open the browser desktops and sign in with the password `ubuntu`:
 
 - Robot container: `http://<server_ip>:6080/`
 - Control container: `http://<server_ip>:6081/`
+
+{{% notice Important %}}
+Do not expose ports `6080`, `6081`, or `7447` directly to the public internet. Use a private network, VPN, SSH tunnel, or restrictive firewall or security-group rules so that only trusted clients can reach these services.
+{{% /notice %}}
 
 ![Browser showing the Ubuntu desktop running inside the robot container through noVNC.](images/robot-desktop.png)
 


### PR DESCRIPTION
Updated ROS 2 LP1 based on the latest review feedback.

The changes include:
- Restoring the router, simulation, and Navigation2 environment at the end of LP1 so it is ready for LP2
- Updating the `/cmd_vel` example to publish at a fixed rate for approximately three seconds and explicitly stop the robot afterward
- Adding clearer Physical AI context for the ROS 2, Gazebo, LiDAR, camera, Navigation2, RViz, and rmw_zenoh workload
- Adding a security notice for ports 6080, 6081, and 7447
- Retaining the previously added screenshots and Learning Path structure

The `ros2-zenoh-arm` Learning Path is available under both the **Embedded and Microcontrollers** and **Cross-platform** folders. These point to the same Learning Path content.