### PR TITLE
Feature/optimize image integrity: Adds automated orphaned image cleanup

### DIFF
--- a/.github/skills/audit-images/SKILL.md
+++ b/.github/skills/audit-images/SKILL.md
@@ -89,8 +89,8 @@ findings do not block image-integrity checks.
 Case-colliding duplicate paths are removed from the Git index without deleting
 the shared worktree file on case-insensitive systems. GitHub Actions never
 writes deletions directly to the default branch. The Orphaned images cleanup
-workflow performs one full, Hugo-rendered audit at 09:00 UTC on January 1,
-May 1, and September 1 and creates or updates a bot-owned cleanup PR when safe
+workflow performs one full, Hugo-rendered audit at 09:00 UTC on March 1
+and September 1 and creates or updates a bot-owned cleanup PR when safe
 candidates exist. Scheduled runs are restricted to the canonical Arm
 repository; forks can still start manual runs. The workflow rebuilds Hugo and
 verifies the staged deletion set before pushing that proposal branch. It writes
@@ -168,7 +168,7 @@ python3 .github/skills/audit-images/scripts/orphan_images.py \
 ```
 
 Use the **Orphaned images cleanup** workflow's **Run workflow** control to start
-the same full Hugo-backed audit without waiting for the four-month schedule.
+the same full Hugo-backed audit without waiting for the six-month schedule.
 Select **Create cleanup PR** to propose verified safe deletions, or leave it
 clear for a report-only run. Scheduled canonical-repository runs automatically
 create or update the proposal. Pushes and pull requests do not trigger this

--- a/.github/skills/audit-images/SKILL.md
+++ b/.github/skills/audit-images/SKILL.md
@@ -66,6 +66,38 @@ Use path/guide-level review to:
 6. After the reviewer accepts suggestions, rewrite text, then re-run the audit on the same scope.
 7. Report before/after counts, files changed, and any remaining issues.
 
+## Orphan and reference-integrity workflow
+
+Use `scripts/orphan_images.py` when the task concerns unreferenced image files,
+broken local image paths, filename case mismatches, or malformed Markdown image
+destinations. This is separate from the alt-text audit so existing editorial
+findings do not block image-integrity checks.
+
+1. Run the checker in report mode before deleting anything.
+2. Run `scripts/orphan_images.py --fix-references` to repair deterministic
+   malformed, missing, and case-mismatched references. Review any ambiguous
+   references that remain instead of guessing.
+3. Render the site with Hugo and pass the output to `--generated-site`. The
+   checker combines tracked source references, rendered references, exact Git
+   blob matches, and unresolved-reference proximity to classify candidates.
+4. Run `--delete-safe` to remove only high-confidence candidates. Without a
+   rendered site, only byte-identical duplicates of referenced images qualify.
+5. Review only the smaller `needs review` group. Do not maintain a repository-wide
+   keep-list for historical candidates.
+6. Re-run the checker and Hugo build after cleanup.
+
+Case-colliding duplicate paths are removed from the Git index without deleting
+the shared worktree file on case-insensitive systems. GitHub Actions never
+writes deletions directly to the default branch. The Orphaned images cleanup
+workflow performs one full, Hugo-rendered audit at 09:00 UTC on January 1,
+May 1, and September 1 and creates or updates a bot-owned cleanup PR when safe
+candidates exist. Scheduled runs are restricted to the canonical Arm
+repository; forks can still start manual runs. The workflow rebuilds Hugo and
+verifies the staged deletion set before pushing that proposal branch. It writes
+Markdown and JSON from one audit pass, then applies only manifest paths whose
+Git blob IDs still match the audited snapshot. The PR is never auto-merged, and
+`needs review` images remain untouched.
+
 ## Validation rules
 
 - Treat the script as a detector, not the final authority. It flags likely problems for review.
@@ -100,3 +132,75 @@ Write JSON for tracking:
 ```bash
 python3 .github/skills/audit-images/scripts/audit_images.py --format json --output image-audit.json
 ```
+
+Report image-integrity problems without changing files:
+
+```bash
+python3 .github/skills/audit-images/scripts/orphan_images.py
+```
+
+Fail when any current problems exist:
+
+```bash
+python3 .github/skills/audit-images/scripts/orphan_images.py --check
+```
+
+Apply deterministic reference repairs in bulk:
+
+```bash
+python3 .github/skills/audit-images/scripts/orphan_images.py --fix-references
+```
+
+Build the site and classify candidates with independent rendered evidence:
+
+```bash
+hugo --destination /tmp/arm-learning-paths-image-integrity
+python3 .github/skills/audit-images/scripts/orphan_images.py \
+  --generated-site /tmp/arm-learning-paths-image-integrity
+```
+
+Delete only candidates supported by the available confidence evidence:
+
+```bash
+python3 .github/skills/audit-images/scripts/orphan_images.py \
+  --generated-site /tmp/arm-learning-paths-image-integrity \
+  --delete-safe
+```
+
+Use the **Orphaned images cleanup** workflow's **Run workflow** control to start
+the same full Hugo-backed audit without waiting for the four-month schedule.
+Select **Create cleanup PR** to propose verified safe deletions, or leave it
+clear for a report-only run. Scheduled canonical-repository runs automatically
+create or update the proposal. Pushes and pull requests do not trigger this
+workflow.
+The repository's Actions settings must grant the workflow token read/write
+access and allow GitHub Actions to create pull requests. If those permissions
+are disabled, the audit report still completes before the proposal step fails.
+
+Every workflow report lists the actionable `needs review` group even when those
+images are historical. Markdown reports link each protected image and related
+source line, explain why automatic deletion was blocked, and recommend the next
+review action. The full audit uses both source references and the rendered Hugo
+site to avoid treating images used by published pages as safe to delete.
+The cleanup PR contains deletion-only content changes, links every proposed
+deletion at the audited commit, and links the protected review group. Before
+opening the PR, the workflow requires the staged deletions to exactly match the
+JSON dry-run manifest, rebuilds the complete site, and rejects any newly
+introduced non-orphan problem. Rendered-site scans skip copied raster images
+before reading file contents while retaining text-based SVG reference checks.
+
+For a manual Git cleanup, build Hugo first and let the checker stage only the
+safe deletion set:
+
+```bash
+hugo --destination /tmp/arm-learning-paths-image-integrity
+python3 .github/skills/audit-images/scripts/orphan_images.py \
+  --generated-site /tmp/arm-learning-paths-image-integrity \
+  --delete-safe
+git diff --cached --name-status
+git diff --cached --stat
+```
+
+Review the staged deletion list before committing. The automated workflow uses
+the same `safe_delete_images` list and adds the post-deletion verification and
+pull-request boundary.

--- a/.github/skills/audit-images/SKILL.md
+++ b/.github/skills/audit-images/SKILL.md
@@ -104,10 +104,6 @@ Git blob IDs still match the audited snapshot. The PR is never auto-merged, and
 Markdown is the default human-readable report format and provides clickable
 GitHub source links. JSON is the machine-readable cleanup manifest used by the
 workflow; the checker does not maintain a duplicate plain-text report.
-Learning Paths whose `_index.md` has top-level `draft: true` are excluded as
-complete directories, so neither unfinished references nor planned draft assets
-can enter an audit or automated deletion proposal. They become eligible for the
-next scheduled or manual audit after the draft flag is removed.
 
 ## Validation rules
 

--- a/.github/skills/audit-images/SKILL.md
+++ b/.github/skills/audit-images/SKILL.md
@@ -74,17 +74,20 @@ destinations. This is separate from the alt-text audit so existing editorial
 findings do not block image-integrity checks.
 
 1. Run the checker in report mode before deleting anything.
-2. Run `scripts/orphan_images.py --fix-references` to repair deterministic
-   malformed, missing, and case-mismatched references. Review any ambiguous
-   references that remain instead of guessing.
-3. Render the site with Hugo and pass the output to `--generated-site`. The
-   checker combines tracked source references, rendered references, exact Git
-   blob matches, and unresolved-reference proximity to classify candidates.
-4. Run `--delete-safe` to remove only high-confidence candidates. Without a
-   rendered site, only byte-identical duplicates of referenced images qualify.
-5. Review only the smaller `needs review` group. Do not maintain a repository-wide
-   keep-list for historical candidates.
-6. Re-run the checker and Hugo build after cleanup.
+2. When reference repairs are needed, run
+   `scripts/orphan_images.py --fix-references` separately because it changes
+   Learning Path Markdown. Review those changes and any ambiguous references
+   instead of guessing.
+3. Run every full audit with a Hugo render passed to `--generated-site`. The
+   checker always combines tracked source references, rendered references,
+   exact Git blob matches, and unresolved-reference proximity before cleanup.
+4. Inspect every candidate in the report. Handle `requires review` candidates
+   manually outside the checker.
+5. Use the workflow's **Create cleanup PR** option to propose blob-verified
+   deletions for `safe-deletion candidate` paths.
+6. Review every proposed deletion before merging. The classification is audit
+   evidence, not a semantic decision. The workflow rebuilds Hugo and verifies
+   the staged deletion set automatically.
 
 Case-colliding duplicate paths are removed from the Git index without deleting
 the shared worktree file on case-insensitive systems. GitHub Actions never
@@ -96,7 +99,15 @@ repository; forks can still start manual runs. The workflow rebuilds Hugo and
 verifies the staged deletion set before pushing that proposal branch. It writes
 Markdown and JSON from one audit pass, then applies only manifest paths whose
 Git blob IDs still match the audited snapshot. The PR is never auto-merged, and
-`needs review` images remain untouched.
+`requires review` images remain untouched.
+
+Markdown is the default human-readable report format and provides clickable
+GitHub source links. JSON is the machine-readable cleanup manifest used by the
+workflow; the checker does not maintain a duplicate plain-text report.
+Learning Paths whose `_index.md` has top-level `draft: true` are excluded as
+complete directories, so neither unfinished references nor planned draft assets
+can enter an audit or automated deletion proposal. They become eligible for the
+next scheduled or manual audit after the draft flag is removed.
 
 ## Validation rules
 
@@ -159,17 +170,9 @@ python3 .github/skills/audit-images/scripts/orphan_images.py \
   --generated-site /tmp/arm-learning-paths-image-integrity
 ```
 
-Delete only candidates supported by the available confidence evidence:
-
-```bash
-python3 .github/skills/audit-images/scripts/orphan_images.py \
-  --generated-site /tmp/arm-learning-paths-image-integrity \
-  --delete-safe
-```
-
 Use the **Orphaned images cleanup** workflow's **Run workflow** control to start
 the same full Hugo-backed audit without waiting for the six-month schedule.
-Select **Create cleanup PR** to propose verified safe deletions, or leave it
+Select **Create cleanup PR** to propose verified safe-deletion candidates, or leave it
 clear for a report-only run. Scheduled canonical-repository runs automatically
 create or update the proposal. Pushes and pull requests do not trigger this
 workflow.
@@ -177,11 +180,12 @@ The repository's Actions settings must grant the workflow token read/write
 access and allow GitHub Actions to create pull requests. If those permissions
 are disabled, the audit report still completes before the proposal step fails.
 
-Every workflow report lists the actionable `needs review` group even when those
-images are historical. Markdown reports link each protected image and related
-source line, explain why automatic deletion was blocked, and recommend the next
-review action. The full audit uses both source references and the rendered Hugo
-site to avoid treating images used by published pages as safe to delete.
+Every workflow report lists both `requires review` and `safe-deletion candidate`
+groups for manual inspection. Records contain the image path, a high-level
+category, and any related source file and line; they do not attempt to infer the
+author's intent. Review every candidate during the initial cleanup and each
+six-month report. The full audit uses both source references and the rendered
+Hugo site to avoid treating images used by published pages as deletion candidates.
 The cleanup PR contains deletion-only content changes, links every proposed
 deletion at the audited commit, and links the protected review group. Before
 opening the PR, the workflow requires the staged deletions to exactly match the
@@ -189,18 +193,7 @@ JSON dry-run manifest, rebuilds the complete site, and rejects any newly
 introduced non-orphan problem. Rendered-site scans skip copied raster images
 before reading file contents while retaining text-based SVG reference checks.
 
-For a manual Git cleanup, build Hugo first and let the checker stage only the
-safe deletion set:
-
-```bash
-hugo --destination /tmp/arm-learning-paths-image-integrity
-python3 .github/skills/audit-images/scripts/orphan_images.py \
-  --generated-site /tmp/arm-learning-paths-image-integrity \
-  --delete-safe
-git diff --cached --name-status
-git diff --cached --stat
-```
-
-Review the staged deletion list before committing. The automated workflow uses
-the same `safe_delete_images` list and adds the post-deletion verification and
-pull-request boundary.
+Do not delete reported candidates directly through the checker. Fix protected
+`requires review` cases manually, and use the workflow-generated cleanup PR for
+safe-deletion candidates. The workflow applies the `safe_delete_images` list,
+verifies the manifest and rebuilt site, and leaves the proposal for human review.

--- a/.github/skills/audit-images/references/image-guidance.md
+++ b/.github/skills/audit-images/references/image-guidance.md
@@ -96,5 +96,5 @@ Preferred example:
 - Automatically delete only candidates classified as safe; review the smaller ambiguous group
 - Use `orphan_images.py --fix-references` for deterministic bulk repairs; leave ambiguous matches for review
 - Use `orphan_images.py --delete-safe` to remove only confidence-qualified candidates
-- Run the full Hugo-backed audit weekly, or start it manually when an up-to-date report is needed
+- Run the full Hugo-backed audit on the workflow schedule (currently January, May, and September at 09:00 UTC), or start it manually when an up-to-date report is needed
 - Put automated deletions on a bot-owned branch, rebuild and verify the site, and require human review through a non-auto-merged PR

--- a/.github/skills/audit-images/references/image-guidance.md
+++ b/.github/skills/audit-images/references/image-guidance.md
@@ -92,9 +92,9 @@ Preferred example:
 - Do not remove valid alignment syntax during cleanup
 - For bulk cleanup, update the guidance first, then fix content by category or directory in manageable batches
 - Repair malformed, missing, and case-mismatched references before classifying files as orphaned
-- Combine tracked source references with rendered Hugo output before deleting unique files
-- Automatically delete only candidates classified as safe; review the smaller ambiguous group
-- Use `orphan_images.py --fix-references` for deterministic bulk repairs; leave ambiguous matches for review
-- Use `orphan_images.py --delete-safe` to remove only confidence-qualified candidates
+- Combine tracked source references with rendered Hugo output in every full audit before deleting unique files
+- Review every candidate; fix `requires review` cases manually and use the workflow to propose `safe-deletion candidate` paths in a reviewable PR
+- Run `orphan_images.py --fix-references` separately because it changes Markdown; review those repairs, rerun the full audit, and leave ambiguous matches for manual review
 - Run the full Hugo-backed audit on the workflow schedule (currently March and September at 09:00 UTC), or start it manually when an up-to-date report is needed
+- Exclude complete Learning Path directories marked with top-level `draft: true`; audit them after publication instead of treating unfinished assets as deletable
 - Put automated deletions on a bot-owned branch, rebuild and verify the site, and require human review through a non-auto-merged PR

--- a/.github/skills/audit-images/references/image-guidance.md
+++ b/.github/skills/audit-images/references/image-guidance.md
@@ -96,5 +96,5 @@ Preferred example:
 - Automatically delete only candidates classified as safe; review the smaller ambiguous group
 - Use `orphan_images.py --fix-references` for deterministic bulk repairs; leave ambiguous matches for review
 - Use `orphan_images.py --delete-safe` to remove only confidence-qualified candidates
-- Run the full Hugo-backed audit on the workflow schedule (currently January, May, and September at 09:00 UTC), or start it manually when an up-to-date report is needed
+- Run the full Hugo-backed audit on the workflow schedule (currently March and September at 09:00 UTC), or start it manually when an up-to-date report is needed
 - Put automated deletions on a bot-owned branch, rebuild and verify the site, and require human review through a non-auto-merged PR

--- a/.github/skills/audit-images/references/image-guidance.md
+++ b/.github/skills/audit-images/references/image-guidance.md
@@ -96,5 +96,4 @@ Preferred example:
 - Review every candidate; fix `requires review` cases manually and use the workflow to propose `safe-deletion candidate` paths in a reviewable PR
 - Run `orphan_images.py --fix-references` separately because it changes Markdown; review those repairs, rerun the full audit, and leave ambiguous matches for manual review
 - Run the full Hugo-backed audit on the workflow schedule (currently March and September at 09:00 UTC), or start it manually when an up-to-date report is needed
-- Exclude complete Learning Path directories marked with top-level `draft: true`; audit them after publication instead of treating unfinished assets as deletable
 - Put automated deletions on a bot-owned branch, rebuild and verify the site, and require human review through a non-auto-merged PR

--- a/.github/skills/audit-images/references/image-guidance.md
+++ b/.github/skills/audit-images/references/image-guidance.md
@@ -91,3 +91,10 @@ Preferred example:
 - Keep the repository-specific `#center` syntax when fixing alt text
 - Do not remove valid alignment syntax during cleanup
 - For bulk cleanup, update the guidance first, then fix content by category or directory in manageable batches
+- Repair malformed, missing, and case-mismatched references before classifying files as orphaned
+- Combine tracked source references with rendered Hugo output before deleting unique files
+- Automatically delete only candidates classified as safe; review the smaller ambiguous group
+- Use `orphan_images.py --fix-references` for deterministic bulk repairs; leave ambiguous matches for review
+- Use `orphan_images.py --delete-safe` to remove only confidence-qualified candidates
+- Run the full Hugo-backed audit weekly, or start it manually when an up-to-date report is needed
+- Put automated deletions on a bot-owned branch, rebuild and verify the site, and require human review through a non-auto-merged PR

--- a/.github/skills/audit-images/scripts/orphan_images.py
+++ b/.github/skills/audit-images/scripts/orphan_images.py
@@ -38,14 +38,13 @@ IMAGE_EXTENSIONS = {
 }
 GENERATED_BINARY_IMAGE_EXTENSIONS = IMAGE_EXTENSIONS - {".svg"}
 
-# Find inline Markdown links and images; destination parsing happens separately.
-MARKDOWN_LINK_START_RE = re.compile(r"(!?)\[([^\]]*)\]\(")
-# Find image paths in the repository's tab shortcode.
-HUGO_IMG_SRC_RE = re.compile(r"\bimg_src\s*=\s*([\"'])(.*?)\1", re.IGNORECASE)
-# Find the image fields currently used by demo front matter.
+# Find inline Markdown images; destination parsing happens separately.
+MARKDOWN_IMAGE_START_RE = re.compile(r"!\[([^\]]*)\]\(")
+# Find double-quoted image paths in the repository's tab shortcode.
+HUGO_IMG_SRC_RE = re.compile(r'\bimg_src\s*=\s*"([^"]*)"', re.IGNORECASE)
+# Find the unquoted image fields currently used by demo front matter.
 FRONT_MATTER_IMAGE_RE = re.compile(
-    r"^\s*(?:diagram|diagram_blowup)\s*:\s*"
-    r"(?:[\"']([^\"']+)[\"']|(\S+))\s*$",
+    r"^\s*(?:diagram|diagram_blowup)\s*:\s*([^\s\"']+)\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
 # Protect exact local image paths mentioned outside rendered Markdown.
@@ -302,41 +301,31 @@ def line_number(text: str, offset: int) -> int:
 
 
 def find_closing_parenthesis(text: str, start: int) -> int | None:
-    """Find the closing parenthesis for an inline Markdown destination."""
+    """Find the balanced closing parenthesis outside a double-quoted title."""
     depth = 1
-    quote = ""
-    escaped = False
+    in_title = False
 
     for index in range(start, len(text)):
         char = text[index]
-        if escaped:
-            escaped = False
-            continue
-        if char == "\\":
-            escaped = True
-            continue
-        if quote:
-            if char == quote:
-                quote = ""
-            continue
-        if char in {'"', "'"}:
-            quote = char
-        elif char == "(":
-            depth += 1
-        elif char == ")":
-            depth -= 1
-            if depth == 0:
-                return index
+        if char == '"':
+            in_title = not in_title
+        elif not in_title:
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    return index
     return None
 
 
 def parse_markdown_destination(value: str) -> tuple[str, str | None]:
-    """Parse a repository-style destination and optional Markdown title."""
+    """Parse a repository-style destination and optional double-quoted title."""
     content = value.strip()
     if not content:
         return "", "missing image destination"
 
-    match = re.match(r"(?:\\.|[^\s<>])+", content)
+    match = re.match(r"[^\s<>()]+", content)
     if not match:
         return "", "missing image destination"
     target = match.group(0)
@@ -345,13 +334,7 @@ def parse_markdown_destination(value: str) -> tuple[str, str | None]:
     if not remainder:
         return target, None
 
-    valid_title = (
-        len(remainder) >= 2
-        and (
-            (remainder[0] == remainder[-1] and remainder[0] in {'"', "'"})
-            or (remainder[0] == "(" and remainder[-1] == ")")
-        )
-    )
+    valid_title = len(remainder) >= 2 and remainder[0] == remainder[-1] == '"'
     if not valid_title:
         return target, "invalid text after the image destination"
     return target, None
@@ -363,33 +346,32 @@ def extract_markdown_references(source: str, text: str) -> tuple[list[Reference]
     references: list[Reference] = []
     problems: list[Problem] = []
 
-    for match in MARKDOWN_LINK_START_RE.finditer(visible_text):
+    for match in MARKDOWN_IMAGE_START_RE.finditer(visible_text):
         closing = find_closing_parenthesis(visible_text, match.end())
         source_line = line_number(visible_text, match.start())
         if closing is None:
-            if match.group(1):
-                line_end = visible_text.find("\n", match.end())
-                if line_end < 0:
-                    line_end = len(visible_text)
-                probable_target, _error = parse_markdown_destination(
-                    visible_text[match.end() : line_end]
+            line_end = visible_text.find("\n", match.end())
+            if line_end < 0:
+                line_end = len(visible_text)
+            probable_target, _error = parse_markdown_destination(
+                visible_text[match.end() : line_end]
+            )
+            problems.append(
+                Problem(
+                    kind="malformed_markdown",
+                    path=source,
+                    line=source_line,
+                    target=probable_target,
+                    detail="image destination is not closed",
                 )
-                problems.append(
-                    Problem(
-                        kind="malformed_markdown",
-                        path=source,
-                        line=source_line,
-                        target=probable_target,
-                        detail="image destination is not closed",
-                    )
-                )
+            )
             continue
 
         target, error = parse_markdown_destination(visible_text[match.end() : closing])
         target_is_image = bool(
             target and is_image_path(target.split("?", 1)[0].split("#", 1)[0])
         )
-        if error and (match.group(1) or target_is_image):
+        if error:
             problems.append(
                 Problem(
                     kind="malformed_markdown",
@@ -399,13 +381,13 @@ def extract_markdown_references(source: str, text: str) -> tuple[list[Reference]
                     detail=error,
                 )
             )
-        if target_is_image:
+        if target_is_image and not error:
             references.append(
                 Reference(
                     source=source,
                     line=source_line,
                     target=target,
-                    kind="markdown_image" if match.group(1) else "markdown_link",
+                    kind="markdown_image",
                 )
             )
 
@@ -414,7 +396,7 @@ def extract_markdown_references(source: str, text: str) -> tuple[list[Reference]
             Reference(
                 source=source,
                 line=line_number(visible_text, match.start()),
-                target=match.group(2),
+                target=match.group(1),
                 kind="hugo_image",
             )
         )
@@ -426,7 +408,7 @@ def extract_markdown_references(source: str, text: str) -> tuple[list[Reference]
                 Reference(
                     source=source,
                     line=line_number(front_matter, match.start()) + 1,
-                    target=match.group(1) or match.group(2),
+                    target=match.group(1),
                     kind="front_matter_image",
                 )
             )
@@ -463,7 +445,7 @@ def extract_conservative_references(source: str, text: str) -> list[Reference]:
 
 
 def normalize_target(source: str, target: str) -> str | None:
-    value = target.strip().replace("\\ ", " ")
+    value = target.strip()
     parsed = urlparse(value)
     if parsed.scheme or value.startswith(("#", "$", "~")) or URL_SCHEME_RE.match(value):
         return None
@@ -519,26 +501,22 @@ def target_for_asset(
     preserve_site_root: bool = False,
 ) -> str:
     """Format a tracked asset path for use from a source Markdown file."""
-    suffix_match = re.search(r"[?#]", original)
-    suffix = original[suffix_match.start() :] if suffix_match else ""
-    original_path = original[: suffix_match.start()] if suffix_match else original
-
-    if preserve_site_root and original_path.startswith("/") and asset.startswith("content/"):
+    if preserve_site_root and original.startswith("/") and asset.startswith("content/"):
         rendered = "/" + asset.removeprefix("content/")
     else:
         rendered = posixpath.relpath(asset, posixpath.dirname(source))
-        if original_path.startswith(("./", "/")) and not rendered.startswith("."):
+        if original.startswith(("./", "/")) and not rendered.startswith("."):
             rendered = "./" + rendered
-    return rendered + suffix
+    return rendered
 
 
 # Repair only the duplicated image corruption already present in this repository.
 MALFORMED_DUPLICATE_IMAGE_RE = re.compile(
     r"^(?P<indent>\s*)!\[(?P<alt>[^\]]+)\]\("
     r"(?P<target>\S+)\s+"
-    r"(?P<quote>[\"'])(?P<title>.*?)(?P=quote)"
+    r'"(?P<title>.*?)"'
     r"(?P<duplicated>.+)\]\((?P=target)\s+"
-    r"(?P=quote)(?P=title)(?P=quote)\)(?P<trailing>\s*)$"
+    r'"(?P=title)"\)(?P<trailing>\s*)$'
 )
 
 
@@ -549,10 +527,9 @@ def repair_duplicated_image_line(line: str) -> str | None:
     match = MALFORMED_DUPLICATE_IMAGE_RE.fullmatch(value)
     if not match:
         return None
-    quote = match.group("quote")
     return (
         f'{match.group("indent")}![{match.group("alt")}]'
-        f'({match.group("target")} {quote}{match.group("title")}{quote})'
+        f'({match.group("target")} "{match.group("title")}")'
         f'{match.group("trailing")}{newline}'
     )
 

--- a/.github/skills/audit-images/scripts/orphan_images.py
+++ b/.github/skills/audit-images/scripts/orphan_images.py
@@ -3,6 +3,8 @@
 
 The checker deliberately uses Git's tracked paths as the source of truth so
 filename comparisons remain case-sensitive on every operating system.
+It excludes draft Learning Paths, combines source and rendered-site evidence,
+and produces reviewable candidates rather than making semantic decisions.
 """
 
 from __future__ import annotations
@@ -36,23 +38,17 @@ IMAGE_EXTENSIONS = {
 }
 GENERATED_BINARY_IMAGE_EXTENSIONS = IMAGE_EXTENSIONS - {".svg"}
 
+# Find inline Markdown links and images; destination parsing happens separately.
 MARKDOWN_LINK_START_RE = re.compile(r"(!?)\[([^\]]*)\]\(")
-REFERENCE_DEFINITION_RE = re.compile(
-    r"^\s*\[([^\]]+)\]:\s*(?:<([^>]+)>|(\S+))", re.MULTILINE
-)
-REFERENCE_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\[([^\]]*)\]")
-HTML_IMAGE_RE = re.compile(
-    r"<img\b[^>]*?\b(?:src|data-src)\s*=\s*([\"'])(.*?)\1[^>]*>",
-    re.IGNORECASE | re.DOTALL,
-)
-HUGO_IMAGE_RE = re.compile(
-    r"\b(?:img_src|image|src)\s*=\s*([\"'])(.*?)\1", re.IGNORECASE
-)
+# Find image paths in the repository's tab shortcode.
+HUGO_IMG_SRC_RE = re.compile(r"\bimg_src\s*=\s*([\"'])(.*?)\1", re.IGNORECASE)
+# Find the image fields currently used by demo front matter.
 FRONT_MATTER_IMAGE_RE = re.compile(
-    r"^\s*(?:cover|diagram|diagram_blowup|image|thumbnail)\s*:\s*"
+    r"^\s*(?:diagram|diagram_blowup)\s*:\s*"
     r"(?:[\"']([^\"']+)[\"']|(\S+))\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
+# Protect exact local image paths mentioned outside rendered Markdown.
 LOCAL_IMAGE_TOKEN_RE = re.compile(
     r"(?<![A-Za-z0-9_.-])"
     r"((?:/|\./|\.\./)?[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*"
@@ -60,6 +56,7 @@ LOCAL_IMAGE_TOKEN_RE = re.compile(
     r"(?:[?#][^\s\"'<>)]*)?",
     re.IGNORECASE,
 )
+# Find image URLs and paths in Hugo's generated text output.
 GENERATED_IMAGE_TOKEN_RE = re.compile(
     r"(?P<target>"
     r"(?:(?:https?:)?//[^\s\"'<>]+?\.(?:avif|bmp|gif|jpe?g|png|svg|tiff?|webp)"
@@ -68,8 +65,10 @@ GENERATED_IMAGE_TOKEN_RE = re.compile(
     r"(?:[?#][^\s\"'<>)]*)?)",
     re.IGNORECASE,
 )
+# Mask code examples so sample image syntax is not treated as page content.
 FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
 INLINE_CODE_RE = re.compile(r"(`+)(.+?)\1")
+# Reject external URI schemes before resolving repository-relative paths.
 URL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
 
 
@@ -78,6 +77,7 @@ class Snapshot:
     files: dict[str, str]
     text: dict[str, str]
     scopes: tuple[str, ...] = DEFAULT_PATHS
+    excluded_draft_learning_paths: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -134,6 +134,7 @@ class Analysis:
     duplicate_orphans: dict[str, tuple[str, ...]]
     generated_site_checked: bool
     problems: list[Problem]
+    excluded_draft_learning_paths: int = 0
 
     def all_problems(self) -> list[Problem]:
         safe = set(self.safe_delete_images)
@@ -141,17 +142,9 @@ class Analysis:
         for path in self.orphan_images:
             matches = self.duplicate_orphans.get(path, ())
             if path not in safe:
-                detail = "needs review because evidence is incomplete or ambiguous"
-            elif matches:
-                detail = (
-                    "delete only this unreferenced path; byte-identical referenced "
-                    "copies are kept"
-                )
+                detail = "requires_review"
             else:
-                detail = (
-                    "not referenced in tracked source or the rendered site; "
-                    "safe deletion proposal"
-                )
+                detail = "safe_deletion_candidate"
             orphan_problems.append(
                 Problem(
                     kind="orphan",
@@ -203,9 +196,43 @@ def tracked_file_oids(repo_root: Path) -> dict[str, str]:
     return tracked
 
 
+def draft_learning_path_roots(text_files: Mapping[str, str]) -> tuple[str, ...]:
+    """Return Learning Path directories whose top-level front matter is draft."""
+    roots: set[str] = set()
+    for path, text in text_files.items():
+        if not (
+            path.startswith("content/learning-paths/") and path.endswith("/_index.md")
+        ):
+            continue
+        for line in extract_front_matter(text).splitlines():
+            if not line or line[0].isspace():
+                continue
+            key, separator, value = line.partition(":")
+            if (
+                separator
+                and key.strip().lower() == "draft"
+                and value.split("#", 1)[0].strip().lower() == "true"
+            ):
+                roots.add(posixpath.dirname(path))
+                break
+    return tuple(sorted(roots))
+
+
+def path_in_directories(path: str, directories: Sequence[str]) -> bool:
+    return any(
+        path == directory or path.startswith(directory + "/")
+        for directory in directories
+    )
+
+
+def path_intersects_scopes(path: str, scopes: Sequence[str]) -> bool:
+    return path_in_scopes(path, scopes) or any(
+        scope.startswith(path.rstrip("/") + "/") for scope in scopes
+    )
+
+
 def current_snapshot(repo_root: Path, scopes: Sequence[str]) -> Snapshot:
     tracked = tracked_file_oids(repo_root)
-    files = {path: oid for path, oid in tracked.items() if path_in_scopes(path, scopes)}
     text_entries = [
         (path, oid) for path, oid in tracked.items() if not is_image_path(path)
     ]
@@ -222,7 +249,28 @@ def current_snapshot(repo_root: Path, scopes: Sequence[str]) -> Snapshot:
         if is_probably_text(data):
             text_files[path] = data.decode("utf-8", errors="replace")
 
-    return Snapshot(files=files, text=text_files, scopes=tuple(scopes))
+    all_draft_roots = draft_learning_path_roots(text_files)
+    draft_roots = tuple(
+        root for root in all_draft_roots if path_intersects_scopes(root, scopes)
+    )
+    files = {
+        path: oid
+        for path, oid in tracked.items()
+        if path_in_scopes(path, scopes)
+        and not path_in_directories(path, all_draft_roots)
+    }
+    text_files = {
+        path: text
+        for path, text in text_files.items()
+        if not path_in_directories(path, all_draft_roots)
+    }
+
+    return Snapshot(
+        files=files,
+        text=text_files,
+        scopes=tuple(scopes),
+        excluded_draft_learning_paths=draft_roots,
+    )
 
 
 def mask_fenced_code(text: str) -> str:
@@ -249,10 +297,12 @@ def mask_fenced_code(text: str) -> str:
 
 
 def line_number(text: str, offset: int) -> int:
+    """Return the one-based line containing a character offset."""
     return text.count("\n", 0, offset) + 1
 
 
 def find_closing_parenthesis(text: str, start: int) -> int | None:
+    """Find the closing parenthesis for an inline Markdown destination."""
     depth = 1
     quote = ""
     escaped = False
@@ -281,22 +331,16 @@ def find_closing_parenthesis(text: str, start: int) -> int | None:
 
 
 def parse_markdown_destination(value: str) -> tuple[str, str | None]:
+    """Parse a repository-style destination and optional Markdown title."""
     content = value.strip()
     if not content:
         return "", "missing image destination"
 
-    if content.startswith("<"):
-        closing = content.find(">")
-        if closing < 0:
-            return "", "unterminated angle-bracket destination"
-        target = content[1:closing]
-        remainder = content[closing + 1 :].strip()
-    else:
-        match = re.match(r"(?:\\.|\S)+", content)
-        if not match:
-            return "", "missing image destination"
-        target = match.group(0)
-        remainder = content[match.end() :].strip()
+    match = re.match(r"(?:\\.|[^\s<>])+", content)
+    if not match:
+        return "", "missing image destination"
+    target = match.group(0)
+    remainder = content[match.end() :].strip()
 
     if not remainder:
         return target, None
@@ -314,6 +358,7 @@ def parse_markdown_destination(value: str) -> tuple[str, str | None]:
 
 
 def extract_markdown_references(source: str, text: str) -> tuple[list[Reference], list[Problem]]:
+    """Extract supported source references and malformed image findings."""
     visible_text = mask_fenced_code(text)
     references: list[Reference] = []
     problems: list[Problem] = []
@@ -364,37 +409,7 @@ def extract_markdown_references(source: str, text: str) -> tuple[list[Reference]
                 )
             )
 
-    definitions: dict[str, tuple[str, int]] = {}
-    for match in REFERENCE_DEFINITION_RE.finditer(visible_text):
-        target = match.group(2) or match.group(3) or ""
-        definitions[match.group(1).strip().lower()] = (
-            target,
-            line_number(visible_text, match.start()),
-        )
-    for match in REFERENCE_IMAGE_RE.finditer(visible_text):
-        label = (match.group(2) or match.group(1)).strip().lower()
-        if label in definitions:
-            target, _definition_line = definitions[label]
-            references.append(
-                Reference(
-                    source=source,
-                    line=line_number(visible_text, match.start()),
-                    target=target,
-                    kind="markdown_reference_image",
-                )
-            )
-
-    for match in HTML_IMAGE_RE.finditer(visible_text):
-        references.append(
-            Reference(
-                source=source,
-                line=line_number(visible_text, match.start()),
-                target=match.group(2),
-                kind="html_image",
-            )
-        )
-
-    for match in HUGO_IMAGE_RE.finditer(visible_text):
+    for match in HUGO_IMG_SRC_RE.finditer(visible_text):
         references.append(
             Reference(
                 source=source,
@@ -449,8 +464,6 @@ def extract_conservative_references(source: str, text: str) -> list[Reference]:
 
 def normalize_target(source: str, target: str) -> str | None:
     value = target.strip().replace("\\ ", " ")
-    if value.startswith("<") and value.endswith(">"):
-        value = value[1:-1]
     parsed = urlparse(value)
     if parsed.scheme or value.startswith(("#", "$", "~")) or URL_SCHEME_RE.match(value):
         return None
@@ -519,9 +532,10 @@ def target_for_asset(
     return rendered + suffix
 
 
+# Repair only the duplicated image corruption already present in this repository.
 MALFORMED_DUPLICATE_IMAGE_RE = re.compile(
     r"^(?P<indent>\s*)!\[(?P<alt>[^\]]+)\]\("
-    r"(?P<target><[^>]+>|\S+)\s+"
+    r"(?P<target>\S+)\s+"
     r"(?P<quote>[\"'])(?P<title>.*?)(?P=quote)"
     r"(?P<duplicated>.+)\]\((?P=target)\s+"
     r"(?P=quote)(?P=title)(?P=quote)\)(?P<trailing>\s*)$"
@@ -624,6 +638,7 @@ def analyze(
     snapshot: Snapshot,
     generated_used: set[str] | None = None,
 ) -> Analysis:
+    """Classify tracked images from source and optional rendered-site evidence."""
     assets = {path for path in snapshot.files if is_image_path(path)}
     by_casefold: dict[str, list[str]] = defaultdict(list)
     for asset in assets:
@@ -728,6 +743,7 @@ def analyze(
         duplicate_orphans=duplicate_orphans,
         generated_site_checked=generated_used is not None,
         problems=sorted(problems, key=problem_sort_key),
+        excluded_draft_learning_paths=len(snapshot.excluded_draft_learning_paths),
     )
 
 
@@ -864,62 +880,34 @@ def problem_sort_key(problem: Problem) -> tuple:
 
 
 def needs_review_records(analysis: Analysis) -> list[dict[str, object]]:
-    """Describe why each protected orphan needs human review."""
+    """Return protected image paths and their related Markdown locations."""
     records: list[dict[str, object]] = []
     missing = [problem for problem in analysis.problems if problem.kind == "missing_image"]
 
     for path in analysis.needs_review_images:
-        related: list[dict[str, object]] = []
+        related_sources: list[dict[str, object]] = []
         for problem in missing:
             source_directory = posixpath.dirname(problem.path).rstrip("/") + "/"
-            if problem.replacement == path:
-                relationship = "unique nearby replacement"
-            elif not problem.replacement and path.startswith(source_directory):
-                relationship = "unresolved image in the same content directory"
-            else:
+            if not (
+                problem.replacement == path
+                or (not problem.replacement and path.startswith(source_directory))
+            ):
                 continue
-            related.append(
+            related_sources.append(
                 {
                     "source": problem.path,
                     "line": problem.line,
-                    "target": problem.target,
-                    "relationship": relationship,
                 }
             )
-
-        if any(item["relationship"] == "unique nearby replacement" for item in related):
-            reason = "A missing image reference uniquely points to this nearby asset."
-            recommendation = "Fix the related reference before considering deletion."
-        elif related:
-            reason = "An unresolved missing reference exists in the same content directory."
-            recommendation = "Inspect the image and article to decide whether to link or delete it."
-        elif not analysis.generated_site_checked:
-            reason = "Rendered-site evidence is unavailable and this is not an exact duplicate."
-            recommendation = "Run the full rendered audit before making a deletion decision."
-        else:
-            reason = "Available evidence is incomplete or ambiguous."
-            recommendation = "Inspect the image and nearby content before changing it."
 
         records.append(
             {
                 "path": path,
-                "reason": reason,
-                "recommendation": recommendation,
-                "related_references": related,
+                "category": "requires_review",
+                "related_sources": related_sources,
             }
         )
     return records
-
-
-def displayed_review_records(
-    analysis: Analysis,
-    records: Sequence[dict[str, object]],
-) -> tuple[list[dict[str, object]], int]:
-    """Separate actionable review details from candidates awaiting a full audit."""
-    if analysis.generated_site_checked:
-        return list(records), 0
-    displayed = [record for record in records if record["related_references"]]
-    return displayed, len(records) - len(displayed)
 
 
 def analysis_json(
@@ -943,6 +931,7 @@ def analysis_json(
                 "needs_review_images": len(analysis.needs_review_images),
                 "duplicate_orphans": len(analysis.duplicate_orphans),
                 "generated_site_checked": analysis.generated_site_checked,
+                "excluded_draft_learning_paths": analysis.excluded_draft_learning_paths,
                 "reported_problems": len(problems),
             },
             "safe_deletions": analysis.safe_delete_images,
@@ -960,6 +949,7 @@ def cleanup_manifest_paths(
     baseline_path: Path,
     tracked_files: Mapping[str, str],
     scopes: Sequence[str],
+    excluded_directories: Sequence[str] = (),
 ) -> list[str]:
     """Validate and return rendered-safe paths whose image blobs are unchanged."""
     try:
@@ -1002,6 +992,10 @@ def cleanup_manifest_paths(
 
         if not path_in_scopes(normalized, scopes):
             errors.append(f"cleanup path is outside the requested scopes: {normalized}")
+        if path_in_directories(normalized, excluded_directories):
+            errors.append(
+                f"cleanup path is inside an excluded draft Learning Path: {normalized}"
+            )
         if not is_image_path(normalized):
             errors.append(f"cleanup path is not a supported image: {normalized}")
         actual_oid = tracked_files.get(normalized)
@@ -1087,104 +1081,6 @@ def verify_cleanup(
     return errors
 
 
-def analysis_text(
-    analysis: Analysis,
-    problems: Sequence[Problem],
-    changes: Sequence[Change] = (),
-) -> str:
-    lines: list[str] = []
-    if changes:
-        lines.extend(["Applied changes", ""])
-        for change in changes:
-            location = change.path + (f":{change.line}" if change.line else "")
-            message = f"- {change.kind}: {location}"
-            if change.before or change.after:
-                message += f" ({change.before} -> {change.after})"
-            lines.append(message)
-        lines.append("")
-
-    lines.extend(
-        [
-            "Image integrity report",
-            "",
-            f"Tracked images: {analysis.tracked_images}",
-            f"Referenced images: {analysis.referenced_images}",
-            f"Current orphan candidates: {len(analysis.orphan_images)}",
-            f"Safe automatic deletions: {len(analysis.safe_delete_images)}",
-            f"Needs review: {len(analysis.needs_review_images)}",
-            f"Exact duplicate orphans: {len(analysis.duplicate_orphans)}",
-            "Generated site checked: "
-            + ("yes" if analysis.generated_site_checked else "no"),
-            f"All detected problems: {len(problems)}",
-        ]
-    )
-
-    review_records = needs_review_records(analysis)
-    displayed_records, awaiting_render = displayed_review_records(
-        analysis,
-        review_records,
-    )
-    if displayed_records:
-        lines.extend(["", f"Current images needing review ({len(displayed_records)})"])
-        for record in displayed_records:
-            lines.append(f"- {record['path']}")
-            lines.append(f"  Reason: {record['reason']}")
-            for related in record["related_references"]:
-                source = related["source"]
-                line = related["line"]
-                target = related["target"]
-                relationship = related["relationship"]
-                lines.append(
-                    f"  Related reference: {source}:{line} -> {target} "
-                    f"({relationship})"
-                )
-            lines.append(f"  Recommended action: {record['recommendation']}")
-    if awaiting_render:
-        lines.extend(
-            [
-                "",
-                f"Awaiting full rendered classification: {awaiting_render}",
-                "Run the full audit before reviewing these candidates individually.",
-            ]
-        )
-
-    if not problems:
-        lines.extend(["", "No actionable image-integrity problems found."])
-        return "\n".join(lines) + "\n"
-
-    grouped: dict[str, list[Problem]] = defaultdict(list)
-    for problem in problems:
-        grouped[problem.kind].append(problem)
-
-    labels = {
-        "case_mismatch": "Filename case mismatches",
-        "malformed_markdown": "Malformed Markdown image references",
-        "missing_image": "Missing referenced images",
-        "orphan": "Unreferenced image candidates",
-    }
-    for kind in sorted(grouped):
-        lines.extend(["", labels.get(kind, kind.replace("_", " ").title())])
-        for problem in grouped[kind]:
-            location = problem.path + (f":{problem.line}" if problem.line else "")
-            message = location
-            if problem.target:
-                message += f" -> {problem.target}"
-            if problem.matches:
-                relationship = (
-                    "referenced byte-identical copies kept"
-                    if problem.kind == "orphan"
-                    else "tracked as"
-                )
-                message += f" ({relationship} {', '.join(problem.matches)})"
-            if problem.replacement:
-                message += f" (safe replacement: {problem.replacement})"
-            if problem.detail:
-                message += f" ({problem.detail})"
-            lines.append(f"- {message}")
-
-    return "\n".join(lines) + "\n"
-
-
 def github_file_link(
     repository_url: str,
     revision: str,
@@ -1220,9 +1116,10 @@ def analysis_markdown(
         f"| Tracked images | {analysis.tracked_images} |",
         f"| Referenced images | {analysis.referenced_images} |",
         f"| Current orphan candidates | {len(analysis.orphan_images)} |",
-        f"| Safe automatic deletions | {len(analysis.safe_delete_images)} |",
-        f"| Needs review | {len(analysis.needs_review_images)} |",
+        f"| Safe-deletion candidates | {len(analysis.safe_delete_images)} |",
+        f"| Requires review | {len(analysis.needs_review_images)} |",
         f"| Exact duplicate orphans | {len(analysis.duplicate_orphans)} |",
+        f"| Draft Learning Paths excluded | {analysis.excluded_draft_learning_paths} |",
         "| Generated site checked | "
         + ("yes" if analysis.generated_site_checked else "no")
         + " |",
@@ -1230,48 +1127,38 @@ def analysis_markdown(
     ]
 
     review_records = needs_review_records(analysis)
-    displayed_records, awaiting_render = displayed_review_records(
-        analysis,
-        review_records,
-    )
-    if awaiting_render:
-        lines.append(f"| Awaiting full rendered classification | {awaiting_render} |")
-    if displayed_records:
+    if analysis.orphan_images:
         lines.extend(
             [
                 "",
-                f"### Current images needing review ({len(displayed_records)})",
+                "### Candidate review",
                 "",
+                "| Category | Image | Related Markdown |",
+                "| --- | --- | --- |",
             ]
         )
-        for record in displayed_records:
+        for path in analysis.safe_delete_images:
+            lines.append(
+                "| Safe-deletion candidate | "
+                f"{github_file_link(repository_url, revision, path)} | — |"
+            )
+        for record in review_records:
             path = str(record["path"])
-            lines.append(f"- {github_file_link(repository_url, revision, path)}")
-            lines.append(f"  - **Why:** {record['reason']}")
-            for related in record["related_references"]:
-                source = str(related["source"])
-                line = int(related["line"])
-                target = related["target"]
-                relationship = related["relationship"]
-                source_link = github_file_link(
+            related_links = [
+                github_file_link(
                     repository_url,
                     revision,
-                    source,
-                    line,
+                    str(related["source"]),
+                    int(related["line"]),
                 )
-                lines.append(
-                    f"  - **Related reference:** {source_link} requests `{target}` "
-                    f"({relationship})."
-                )
-            lines.append(f"  - **Recommended action:** {record['recommendation']}")
-    if awaiting_render:
-        lines.extend(
-            [
-                "",
-                f"> **{awaiting_render} additional candidates** are awaiting rendered-site "
-                "evidence. Run the full audit before reviewing them individually.",
+                for related in record["related_sources"]
             ]
-        )
+            related_markdown = "<br>".join(related_links) if related_links else "—"
+            lines.append(
+                "| Requires review | "
+                f"{github_file_link(repository_url, revision, path)} | "
+                f"{related_markdown} |"
+            )
 
     if changes:
         lines.extend(["", "### Applied changes", ""])
@@ -1284,45 +1171,42 @@ def analysis_markdown(
             )
             lines.append(f"- `{change.kind}`: {link}")
 
-    lines.extend(["", "### All detected problems", ""])
-    if not problems:
-        lines.append("No actionable image-integrity problems found.")
+    lines.extend(["", "### Reference problems", ""])
+    reference_problems = [problem for problem in problems if problem.kind != "orphan"]
+    if not reference_problems:
+        lines.append("No malformed, missing, or case-mismatched references found.")
         return "\n".join(lines) + "\n"
 
-    grouped: dict[str, list[Problem]] = defaultdict(list)
-    for problem in problems:
-        grouped[problem.kind].append(problem)
     labels = {
-        "case_mismatch": "Filename case mismatches",
-        "malformed_markdown": "Malformed Markdown image references",
-        "missing_image": "Missing referenced images",
-        "orphan": "Unreferenced image candidates",
+        "case_mismatch": "Filename case mismatch",
+        "malformed_markdown": "Malformed image reference",
+        "missing_image": "Missing image reference",
     }
-    for kind in sorted(grouped):
-        lines.extend(["", f"#### {labels.get(kind, kind.replace('_', ' ').title())}", ""])
-        for problem in grouped[kind]:
-            link = github_file_link(
-                repository_url,
-                revision,
-                problem.path,
-                problem.line,
+    lines.extend(
+        [
+            "| Category | Image | Markdown |",
+            "| --- | --- | --- |",
+        ]
+    )
+    for problem in reference_problems:
+        markdown_link = github_file_link(
+            repository_url,
+            revision,
+            problem.path,
+            problem.line,
+        )
+        image_paths = list(problem.matches)
+        if problem.replacement:
+            image_paths.append(problem.replacement)
+        if image_paths:
+            image = "<br>".join(
+                github_file_link(repository_url, revision, path)
+                for path in image_paths
             )
-            message = f"- {link}"
-            if problem.target:
-                message += f" requests `{problem.target}`"
-            if problem.matches:
-                relationship = (
-                    "referenced byte-identical copies kept"
-                    if kind == "orphan"
-                    else "tracked as"
-                )
-                matches = ", ".join(f"`{match}`" for match in problem.matches)
-                message += f" ({relationship} {matches})"
-            if problem.replacement:
-                message += f" (safe replacement: `{problem.replacement}`)"
-            if problem.detail:
-                message += f" — {problem.detail}"
-            lines.append(message)
+        else:
+            image = f"`{problem.target}`" if problem.target else "—"
+        category = labels.get(problem.kind, problem.kind.replace("_", " ").title())
+        lines.append(f"| {category} | {image} | {markdown_link} |")
     return "\n".join(lines) + "\n"
 
 
@@ -1340,28 +1224,23 @@ def cleanup_changes_report(
             sort_keys=True,
         ) + "\n"
 
-    if output_format == "markdown":
-        lines = ["### Applied cleanup manifest", ""]
-        if not changes:
-            lines.append("The verified manifest contained no safe deletions.")
-        else:
-            lines.append(f"Staged {len(changes)} verified image deletion(s).")
-            lines.append("")
-            for change in changes:
-                link = github_file_link(
-                    repository_url,
-                    revision,
-                    change.path,
-                    change.line,
-                )
-                lines.append(f"- `{change.kind}`: {link}")
-        return "\n".join(lines) + "\n"
+    if output_format != "markdown":
+        raise ValueError(f"Unsupported report format: {output_format}")
 
-    lines = ["Applied cleanup manifest", ""]
+    lines = ["### Applied cleanup manifest", ""]
     if not changes:
-        lines.append("No safe deletions were present.")
+        lines.append("The verified manifest contained no safe deletions.")
     else:
-        lines.extend(f"- {change.kind}: {change.path}" for change in changes)
+        lines.append(f"Staged {len(changes)} verified image deletion(s).")
+        lines.append("")
+        for change in changes:
+            link = github_file_link(
+                repository_url,
+                revision,
+                change.path,
+                change.line,
+            )
+            lines.append(f"- `{change.kind}`: {link}")
     return "\n".join(lines) + "\n"
 
 
@@ -1404,14 +1283,6 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--delete-safe",
-        action="store_true",
-        help=(
-            "Remove only high-confidence orphan candidates. Without rendered-site "
-            "evidence, only exact duplicates of referenced images qualify."
-        ),
-    )
-    parser.add_argument(
         "--apply-cleanup",
         metavar="BASELINE_JSON",
         help=(
@@ -1429,8 +1300,9 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--format",
-        choices=("text", "json", "markdown"),
-        default="text",
+        choices=("json", "markdown"),
+        default="markdown",
+        help="Write human-readable Markdown (default) or machine-readable JSON.",
     )
     parser.add_argument(
         "--repository-url",
@@ -1450,12 +1322,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repo-root", default=".")
     args = parser.parse_args()
     changing_modes = sum(
-        bool(mode) for mode in (args.fix_references, args.delete_safe, args.apply_cleanup)
+        bool(mode) for mode in (args.fix_references, args.apply_cleanup)
     )
     if changing_modes > 1:
-        parser.error(
-            "--fix-references, --delete-safe, and --apply-cleanup are mutually exclusive"
-        )
+        parser.error("--fix-references and --apply-cleanup are mutually exclusive")
     if args.verify_cleanup and changing_modes:
         parser.error("--verify-cleanup cannot be combined with file-changing modes")
     if args.apply_cleanup and args.generated_site:
@@ -1485,10 +1355,12 @@ def main() -> int:
         if not baseline_path.is_absolute():
             baseline_path = repo_root / baseline_path
         tracked_files = tracked_file_oids(repo_root)
+        snapshot = current_snapshot(repo_root, scopes)
         paths = cleanup_manifest_paths(
             baseline_path.resolve(),
             tracked_files,
             scopes,
+            snapshot.excluded_draft_learning_paths,
         )
         progress(f"Applying {len(paths)} blob-verified deletion(s) from the manifest.")
         changes = delete_safe_images(repo_root, paths, tuple(tracked_files))
@@ -1541,16 +1413,6 @@ def main() -> int:
         changes.extend(apply_safe_reference_fixes(repo_root, current))
         current_snapshot_value, current = analyze_current()
 
-    if args.delete_safe:
-        changes.extend(
-            delete_safe_images(
-                repo_root,
-                current.safe_delete_images,
-                tuple(current_snapshot_value.files),
-            )
-        )
-        current_snapshot_value, current = analyze_current()
-
     reported = current.all_problems()
     verification_errors: list[str] = []
     if args.verify_cleanup:
@@ -1571,7 +1433,7 @@ def main() -> int:
     )
     if args.format == "json":
         output = json_output
-    elif args.format == "markdown":
+    else:
         output = analysis_markdown(
             current,
             reported,
@@ -1579,9 +1441,6 @@ def main() -> int:
             args.repository_url,
             args.revision,
         )
-    else:
-        output = analysis_text(current, reported, changes)
-
     if args.output:
         write_cli_output(repo_root, args.output, output)
     else:

--- a/.github/skills/audit-images/scripts/orphan_images.py
+++ b/.github/skills/audit-images/scripts/orphan_images.py
@@ -581,7 +581,7 @@ def generated_site_references(
     found_html = False
     files_seen = 0
     text_files_scanned = 0
-    for path in sorted(site_root.rglob("*")):
+    for path in site_root.rglob("*"):
         if not path.is_file():
             continue
         files_seen += 1
@@ -1196,7 +1196,7 @@ def github_file_link(
     if not repository_url or not revision:
         return f"`{label}`"
     url = (
-        f"{repository_url.rstrip('/')}/blob/{quote(revision, safe='')}/"
+        f"{repository_url.rstrip('/')}/blob/{quote(revision, safe='/')}/"
         f"{quote(path, safe='/')}"
     )
     if line:

--- a/.github/skills/audit-images/scripts/orphan_images.py
+++ b/.github/skills/audit-images/scripts/orphan_images.py
@@ -3,8 +3,8 @@
 
 The checker deliberately uses Git's tracked paths as the source of truth so
 filename comparisons remain case-sensitive on every operating system.
-It excludes draft Learning Paths, combines source and rendered-site evidence,
-and produces reviewable candidates rather than making semantic decisions.
+It combines source and rendered-site evidence and produces reviewable
+candidates rather than making semantic decisions.
 """
 
 from __future__ import annotations
@@ -76,7 +76,6 @@ class Snapshot:
     files: dict[str, str]
     text: dict[str, str]
     scopes: tuple[str, ...] = DEFAULT_PATHS
-    excluded_draft_learning_paths: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -133,7 +132,6 @@ class Analysis:
     duplicate_orphans: dict[str, tuple[str, ...]]
     generated_site_checked: bool
     problems: list[Problem]
-    excluded_draft_learning_paths: int = 0
 
     def all_problems(self) -> list[Problem]:
         safe = set(self.safe_delete_images)
@@ -195,43 +193,9 @@ def tracked_file_oids(repo_root: Path) -> dict[str, str]:
     return tracked
 
 
-def draft_learning_path_roots(text_files: Mapping[str, str]) -> tuple[str, ...]:
-    """Return Learning Path directories whose top-level front matter is draft."""
-    roots: set[str] = set()
-    for path, text in text_files.items():
-        if not (
-            path.startswith("content/learning-paths/") and path.endswith("/_index.md")
-        ):
-            continue
-        for line in extract_front_matter(text).splitlines():
-            if not line or line[0].isspace():
-                continue
-            key, separator, value = line.partition(":")
-            if (
-                separator
-                and key.strip().lower() == "draft"
-                and value.split("#", 1)[0].strip().lower() == "true"
-            ):
-                roots.add(posixpath.dirname(path))
-                break
-    return tuple(sorted(roots))
-
-
-def path_in_directories(path: str, directories: Sequence[str]) -> bool:
-    return any(
-        path == directory or path.startswith(directory + "/")
-        for directory in directories
-    )
-
-
-def path_intersects_scopes(path: str, scopes: Sequence[str]) -> bool:
-    return path_in_scopes(path, scopes) or any(
-        scope.startswith(path.rstrip("/") + "/") for scope in scopes
-    )
-
-
 def current_snapshot(repo_root: Path, scopes: Sequence[str]) -> Snapshot:
     tracked = tracked_file_oids(repo_root)
+    files = {path: oid for path, oid in tracked.items() if path_in_scopes(path, scopes)}
     text_entries = [
         (path, oid) for path, oid in tracked.items() if not is_image_path(path)
     ]
@@ -248,27 +212,10 @@ def current_snapshot(repo_root: Path, scopes: Sequence[str]) -> Snapshot:
         if is_probably_text(data):
             text_files[path] = data.decode("utf-8", errors="replace")
 
-    all_draft_roots = draft_learning_path_roots(text_files)
-    draft_roots = tuple(
-        root for root in all_draft_roots if path_intersects_scopes(root, scopes)
-    )
-    files = {
-        path: oid
-        for path, oid in tracked.items()
-        if path_in_scopes(path, scopes)
-        and not path_in_directories(path, all_draft_roots)
-    }
-    text_files = {
-        path: text
-        for path, text in text_files.items()
-        if not path_in_directories(path, all_draft_roots)
-    }
-
     return Snapshot(
         files=files,
         text=text_files,
         scopes=tuple(scopes),
-        excluded_draft_learning_paths=draft_roots,
     )
 
 
@@ -720,7 +667,6 @@ def analyze(
         duplicate_orphans=duplicate_orphans,
         generated_site_checked=generated_used is not None,
         problems=sorted(problems, key=problem_sort_key),
-        excluded_draft_learning_paths=len(snapshot.excluded_draft_learning_paths),
     )
 
 
@@ -908,7 +854,6 @@ def analysis_json(
                 "needs_review_images": len(analysis.needs_review_images),
                 "duplicate_orphans": len(analysis.duplicate_orphans),
                 "generated_site_checked": analysis.generated_site_checked,
-                "excluded_draft_learning_paths": analysis.excluded_draft_learning_paths,
                 "reported_problems": len(problems),
             },
             "safe_deletions": analysis.safe_delete_images,
@@ -926,7 +871,6 @@ def cleanup_manifest_paths(
     baseline_path: Path,
     tracked_files: Mapping[str, str],
     scopes: Sequence[str],
-    excluded_directories: Sequence[str] = (),
 ) -> list[str]:
     """Validate and return rendered-safe paths whose image blobs are unchanged."""
     try:
@@ -969,10 +913,6 @@ def cleanup_manifest_paths(
 
         if not path_in_scopes(normalized, scopes):
             errors.append(f"cleanup path is outside the requested scopes: {normalized}")
-        if path_in_directories(normalized, excluded_directories):
-            errors.append(
-                f"cleanup path is inside an excluded draft Learning Path: {normalized}"
-            )
         if not is_image_path(normalized):
             errors.append(f"cleanup path is not a supported image: {normalized}")
         actual_oid = tracked_files.get(normalized)
@@ -1096,7 +1036,6 @@ def analysis_markdown(
         f"| Safe-deletion candidates | {len(analysis.safe_delete_images)} |",
         f"| Requires review | {len(analysis.needs_review_images)} |",
         f"| Exact duplicate orphans | {len(analysis.duplicate_orphans)} |",
-        f"| Draft Learning Paths excluded | {analysis.excluded_draft_learning_paths} |",
         "| Generated site checked | "
         + ("yes" if analysis.generated_site_checked else "no")
         + " |",
@@ -1332,12 +1271,10 @@ def main() -> int:
         if not baseline_path.is_absolute():
             baseline_path = repo_root / baseline_path
         tracked_files = tracked_file_oids(repo_root)
-        snapshot = current_snapshot(repo_root, scopes)
         paths = cleanup_manifest_paths(
             baseline_path.resolve(),
             tracked_files,
             scopes,
-            snapshot.excluded_draft_learning_paths,
         )
         progress(f"Applying {len(paths)} blob-verified deletion(s) from the manifest.")
         changes = delete_safe_images(repo_root, paths, tuple(tracked_files))

--- a/.github/skills/audit-images/scripts/orphan_images.py
+++ b/.github/skills/audit-images/scripts/orphan_images.py
@@ -1,0 +1,1599 @@
+#!/usr/bin/env python3
+"""Find broken image references and unreferenced tracked images.
+
+The checker deliberately uses Git's tracked paths as the source of truth so
+filename comparisons remain case-sensitive on every operating system.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import posixpath
+import re
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Callable, Mapping, Sequence
+from urllib.parse import quote, unquote, urlparse
+
+
+DEFAULT_PATHS = ("content/learning-paths", "content/install-guides")
+IMAGE_EXTENSIONS = {
+    ".avif",
+    ".bmp",
+    ".gif",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".svg",
+    ".tif",
+    ".tiff",
+    ".webp",
+}
+GENERATED_BINARY_IMAGE_EXTENSIONS = IMAGE_EXTENSIONS - {".svg"}
+
+MARKDOWN_LINK_START_RE = re.compile(r"(!?)\[([^\]]*)\]\(")
+REFERENCE_DEFINITION_RE = re.compile(
+    r"^\s*\[([^\]]+)\]:\s*(?:<([^>]+)>|(\S+))", re.MULTILINE
+)
+REFERENCE_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\[([^\]]*)\]")
+HTML_IMAGE_RE = re.compile(
+    r"<img\b[^>]*?\b(?:src|data-src)\s*=\s*([\"'])(.*?)\1[^>]*>",
+    re.IGNORECASE | re.DOTALL,
+)
+HUGO_IMAGE_RE = re.compile(
+    r"\b(?:img_src|image|src)\s*=\s*([\"'])(.*?)\1", re.IGNORECASE
+)
+FRONT_MATTER_IMAGE_RE = re.compile(
+    r"^\s*(?:cover|diagram|diagram_blowup|image|thumbnail)\s*:\s*"
+    r"(?:[\"']([^\"']+)[\"']|(\S+))\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+LOCAL_IMAGE_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9_.-])"
+    r"((?:/|\./|\.\./)?[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*"
+    r"\.(?:avif|bmp|gif|jpe?g|png|svg|tiff?|webp))"
+    r"(?:[?#][^\s\"'<>)]*)?",
+    re.IGNORECASE,
+)
+GENERATED_IMAGE_TOKEN_RE = re.compile(
+    r"(?P<target>"
+    r"(?:(?:https?:)?//[^\s\"'<>]+?\.(?:avif|bmp|gif|jpe?g|png|svg|tiff?|webp)"
+    r"|(?:/|\./|\.\./)?[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*"
+    r"\.(?:avif|bmp|gif|jpe?g|png|svg|tiff?|webp))"
+    r"(?:[?#][^\s\"'<>)]*)?)",
+    re.IGNORECASE,
+)
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+INLINE_CODE_RE = re.compile(r"(`+)(.+?)\1")
+URL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    files: dict[str, str]
+    text: dict[str, str]
+    scopes: tuple[str, ...] = DEFAULT_PATHS
+
+
+@dataclass(frozen=True)
+class Reference:
+    source: str
+    line: int
+    target: str
+    kind: str
+    explicit: bool = True
+
+
+@dataclass(frozen=True)
+class Problem:
+    kind: str
+    path: str
+    line: int = 0
+    target: str = ""
+    resolved: str = ""
+    matches: tuple[str, ...] = ()
+    replacement: str = ""
+    detail: str = ""
+
+    def identity(self) -> tuple:
+        """Return a line-number-independent identity for problem deduplication."""
+        if self.kind == "orphan":
+            return (self.kind, self.path)
+        return (
+            self.kind,
+            self.path,
+            self.target,
+            self.resolved,
+            self.matches,
+            self.replacement,
+            self.detail,
+        )
+
+
+@dataclass(frozen=True)
+class Change:
+    kind: str
+    path: str
+    line: int = 0
+    before: str = ""
+    after: str = ""
+
+
+@dataclass
+class Analysis:
+    tracked_images: int
+    referenced_images: int
+    orphan_images: list[str]
+    safe_delete_images: list[str]
+    needs_review_images: list[str]
+    duplicate_orphans: dict[str, tuple[str, ...]]
+    generated_site_checked: bool
+    problems: list[Problem]
+
+    def all_problems(self) -> list[Problem]:
+        safe = set(self.safe_delete_images)
+        orphan_problems: list[Problem] = []
+        for path in self.orphan_images:
+            matches = self.duplicate_orphans.get(path, ())
+            if path not in safe:
+                detail = "needs review because evidence is incomplete or ambiguous"
+            elif matches:
+                detail = (
+                    "delete only this unreferenced path; byte-identical referenced "
+                    "copies are kept"
+                )
+            else:
+                detail = (
+                    "not referenced in tracked source or the rendered site; "
+                    "safe deletion proposal"
+                )
+            orphan_problems.append(
+                Problem(
+                    kind="orphan",
+                    path=path,
+                    matches=matches,
+                    detail=detail,
+                )
+            )
+        return sorted(
+            self.problems + orphan_problems,
+            key=problem_sort_key,
+        )
+
+
+def run_git(repo_root: Path, args: Sequence[str], *, text: bool = False) -> bytes | str:
+    command = ["git", "-C", str(repo_root), *args]
+    try:
+        return subprocess.check_output(command, text=text)
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(f"Git command failed: {' '.join(command)}") from error
+
+
+def path_in_scopes(path: str, scopes: Sequence[str]) -> bool:
+    return any(path == scope or path.startswith(scope.rstrip("/") + "/") for scope in scopes)
+
+
+def is_image_path(path: str) -> bool:
+    return PurePosixPath(path).suffix.lower() in IMAGE_EXTENSIONS
+
+
+def is_probably_text(data: bytes) -> bool:
+    return b"\0" not in data
+
+
+def tracked_file_oids(repo_root: Path) -> dict[str, str]:
+    """Return stage-zero tracked paths and blob IDs without reading file contents."""
+    raw = run_git(repo_root, ["ls-files", "-s", "-z"])
+    assert isinstance(raw, bytes)
+    tracked: dict[str, str] = {}
+
+    for record in raw.decode("utf-8").split("\0"):
+        if not record:
+            continue
+        metadata, path = record.split("\t", 1)
+        _mode, oid, stage = metadata.split()
+        if stage != "0":
+            continue
+        tracked[path] = oid
+    return tracked
+
+
+def current_snapshot(repo_root: Path, scopes: Sequence[str]) -> Snapshot:
+    tracked = tracked_file_oids(repo_root)
+    files = {path: oid for path, oid in tracked.items() if path_in_scopes(path, scopes)}
+    text_entries = [
+        (path, oid) for path, oid in tracked.items() if not is_image_path(path)
+    ]
+
+    text_files: dict[str, str] = {}
+    for path, oid in text_entries:
+        file_path = repo_root / path
+        try:
+            data = file_path.read_bytes()
+        except OSError:
+            blob = run_git(repo_root, ["show", f":{path}"])
+            assert isinstance(blob, bytes)
+            data = blob
+        if is_probably_text(data):
+            text_files[path] = data.decode("utf-8", errors="replace")
+
+    return Snapshot(files=files, text=text_files, scopes=tuple(scopes))
+
+
+def mask_fenced_code(text: str) -> str:
+    """Mask fenced code while preserving offsets and line numbers."""
+    masked: list[str] = []
+    active_marker = ""
+
+    for line in text.splitlines(keepends=True):
+        match = FENCE_RE.match(line)
+        marker = match.group(1) if match else ""
+        if not active_marker and marker:
+            active_marker = marker
+            masked.append(" " * (len(line) - line.count("\n")) + "\n" * line.count("\n"))
+            continue
+        if active_marker:
+            masked.append(" " * (len(line) - line.count("\n")) + "\n" * line.count("\n"))
+            if marker and marker[0] == active_marker[0] and len(marker) >= len(active_marker):
+                active_marker = ""
+            continue
+        masked.append(line)
+
+    joined = "".join(masked)
+    return INLINE_CODE_RE.sub(lambda match: " " * len(match.group(0)), joined)
+
+
+def line_number(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def find_closing_parenthesis(text: str, start: int) -> int | None:
+    depth = 1
+    quote = ""
+    escaped = False
+
+    for index in range(start, len(text)):
+        char = text[index]
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if quote:
+            if char == quote:
+                quote = ""
+            continue
+        if char in {'"', "'"}:
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def parse_markdown_destination(value: str) -> tuple[str, str | None]:
+    content = value.strip()
+    if not content:
+        return "", "missing image destination"
+
+    if content.startswith("<"):
+        closing = content.find(">")
+        if closing < 0:
+            return "", "unterminated angle-bracket destination"
+        target = content[1:closing]
+        remainder = content[closing + 1 :].strip()
+    else:
+        match = re.match(r"(?:\\.|\S)+", content)
+        if not match:
+            return "", "missing image destination"
+        target = match.group(0)
+        remainder = content[match.end() :].strip()
+
+    if not remainder:
+        return target, None
+
+    valid_title = (
+        len(remainder) >= 2
+        and (
+            (remainder[0] == remainder[-1] and remainder[0] in {'"', "'"})
+            or (remainder[0] == "(" and remainder[-1] == ")")
+        )
+    )
+    if not valid_title:
+        return target, "invalid text after the image destination"
+    return target, None
+
+
+def extract_markdown_references(source: str, text: str) -> tuple[list[Reference], list[Problem]]:
+    visible_text = mask_fenced_code(text)
+    references: list[Reference] = []
+    problems: list[Problem] = []
+
+    for match in MARKDOWN_LINK_START_RE.finditer(visible_text):
+        closing = find_closing_parenthesis(visible_text, match.end())
+        source_line = line_number(visible_text, match.start())
+        if closing is None:
+            if match.group(1):
+                line_end = visible_text.find("\n", match.end())
+                if line_end < 0:
+                    line_end = len(visible_text)
+                probable_target, _error = parse_markdown_destination(
+                    visible_text[match.end() : line_end]
+                )
+                problems.append(
+                    Problem(
+                        kind="malformed_markdown",
+                        path=source,
+                        line=source_line,
+                        target=probable_target,
+                        detail="image destination is not closed",
+                    )
+                )
+            continue
+
+        target, error = parse_markdown_destination(visible_text[match.end() : closing])
+        target_is_image = bool(
+            target and is_image_path(target.split("?", 1)[0].split("#", 1)[0])
+        )
+        if error and (match.group(1) or target_is_image):
+            problems.append(
+                Problem(
+                    kind="malformed_markdown",
+                    path=source,
+                    line=source_line,
+                    target=target,
+                    detail=error,
+                )
+            )
+        if target_is_image:
+            references.append(
+                Reference(
+                    source=source,
+                    line=source_line,
+                    target=target,
+                    kind="markdown_image" if match.group(1) else "markdown_link",
+                )
+            )
+
+    definitions: dict[str, tuple[str, int]] = {}
+    for match in REFERENCE_DEFINITION_RE.finditer(visible_text):
+        target = match.group(2) or match.group(3) or ""
+        definitions[match.group(1).strip().lower()] = (
+            target,
+            line_number(visible_text, match.start()),
+        )
+    for match in REFERENCE_IMAGE_RE.finditer(visible_text):
+        label = (match.group(2) or match.group(1)).strip().lower()
+        if label in definitions:
+            target, _definition_line = definitions[label]
+            references.append(
+                Reference(
+                    source=source,
+                    line=line_number(visible_text, match.start()),
+                    target=target,
+                    kind="markdown_reference_image",
+                )
+            )
+
+    for match in HTML_IMAGE_RE.finditer(visible_text):
+        references.append(
+            Reference(
+                source=source,
+                line=line_number(visible_text, match.start()),
+                target=match.group(2),
+                kind="html_image",
+            )
+        )
+
+    for match in HUGO_IMAGE_RE.finditer(visible_text):
+        references.append(
+            Reference(
+                source=source,
+                line=line_number(visible_text, match.start()),
+                target=match.group(2),
+                kind="hugo_image",
+            )
+        )
+
+    front_matter = extract_front_matter(text)
+    if front_matter:
+        for match in FRONT_MATTER_IMAGE_RE.finditer(front_matter):
+            references.append(
+                Reference(
+                    source=source,
+                    line=line_number(front_matter, match.start()) + 1,
+                    target=match.group(1) or match.group(2),
+                    kind="front_matter_image",
+                )
+            )
+
+    return references, problems
+
+
+def extract_front_matter(text: str) -> str:
+    if not text.startswith("---"):
+        return ""
+    lines = text.splitlines(keepends=True)
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            return "".join(lines[1:index])
+    return ""
+
+
+def extract_conservative_references(source: str, text: str) -> list[Reference]:
+    """Reserve any exact local image path mentioned in tracked text.
+
+    These references prevent unsafe deletion but do not produce missing-image
+    findings because paths inside examples and commands may be generated later.
+    """
+    return [
+        Reference(
+            source=source,
+            line=line_number(text, match.start()),
+            target=match.group(1),
+            kind="text_path",
+            explicit=False,
+        )
+        for match in LOCAL_IMAGE_TOKEN_RE.finditer(text)
+    ]
+
+
+def normalize_target(source: str, target: str) -> str | None:
+    value = target.strip().replace("\\ ", " ")
+    if value.startswith("<") and value.endswith(">"):
+        value = value[1:-1]
+    parsed = urlparse(value)
+    if parsed.scheme or value.startswith(("#", "$", "~")) or URL_SCHEME_RE.match(value):
+        return None
+
+    value = unquote(value.split("#", 1)[0].split("?", 1)[0])
+    if not value or "\\" in value:
+        return None
+
+    if value.startswith("content/"):
+        resolved = value
+    elif value.startswith("/"):
+        resolved = "content/" + value.lstrip("/")
+    else:
+        resolved = posixpath.join(posixpath.dirname(source), value)
+    normalized = posixpath.normpath(resolved)
+    if normalized == ".." or normalized.startswith("../"):
+        return None
+    return normalized
+
+
+def suggested_missing_asset(source: str, resolved: str, assets: set[str]) -> str:
+    """Return a unique nearby asset for an obviously mistyped reference.
+
+    Suggestions stay inside the content unit containing the Markdown source.
+    This repairs cases such as a wrong extension or an accidental site-root
+    path without guessing between similarly named assets elsewhere.
+    """
+    source_directory = posixpath.dirname(source)
+    nearby = [
+        asset
+        for asset in assets
+        if asset.startswith(source_directory.rstrip("/") + "/")
+    ]
+    missing_name = PurePosixPath(resolved).name.casefold()
+    same_name = [
+        asset for asset in nearby if PurePosixPath(asset).name.casefold() == missing_name
+    ]
+    if len(same_name) == 1:
+        return same_name[0]
+
+    missing_stem = PurePosixPath(resolved).stem.casefold()
+    same_stem = [
+        asset for asset in nearby if PurePosixPath(asset).stem.casefold() == missing_stem
+    ]
+    return same_stem[0] if len(same_stem) == 1 else ""
+
+
+def target_for_asset(
+    source: str,
+    original: str,
+    asset: str,
+    *,
+    preserve_site_root: bool = False,
+) -> str:
+    """Format a tracked asset path for use from a source Markdown file."""
+    suffix_match = re.search(r"[?#]", original)
+    suffix = original[suffix_match.start() :] if suffix_match else ""
+    original_path = original[: suffix_match.start()] if suffix_match else original
+
+    if preserve_site_root and original_path.startswith("/") and asset.startswith("content/"):
+        rendered = "/" + asset.removeprefix("content/")
+    else:
+        rendered = posixpath.relpath(asset, posixpath.dirname(source))
+        if original_path.startswith(("./", "/")) and not rendered.startswith("."):
+            rendered = "./" + rendered
+    return rendered + suffix
+
+
+MALFORMED_DUPLICATE_IMAGE_RE = re.compile(
+    r"^(?P<indent>\s*)!\[(?P<alt>[^\]]+)\]\("
+    r"(?P<target><[^>]+>|\S+)\s+"
+    r"(?P<quote>[\"'])(?P<title>.*?)(?P=quote)"
+    r"(?P<duplicated>.+)\]\((?P=target)\s+"
+    r"(?P=quote)(?P=title)(?P=quote)\)(?P<trailing>\s*)$"
+)
+
+
+def repair_duplicated_image_line(line: str) -> str | None:
+    """Repair the known duplicated-alt-text Markdown corruption pattern."""
+    newline = "\n" if line.endswith("\n") else ""
+    value = line[:-1] if newline else line
+    match = MALFORMED_DUPLICATE_IMAGE_RE.fullmatch(value)
+    if not match:
+        return None
+    quote = match.group("quote")
+    return (
+        f'{match.group("indent")}![{match.group("alt")}]'
+        f'({match.group("target")} {quote}{match.group("title")}{quote})'
+        f'{match.group("trailing")}{newline}'
+    )
+
+
+def normalize_generated_target(source: str, target: str) -> str | None:
+    """Map an image URL in generated output back to a content repository path."""
+    value = target.strip()
+    parsed = urlparse(value if not value.startswith("//") else "https:" + value)
+    if parsed.scheme:
+        if parsed.scheme not in {"http", "https"}:
+            return None
+        value = parsed.path
+    value = unquote(value.split("#", 1)[0].split("?", 1)[0])
+    if not value or value.startswith("#"):
+        return None
+    if value.startswith("/"):
+        public_path = value.lstrip("/")
+    else:
+        public_path = posixpath.join(posixpath.dirname(source), value)
+    normalized = posixpath.normpath(public_path)
+    if normalized == ".." or normalized.startswith("../"):
+        return None
+    return "content/" + normalized
+
+
+def generated_site_references(
+    site_root: Path,
+    assets: set[str],
+    progress: Callable[[str], None] | None = None,
+) -> set[str]:
+    """Return tracked content assets referenced by rendered site text."""
+    if not site_root.is_dir():
+        raise SystemExit(f"Generated site directory does not exist: {site_root}")
+
+    by_casefold: dict[str, list[str]] = defaultdict(list)
+    for asset in assets:
+        by_casefold[asset.casefold()].append(asset)
+
+    used: set[str] = set()
+    found_html = False
+    files_seen = 0
+    text_files_scanned = 0
+    for path in sorted(site_root.rglob("*")):
+        if not path.is_file():
+            continue
+        files_seen += 1
+        if progress and files_seen % 1000 == 0:
+            progress(f"Examined {files_seen} rendered files...")
+        if path.suffix.lower() == ".html":
+            found_html = True
+        if path.suffix.lower() in GENERATED_BINARY_IMAGE_EXTENSIONS:
+            continue
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        if not is_probably_text(data):
+            continue
+        text_files_scanned += 1
+        text = data.decode("utf-8", errors="replace")
+        source = path.relative_to(site_root).as_posix()
+        for match in GENERATED_IMAGE_TOKEN_RE.finditer(text):
+            resolved = normalize_generated_target(source, match.group("target"))
+            if not resolved:
+                continue
+            if resolved in assets:
+                used.add(resolved)
+            else:
+                used.update(by_casefold.get(resolved.casefold(), []))
+    if progress:
+        progress(
+            f"Rendered-site scan checked {text_files_scanned} text files "
+            f"and skipped {files_seen - text_files_scanned} non-text files."
+        )
+    if not found_html:
+        raise SystemExit(
+            f"Generated site contains no HTML files; refusing confidence upgrade: {site_root}"
+        )
+    return used
+
+
+def analyze(
+    snapshot: Snapshot,
+    generated_used: set[str] | None = None,
+) -> Analysis:
+    assets = {path for path in snapshot.files if is_image_path(path)}
+    by_casefold: dict[str, list[str]] = defaultdict(list)
+    for asset in assets:
+        by_casefold[asset.casefold()].append(asset)
+
+    used: set[str] = set()
+    problems: list[Problem] = []
+    seen_problems: set[tuple] = set()
+
+    for source, text in snapshot.text.items():
+        if path_in_scopes(source, snapshot.scopes):
+            explicit_references, malformed = extract_markdown_references(source, text)
+        else:
+            explicit_references, malformed = [], []
+        for problem in malformed:
+            add_problem(problems, seen_problems, problem)
+
+        references = explicit_references + extract_conservative_references(source, text)
+        for reference in references:
+            resolved = normalize_target(source, reference.target)
+            if not resolved or not is_image_path(resolved):
+                continue
+            if not reference.explicit and not path_in_scopes(resolved, snapshot.scopes):
+                continue
+            if resolved in assets:
+                used.add(resolved)
+                continue
+
+            case_matches = tuple(sorted(by_casefold.get(resolved.casefold(), [])))
+            if case_matches:
+                used.update(case_matches)
+                if reference.explicit:
+                    add_problem(
+                        problems,
+                        seen_problems,
+                        Problem(
+                            kind="case_mismatch",
+                            path=source,
+                            line=reference.line,
+                            target=reference.target,
+                            resolved=resolved,
+                            matches=case_matches,
+                        ),
+                    )
+                continue
+
+            if reference.explicit:
+                replacement = suggested_missing_asset(source, resolved, assets)
+                add_problem(
+                    problems,
+                    seen_problems,
+                    Problem(
+                        kind="missing_image",
+                        path=source,
+                        line=reference.line,
+                        target=reference.target,
+                        resolved=resolved,
+                        replacement=replacement,
+                    ),
+                )
+
+    if generated_used is not None:
+        used.update(generated_used & assets)
+
+    orphan_images = sorted(assets - used)
+    used_by_oid: dict[str, list[str]] = defaultdict(list)
+    for path in used:
+        used_by_oid[snapshot.files[path]].append(path)
+    duplicate_orphans = {
+        path: tuple(sorted(used_by_oid[snapshot.files[path]]))
+        for path in orphan_images
+        if snapshot.files[path] in used_by_oid
+    }
+
+    ambiguous_directories = {
+        posixpath.dirname(problem.path).rstrip("/") + "/"
+        for problem in problems
+        if problem.kind == "missing_image" and not problem.replacement
+    }
+    ambiguous = {
+        path
+        for path in orphan_images
+        if any(path.startswith(directory) for directory in ambiguous_directories)
+    }
+    ambiguous.update(
+        problem.replacement
+        for problem in problems
+        if problem.kind == "missing_image" and problem.replacement in assets
+    )
+    if generated_used is None:
+        safe_delete = set(duplicate_orphans) - ambiguous
+    else:
+        safe_delete = set(orphan_images) - ambiguous
+    needs_review = set(orphan_images) - safe_delete
+
+    return Analysis(
+        tracked_images=len(assets),
+        referenced_images=len(used),
+        orphan_images=orphan_images,
+        safe_delete_images=sorted(safe_delete),
+        needs_review_images=sorted(needs_review),
+        duplicate_orphans=duplicate_orphans,
+        generated_site_checked=generated_used is not None,
+        problems=sorted(problems, key=problem_sort_key),
+    )
+
+
+def apply_safe_reference_fixes(repo_root: Path, analysis: Analysis) -> list[Change]:
+    """Apply only deterministic repairs and return the changes made."""
+    by_source: dict[str, list[Problem]] = defaultdict(list)
+    for problem in analysis.problems:
+        if problem.kind in {"malformed_markdown", "case_mismatch", "missing_image"}:
+            by_source[problem.path].append(problem)
+
+    changes: list[Change] = []
+    for source, problems in sorted(by_source.items()):
+        source_path = repo_root / source
+        lines = source_path.read_text(encoding="utf-8").splitlines(keepends=True)
+
+        for problem in sorted(problems, key=lambda item: item.line, reverse=True):
+            if problem.line < 1 or problem.line > len(lines):
+                continue
+            index = problem.line - 1
+            original_line = lines[index]
+
+            if problem.kind == "malformed_markdown":
+                repaired = repair_duplicated_image_line(original_line)
+                if repaired is None or repaired == original_line:
+                    continue
+                lines[index] = repaired
+                changes.append(
+                    Change(
+                        kind="fixed_malformed_markdown",
+                        path=source,
+                        line=problem.line,
+                        before=original_line.rstrip("\n"),
+                        after=repaired.rstrip("\n"),
+                    )
+                )
+                continue
+
+            asset = ""
+            preserve_site_root = False
+            if problem.kind == "case_mismatch" and len(problem.matches) == 1:
+                asset = problem.matches[0]
+                preserve_site_root = True
+            elif problem.kind == "missing_image" and problem.replacement:
+                asset = problem.replacement
+            if not asset:
+                continue
+
+            replacement_target = target_for_asset(
+                source,
+                problem.target,
+                asset,
+                preserve_site_root=preserve_site_root,
+            )
+            if original_line.count(problem.target) != 1:
+                continue
+            repaired = original_line.replace(problem.target, replacement_target, 1)
+            if repaired == original_line:
+                continue
+            lines[index] = repaired
+            changes.append(
+                Change(
+                    kind=(
+                        "fixed_case_mismatch"
+                        if problem.kind == "case_mismatch"
+                        else "fixed_missing_reference"
+                    ),
+                    path=source,
+                    line=problem.line,
+                    before=problem.target,
+                    after=replacement_target,
+                )
+            )
+
+        source_path.write_text("".join(lines), encoding="utf-8")
+
+    return sorted(changes, key=lambda change: (change.path, change.line, change.kind))
+
+
+def delete_safe_images(
+    repo_root: Path,
+    paths: Sequence[str],
+    tracked_paths: Sequence[str],
+) -> list[Change]:
+    """Remove safe candidates while preserving case-colliding worktree files."""
+    if not paths:
+        return []
+
+    deleting = set(paths)
+    tracked_by_casefold: dict[str, list[str]] = defaultdict(list)
+    for path in tracked_paths:
+        tracked_by_casefold[path.casefold()].append(path)
+
+    index_only = [
+        path
+        for path in paths
+        if any(
+            other not in deleting
+            for other in tracked_by_casefold.get(path.casefold(), [])
+            if other != path
+        )
+    ]
+    index_only_set = set(index_only)
+    regular = [path for path in paths if path not in index_only_set]
+
+    if regular:
+        subprocess.check_call(["git", "-C", str(repo_root), "rm", "-q", "--", *regular])
+    if index_only:
+        subprocess.check_call(
+            ["git", "-C", str(repo_root), "rm", "--cached", "-q", "--", *index_only]
+        )
+
+    return [
+        Change(
+            kind=(
+                "removed_duplicate_index_entry"
+                if path in index_only_set
+                else "deleted_safe_orphan"
+            ),
+            path=path,
+        )
+        for path in paths
+    ]
+
+
+def add_problem(problems: list[Problem], seen: set[tuple], problem: Problem) -> None:
+    occurrence = (problem.identity(), problem.line)
+    if occurrence not in seen:
+        seen.add(occurrence)
+        problems.append(problem)
+
+
+def problem_sort_key(problem: Problem) -> tuple:
+    return (problem.kind, problem.path, problem.line, problem.target, problem.detail)
+
+
+def needs_review_records(analysis: Analysis) -> list[dict[str, object]]:
+    """Describe why each protected orphan needs human review."""
+    records: list[dict[str, object]] = []
+    missing = [problem for problem in analysis.problems if problem.kind == "missing_image"]
+
+    for path in analysis.needs_review_images:
+        related: list[dict[str, object]] = []
+        for problem in missing:
+            source_directory = posixpath.dirname(problem.path).rstrip("/") + "/"
+            if problem.replacement == path:
+                relationship = "unique nearby replacement"
+            elif not problem.replacement and path.startswith(source_directory):
+                relationship = "unresolved image in the same content directory"
+            else:
+                continue
+            related.append(
+                {
+                    "source": problem.path,
+                    "line": problem.line,
+                    "target": problem.target,
+                    "relationship": relationship,
+                }
+            )
+
+        if any(item["relationship"] == "unique nearby replacement" for item in related):
+            reason = "A missing image reference uniquely points to this nearby asset."
+            recommendation = "Fix the related reference before considering deletion."
+        elif related:
+            reason = "An unresolved missing reference exists in the same content directory."
+            recommendation = "Inspect the image and article to decide whether to link or delete it."
+        elif not analysis.generated_site_checked:
+            reason = "Rendered-site evidence is unavailable and this is not an exact duplicate."
+            recommendation = "Run the full rendered audit before making a deletion decision."
+        else:
+            reason = "Available evidence is incomplete or ambiguous."
+            recommendation = "Inspect the image and nearby content before changing it."
+
+        records.append(
+            {
+                "path": path,
+                "reason": reason,
+                "recommendation": recommendation,
+                "related_references": related,
+            }
+        )
+    return records
+
+
+def displayed_review_records(
+    analysis: Analysis,
+    records: Sequence[dict[str, object]],
+) -> tuple[list[dict[str, object]], int]:
+    """Separate actionable review details from candidates awaiting a full audit."""
+    if analysis.generated_site_checked:
+        return list(records), 0
+    displayed = [record for record in records if record["related_references"]]
+    return displayed, len(records) - len(displayed)
+
+
+def analysis_json(
+    analysis: Analysis,
+    problems: Sequence[Problem],
+    changes: Sequence[Change] = (),
+    file_oids: Mapping[str, str] | None = None,
+) -> str:
+    safe_deletion_oids = {
+        path: file_oids[path]
+        for path in analysis.safe_delete_images
+        if file_oids is not None and path in file_oids
+    }
+    return json.dumps(
+        {
+            "summary": {
+                "tracked_images": analysis.tracked_images,
+                "referenced_images": analysis.referenced_images,
+                "orphan_images": len(analysis.orphan_images),
+                "safe_delete_images": len(analysis.safe_delete_images),
+                "needs_review_images": len(analysis.needs_review_images),
+                "duplicate_orphans": len(analysis.duplicate_orphans),
+                "generated_site_checked": analysis.generated_site_checked,
+                "reported_problems": len(problems),
+            },
+            "safe_deletions": analysis.safe_delete_images,
+            "safe_deletion_oids": safe_deletion_oids,
+            "needs_review": needs_review_records(analysis),
+            "problems": [asdict(problem) for problem in problems],
+            "changes": [asdict(change) for change in changes],
+        },
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def cleanup_manifest_paths(
+    baseline_path: Path,
+    tracked_files: Mapping[str, str],
+    scopes: Sequence[str],
+) -> list[str]:
+    """Validate and return rendered-safe paths whose image blobs are unchanged."""
+    try:
+        baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SystemExit(f"Cannot read cleanup manifest {baseline_path}: {error}") from error
+    if not isinstance(baseline, dict):
+        raise SystemExit("Cleanup manifest must be a JSON object")
+
+    errors: list[str] = []
+    summary = baseline.get("summary")
+    if not isinstance(summary, dict) or summary.get("generated_site_checked") is not True:
+        errors.append("manifest was not produced by a rendered-site audit")
+
+    raw_paths = baseline.get("safe_deletions")
+    raw_oids = baseline.get("safe_deletion_oids")
+    if not isinstance(raw_paths, list):
+        errors.append("safe_deletions must be a list")
+        raw_paths = []
+    if not isinstance(raw_oids, dict):
+        errors.append("safe_deletion_oids must be an object")
+        raw_oids = {}
+
+    paths: list[str] = []
+    seen: set[str] = set()
+    for raw_path in raw_paths:
+        if not isinstance(raw_path, str):
+            errors.append("safe_deletions contains a non-string path")
+            continue
+        path = PurePosixPath(raw_path)
+        if path.is_absolute() or ".." in path.parts:
+            errors.append(f"unsafe cleanup path: {raw_path}")
+            continue
+        normalized = path.as_posix()
+        if normalized in seen:
+            errors.append(f"duplicate cleanup path: {normalized}")
+            continue
+        seen.add(normalized)
+        paths.append(normalized)
+
+        if not path_in_scopes(normalized, scopes):
+            errors.append(f"cleanup path is outside the requested scopes: {normalized}")
+        if not is_image_path(normalized):
+            errors.append(f"cleanup path is not a supported image: {normalized}")
+        actual_oid = tracked_files.get(normalized)
+        expected_oid = raw_oids.get(normalized)
+        if actual_oid is None:
+            errors.append(f"cleanup path is no longer tracked: {normalized}")
+        elif not isinstance(expected_oid, str):
+            errors.append(f"cleanup path has no audited blob ID: {normalized}")
+        elif actual_oid != expected_oid:
+            errors.append(f"cleanup path changed after the audit: {normalized}")
+
+    extra_oids = sorted(set(raw_oids) - set(paths))
+    if extra_oids:
+        errors.append(
+            "manifest contains blob IDs for paths outside safe_deletions: "
+            + ", ".join(extra_oids)
+        )
+    if errors:
+        raise SystemExit("Cleanup manifest validation failed:\n- " + "\n- ".join(errors))
+    return paths
+
+
+def verify_cleanup(
+    repo_root: Path,
+    baseline_path: Path,
+    analysis: Analysis,
+) -> list[str]:
+    """Verify that a staged cleanup matches a rendered dry-run exactly."""
+    try:
+        baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        return [f"cannot read cleanup baseline {baseline_path}: {error}"]
+
+    errors: list[str] = []
+    if not baseline.get("summary", {}).get("generated_site_checked"):
+        errors.append("cleanup baseline was not produced by a rendered-site audit")
+    if not analysis.generated_site_checked:
+        errors.append("post-deletion audit did not inspect a rendered site")
+
+    expected = set(baseline.get("safe_deletions", []))
+    raw = run_git(
+        repo_root,
+        [
+            "diff",
+            "--cached",
+            "--name-only",
+            "--diff-filter=D",
+            "-z",
+            "HEAD",
+            "--",
+            *DEFAULT_PATHS,
+        ],
+    )
+    assert isinstance(raw, bytes)
+    actual = {path for path in raw.decode("utf-8").split("\0") if path}
+
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing:
+        errors.append("expected deletions are missing: " + ", ".join(missing))
+    if unexpected:
+        errors.append("unexpected deletions are staged: " + ", ".join(unexpected))
+
+    before_non_orphans = {
+        json.dumps(problem, sort_keys=True)
+        for problem in baseline.get("problems", [])
+        if problem.get("kind") != "orphan"
+    }
+    after_non_orphans = {
+        json.dumps(asdict(problem), sort_keys=True)
+        for problem in analysis.problems
+        if problem.kind != "orphan"
+    }
+    introduced = sorted(after_non_orphans - before_non_orphans)
+    if introduced:
+        errors.append(
+            f"cleanup introduced {len(introduced)} new non-orphan problem(s)"
+        )
+    if analysis.safe_delete_images:
+        errors.append(
+            f"cleanup left {len(analysis.safe_delete_images)} safe deletion(s) behind"
+        )
+    return errors
+
+
+def analysis_text(
+    analysis: Analysis,
+    problems: Sequence[Problem],
+    changes: Sequence[Change] = (),
+) -> str:
+    lines: list[str] = []
+    if changes:
+        lines.extend(["Applied changes", ""])
+        for change in changes:
+            location = change.path + (f":{change.line}" if change.line else "")
+            message = f"- {change.kind}: {location}"
+            if change.before or change.after:
+                message += f" ({change.before} -> {change.after})"
+            lines.append(message)
+        lines.append("")
+
+    lines.extend(
+        [
+            "Image integrity report",
+            "",
+            f"Tracked images: {analysis.tracked_images}",
+            f"Referenced images: {analysis.referenced_images}",
+            f"Current orphan candidates: {len(analysis.orphan_images)}",
+            f"Safe automatic deletions: {len(analysis.safe_delete_images)}",
+            f"Needs review: {len(analysis.needs_review_images)}",
+            f"Exact duplicate orphans: {len(analysis.duplicate_orphans)}",
+            "Generated site checked: "
+            + ("yes" if analysis.generated_site_checked else "no"),
+            f"All detected problems: {len(problems)}",
+        ]
+    )
+
+    review_records = needs_review_records(analysis)
+    displayed_records, awaiting_render = displayed_review_records(
+        analysis,
+        review_records,
+    )
+    if displayed_records:
+        lines.extend(["", f"Current images needing review ({len(displayed_records)})"])
+        for record in displayed_records:
+            lines.append(f"- {record['path']}")
+            lines.append(f"  Reason: {record['reason']}")
+            for related in record["related_references"]:
+                source = related["source"]
+                line = related["line"]
+                target = related["target"]
+                relationship = related["relationship"]
+                lines.append(
+                    f"  Related reference: {source}:{line} -> {target} "
+                    f"({relationship})"
+                )
+            lines.append(f"  Recommended action: {record['recommendation']}")
+    if awaiting_render:
+        lines.extend(
+            [
+                "",
+                f"Awaiting full rendered classification: {awaiting_render}",
+                "Run the full audit before reviewing these candidates individually.",
+            ]
+        )
+
+    if not problems:
+        lines.extend(["", "No actionable image-integrity problems found."])
+        return "\n".join(lines) + "\n"
+
+    grouped: dict[str, list[Problem]] = defaultdict(list)
+    for problem in problems:
+        grouped[problem.kind].append(problem)
+
+    labels = {
+        "case_mismatch": "Filename case mismatches",
+        "malformed_markdown": "Malformed Markdown image references",
+        "missing_image": "Missing referenced images",
+        "orphan": "Unreferenced image candidates",
+    }
+    for kind in sorted(grouped):
+        lines.extend(["", labels.get(kind, kind.replace("_", " ").title())])
+        for problem in grouped[kind]:
+            location = problem.path + (f":{problem.line}" if problem.line else "")
+            message = location
+            if problem.target:
+                message += f" -> {problem.target}"
+            if problem.matches:
+                relationship = (
+                    "referenced byte-identical copies kept"
+                    if problem.kind == "orphan"
+                    else "tracked as"
+                )
+                message += f" ({relationship} {', '.join(problem.matches)})"
+            if problem.replacement:
+                message += f" (safe replacement: {problem.replacement})"
+            if problem.detail:
+                message += f" ({problem.detail})"
+            lines.append(f"- {message}")
+
+    return "\n".join(lines) + "\n"
+
+
+def github_file_link(
+    repository_url: str,
+    revision: str,
+    path: str,
+    line: int = 0,
+) -> str:
+    """Return a Markdown link to a repository file when GitHub context is available."""
+    label = path + (f":{line}" if line else "")
+    if not repository_url or not revision:
+        return f"`{label}`"
+    url = (
+        f"{repository_url.rstrip('/')}/blob/{quote(revision, safe='')}/"
+        f"{quote(path, safe='/')}"
+    )
+    if line:
+        url += f"#L{line}"
+    return f"[`{label}`]({url})"
+
+
+def analysis_markdown(
+    analysis: Analysis,
+    problems: Sequence[Problem],
+    changes: Sequence[Change] = (),
+    repository_url: str = "",
+    revision: str = "",
+) -> str:
+    """Return a GitHub-friendly report with clickable repository paths."""
+    lines = [
+        "### Audit report",
+        "",
+        "| Metric | Count |",
+        "| --- | ---: |",
+        f"| Tracked images | {analysis.tracked_images} |",
+        f"| Referenced images | {analysis.referenced_images} |",
+        f"| Current orphan candidates | {len(analysis.orphan_images)} |",
+        f"| Safe automatic deletions | {len(analysis.safe_delete_images)} |",
+        f"| Needs review | {len(analysis.needs_review_images)} |",
+        f"| Exact duplicate orphans | {len(analysis.duplicate_orphans)} |",
+        "| Generated site checked | "
+        + ("yes" if analysis.generated_site_checked else "no")
+        + " |",
+        f"| All detected problems | {len(problems)} |",
+    ]
+
+    review_records = needs_review_records(analysis)
+    displayed_records, awaiting_render = displayed_review_records(
+        analysis,
+        review_records,
+    )
+    if awaiting_render:
+        lines.append(f"| Awaiting full rendered classification | {awaiting_render} |")
+    if displayed_records:
+        lines.extend(
+            [
+                "",
+                f"### Current images needing review ({len(displayed_records)})",
+                "",
+            ]
+        )
+        for record in displayed_records:
+            path = str(record["path"])
+            lines.append(f"- {github_file_link(repository_url, revision, path)}")
+            lines.append(f"  - **Why:** {record['reason']}")
+            for related in record["related_references"]:
+                source = str(related["source"])
+                line = int(related["line"])
+                target = related["target"]
+                relationship = related["relationship"]
+                source_link = github_file_link(
+                    repository_url,
+                    revision,
+                    source,
+                    line,
+                )
+                lines.append(
+                    f"  - **Related reference:** {source_link} requests `{target}` "
+                    f"({relationship})."
+                )
+            lines.append(f"  - **Recommended action:** {record['recommendation']}")
+    if awaiting_render:
+        lines.extend(
+            [
+                "",
+                f"> **{awaiting_render} additional candidates** are awaiting rendered-site "
+                "evidence. Run the full audit before reviewing them individually.",
+            ]
+        )
+
+    if changes:
+        lines.extend(["", "### Applied changes", ""])
+        for change in changes:
+            link = github_file_link(
+                repository_url,
+                revision,
+                change.path,
+                change.line,
+            )
+            lines.append(f"- `{change.kind}`: {link}")
+
+    lines.extend(["", "### All detected problems", ""])
+    if not problems:
+        lines.append("No actionable image-integrity problems found.")
+        return "\n".join(lines) + "\n"
+
+    grouped: dict[str, list[Problem]] = defaultdict(list)
+    for problem in problems:
+        grouped[problem.kind].append(problem)
+    labels = {
+        "case_mismatch": "Filename case mismatches",
+        "malformed_markdown": "Malformed Markdown image references",
+        "missing_image": "Missing referenced images",
+        "orphan": "Unreferenced image candidates",
+    }
+    for kind in sorted(grouped):
+        lines.extend(["", f"#### {labels.get(kind, kind.replace('_', ' ').title())}", ""])
+        for problem in grouped[kind]:
+            link = github_file_link(
+                repository_url,
+                revision,
+                problem.path,
+                problem.line,
+            )
+            message = f"- {link}"
+            if problem.target:
+                message += f" requests `{problem.target}`"
+            if problem.matches:
+                relationship = (
+                    "referenced byte-identical copies kept"
+                    if kind == "orphan"
+                    else "tracked as"
+                )
+                matches = ", ".join(f"`{match}`" for match in problem.matches)
+                message += f" ({relationship} {matches})"
+            if problem.replacement:
+                message += f" (safe replacement: `{problem.replacement}`)"
+            if problem.detail:
+                message += f" — {problem.detail}"
+            lines.append(message)
+    return "\n".join(lines) + "\n"
+
+
+def cleanup_changes_report(
+    changes: Sequence[Change],
+    output_format: str,
+    repository_url: str = "",
+    revision: str = "",
+) -> str:
+    """Return a report for a manifest application without rerunning the audit."""
+    if output_format == "json":
+        return json.dumps(
+            {"changes": [asdict(change) for change in changes]},
+            indent=2,
+            sort_keys=True,
+        ) + "\n"
+
+    if output_format == "markdown":
+        lines = ["### Applied cleanup manifest", ""]
+        if not changes:
+            lines.append("The verified manifest contained no safe deletions.")
+        else:
+            lines.append(f"Staged {len(changes)} verified image deletion(s).")
+            lines.append("")
+            for change in changes:
+                link = github_file_link(
+                    repository_url,
+                    revision,
+                    change.path,
+                    change.line,
+                )
+                lines.append(f"- `{change.kind}`: {link}")
+        return "\n".join(lines) + "\n"
+
+    lines = ["Applied cleanup manifest", ""]
+    if not changes:
+        lines.append("No safe deletions were present.")
+    else:
+        lines.extend(f"- {change.kind}: {change.path}" for change in changes)
+    return "\n".join(lines) + "\n"
+
+
+def write_cli_output(repo_root: Path, raw_path: str, output: str) -> None:
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = repo_root / path
+    path.write_text(output, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Report malformed, missing, case-mismatched, and unreferenced images."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=list(DEFAULT_PATHS),
+        help="Tracked content directories to inspect.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit with status 1 when reported problems exist.",
+    )
+    parser.add_argument(
+        "--fix-references",
+        action="store_true",
+        help=(
+            "Repair deterministic malformed, case-mismatched, and nearby missing "
+            "image references. Ambiguous references remain unchanged."
+        ),
+    )
+    parser.add_argument(
+        "--generated-site",
+        metavar="DIRECTORY",
+        help=(
+            "Rendered Hugo output to scan as independent usage evidence. "
+            "Relative paths are resolved from the repository root."
+        ),
+    )
+    parser.add_argument(
+        "--delete-safe",
+        action="store_true",
+        help=(
+            "Remove only high-confidence orphan candidates. Without rendered-site "
+            "evidence, only exact duplicates of referenced images qualify."
+        ),
+    )
+    parser.add_argument(
+        "--apply-cleanup",
+        metavar="BASELINE_JSON",
+        help=(
+            "Stage only the safe deletions in a rendered JSON audit after verifying "
+            "that every tracked image still has its audited Git blob ID."
+        ),
+    )
+    parser.add_argument(
+        "--verify-cleanup",
+        metavar="BASELINE_JSON",
+        help=(
+            "Verify that staged image deletions exactly match the safe-deletion "
+            "list from a rendered JSON report and introduce no new reference problems."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json", "markdown"),
+        default="text",
+    )
+    parser.add_argument(
+        "--repository-url",
+        default="",
+        help="Repository URL used to make Markdown report paths clickable.",
+    )
+    parser.add_argument(
+        "--revision",
+        default="",
+        help="Git revision used to make Markdown report paths clickable.",
+    )
+    parser.add_argument("--output", help="Write the report to this file.")
+    parser.add_argument(
+        "--json-output",
+        help="Also write the current analysis as JSON without running a second audit.",
+    )
+    parser.add_argument("--repo-root", default=".")
+    args = parser.parse_args()
+    changing_modes = sum(
+        bool(mode) for mode in (args.fix_references, args.delete_safe, args.apply_cleanup)
+    )
+    if changing_modes > 1:
+        parser.error(
+            "--fix-references, --delete-safe, and --apply-cleanup are mutually exclusive"
+        )
+    if args.verify_cleanup and changing_modes:
+        parser.error("--verify-cleanup cannot be combined with file-changing modes")
+    if args.apply_cleanup and args.generated_site:
+        parser.error("--apply-cleanup uses rendered evidence from its JSON manifest")
+    if args.apply_cleanup and args.json_output:
+        parser.error("--json-output is not available with --apply-cleanup")
+    return args
+
+
+def find_repo_root(raw_root: str) -> Path:
+    root = Path(raw_root).resolve()
+    output = run_git(root, ["rev-parse", "--show-toplevel"], text=True)
+    assert isinstance(output, str)
+    return Path(output.strip()).resolve()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = find_repo_root(args.repo_root)
+    scopes = tuple(PurePosixPath(path).as_posix().rstrip("/") for path in args.paths)
+
+    def progress(message: str) -> None:
+        print(f"[image-integrity] {message}", file=sys.stderr, flush=True)
+
+    if args.apply_cleanup:
+        baseline_path = Path(args.apply_cleanup)
+        if not baseline_path.is_absolute():
+            baseline_path = repo_root / baseline_path
+        tracked_files = tracked_file_oids(repo_root)
+        paths = cleanup_manifest_paths(
+            baseline_path.resolve(),
+            tracked_files,
+            scopes,
+        )
+        progress(f"Applying {len(paths)} blob-verified deletion(s) from the manifest.")
+        changes = delete_safe_images(repo_root, paths, tuple(tracked_files))
+        output = cleanup_changes_report(
+            changes,
+            args.format,
+            args.repository_url,
+            args.revision,
+        )
+        if args.output:
+            write_cli_output(repo_root, args.output, output)
+        else:
+            print(output, end="")
+        return 0
+
+    generated_site: Path | None = None
+    if args.generated_site:
+        generated_site = Path(args.generated_site)
+        if not generated_site.is_absolute():
+            generated_site = repo_root / generated_site
+        generated_site = generated_site.resolve()
+
+    scan_number = 0
+
+    def analyze_current() -> tuple[Snapshot, Analysis]:
+        nonlocal scan_number
+        scan_number += 1
+        started = time.monotonic()
+        progress(f"Starting analysis pass {scan_number}.")
+        snapshot = current_snapshot(repo_root, scopes)
+        generated_used = None
+        if generated_site is not None:
+            assets = {path for path in snapshot.files if is_image_path(path)}
+            generated_used = generated_site_references(
+                generated_site,
+                assets,
+                progress,
+            )
+        result = analyze(snapshot, generated_used)
+        progress(
+            f"Analysis pass {scan_number} completed in "
+            f"{time.monotonic() - started:.1f}s."
+        )
+        return snapshot, result
+
+    current_snapshot_value, current = analyze_current()
+    changes: list[Change] = []
+
+    if args.fix_references:
+        changes.extend(apply_safe_reference_fixes(repo_root, current))
+        current_snapshot_value, current = analyze_current()
+
+    if args.delete_safe:
+        changes.extend(
+            delete_safe_images(
+                repo_root,
+                current.safe_delete_images,
+                tuple(current_snapshot_value.files),
+            )
+        )
+        current_snapshot_value, current = analyze_current()
+
+    reported = current.all_problems()
+    verification_errors: list[str] = []
+    if args.verify_cleanup:
+        baseline_path = Path(args.verify_cleanup)
+        if not baseline_path.is_absolute():
+            baseline_path = repo_root / baseline_path
+        verification_errors = verify_cleanup(
+            repo_root,
+            baseline_path.resolve(),
+            current,
+        )
+
+    json_output = analysis_json(
+        current,
+        reported,
+        changes,
+        current_snapshot_value.files,
+    )
+    if args.format == "json":
+        output = json_output
+    elif args.format == "markdown":
+        output = analysis_markdown(
+            current,
+            reported,
+            changes,
+            args.repository_url,
+            args.revision,
+        )
+    else:
+        output = analysis_text(current, reported, changes)
+
+    if args.output:
+        write_cli_output(repo_root, args.output, output)
+    else:
+        print(output, end="")
+    if args.json_output:
+        write_cli_output(repo_root, args.json_output, json_output)
+
+    for error in verification_errors:
+        print(f"Cleanup verification failed: {error}", file=sys.stderr)
+
+    return 1 if verification_errors or (args.check and reported) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/audit-images/tests/test_orphan_images.py
+++ b/.github/skills/audit-images/tests/test_orphan_images.py
@@ -37,56 +37,6 @@ class OrphanImagesTests(unittest.TestCase):
 
         self.assertEqual(args.format, "markdown")
 
-    def test_snapshot_excludes_entire_draft_learning_path(self) -> None:
-        draft_root = "content/learning-paths/category/draft-example"
-        published_root = "content/learning-paths/category/published-example"
-        tracked = {
-            f"{draft_root}/_index.md": "draft-index",
-            f"{draft_root}/guide.md": "draft-guide",
-            f"{draft_root}/planned.png": "draft-image",
-            f"{published_root}/_index.md": "published-index",
-            f"{published_root}/guide.md": "published-guide",
-            f"{published_root}/used.png": "published-image",
-        }
-
-        with tempfile.TemporaryDirectory() as directory:
-            repository = Path(directory)
-            text_files = {
-                f"{draft_root}/_index.md": "---\ndraft: true\ncascade:\n    draft: true\n---\n",
-                f"{draft_root}/guide.md": "![Incomplete](missing.png)\n",
-                f"{published_root}/_index.md": "---\ndraft: false\n---\n",
-                f"{published_root}/guide.md": "![Published](used.png)\n",
-            }
-            for path, content in text_files.items():
-                destination = repository / path
-                destination.parent.mkdir(parents=True, exist_ok=True)
-                destination.write_text(content, encoding="utf-8")
-
-            with mock.patch.object(
-                orphan_images,
-                "tracked_file_oids",
-                return_value=tracked,
-            ):
-                state = orphan_images.current_snapshot(
-                    repository,
-                    orphan_images.DEFAULT_PATHS,
-                )
-                install_guide_state = orphan_images.current_snapshot(
-                    repository,
-                    ("content/install-guides",),
-                )
-
-        self.assertEqual(state.excluded_draft_learning_paths, (draft_root,))
-        self.assertEqual(install_guide_state.excluded_draft_learning_paths, ())
-        self.assertNotIn(f"{draft_root}/planned.png", state.files)
-        self.assertNotIn(f"{draft_root}/guide.md", state.text)
-        analysis = orphan_images.analyze(state, set())
-        self.assertEqual(analysis.tracked_images, 1)
-        self.assertEqual(analysis.referenced_images, 1)
-        self.assertEqual(analysis.orphan_images, [])
-        self.assertEqual(analysis.problems, [])
-        self.assertEqual(analysis.excluded_draft_learning_paths, 1)
-
     def test_recognizes_repository_reference_formats(self) -> None:
         guide = """---
 diagram: frontmatter.png
@@ -344,30 +294,6 @@ diagram: "quoted-frontmatter.png"
                     baseline,
                     changed,
                     orphan_images.DEFAULT_PATHS,
-                )
-
-    def test_cleanup_manifest_rejects_a_newly_drafted_path(self) -> None:
-        draft_root = "content/learning-paths/category/draft-example"
-        image = f"{draft_root}/unused.png"
-        state = snapshot({image: b"unused"})
-        analysis = orphan_images.analyze(state, set())
-
-        with tempfile.TemporaryDirectory() as directory:
-            baseline = Path(directory) / "before.json"
-            baseline.write_text(
-                orphan_images.analysis_json(
-                    analysis,
-                    analysis.all_problems(),
-                    file_oids=state.files,
-                ),
-                encoding="utf-8",
-            )
-            with self.assertRaisesRegex(SystemExit, "excluded draft Learning Path"):
-                orphan_images.cleanup_manifest_paths(
-                    baseline,
-                    state.files,
-                    orphan_images.DEFAULT_PATHS,
-                    (draft_root,),
                 )
 
     def test_cleanup_verification_accepts_exact_staged_deletions(self) -> None:

--- a/.github/skills/audit-images/tests/test_orphan_images.py
+++ b/.github/skills/audit-images/tests/test_orphan_images.py
@@ -113,15 +113,27 @@ diagram: frontmatter.png
     def test_does_not_parse_unused_reference_formats(self) -> None:
         references, problems = orphan_images.extract_markdown_references(
             "content/learning-paths/category/example/guide.md",
-            """![Reference style][diagram]
+            r"""---
+diagram: "quoted-frontmatter.png"
+---
+
+![Reference style][diagram]
 [diagram]: reference.png
 ![Angle destination](<angle.png>)
 <img data-src="lazy.png" alt="Lazy image">
+[Image download](linked.png)
+{{< tab img_src='single-quoted-shortcode.png' >}}
+![Single-quoted title](single-title.png 'Title')
+![Parenthesized title](parenthesized-title.png (Title))
+![Escaped space](escaped\ path.png)
 """,
         )
 
         self.assertEqual(references, [])
-        self.assertEqual([problem.kind for problem in problems], ["malformed_markdown"])
+        self.assertEqual(
+            [problem.kind for problem in problems],
+            ["malformed_markdown"] * 4,
+        )
 
     def test_malformed_reference_reserves_the_probable_image(self) -> None:
         malformed = (

--- a/.github/skills/audit-images/tests/test_orphan_images.py
+++ b/.github/skills/audit-images/tests/test_orphan_images.py
@@ -332,6 +332,22 @@ diagram: frontmatter.png
         )
         self.assertIn("Current images needing review (1)", report)
 
+    def test_github_file_link_preserves_branch_name_slashes(self) -> None:
+        link = orphan_images.github_file_link(
+            "https://github.com/owner/repository",
+            "automation/image-integrity-cleanup",
+            "content/learning-paths/category/example/guide.md",
+            7,
+        )
+
+        self.assertEqual(
+            link,
+            "[`content/learning-paths/category/example/guide.md:7`]"
+            "(https://github.com/owner/repository/blob/"
+            "automation/image-integrity-cleanup/"
+            "content/learning-paths/category/example/guide.md#L7)",
+        )
+
     def test_generated_site_reference_marks_asset_used(self) -> None:
         image = "content/learning-paths/category/example/rendered.png"
         absolute = "content/learning-paths/category/example/absolute.webp"

--- a/.github/skills/audit-images/tests/test_orphan_images.py
+++ b/.github/skills/audit-images/tests/test_orphan_images.py
@@ -1,0 +1,569 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "orphan_images.py"
+SPEC = importlib.util.spec_from_file_location("orphan_images", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+orphan_images = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = orphan_images
+SPEC.loader.exec_module(orphan_images)
+
+
+def snapshot(files: dict[str, str | bytes]) -> orphan_images.Snapshot:
+    tracked: dict[str, str] = {}
+    text: dict[str, str] = {}
+    for path, content in files.items():
+        data = content.encode("utf-8") if isinstance(content, str) else content
+        tracked[path] = hashlib.sha1(data).hexdigest()
+        if not orphan_images.is_image_path(path):
+            text[path] = data.decode("utf-8")
+    return orphan_images.Snapshot(files=tracked, text=text)
+
+
+class OrphanImagesTests(unittest.TestCase):
+    def test_recognizes_supported_reference_formats(self) -> None:
+        guide = """---
+diagram: frontmatter.png
+---
+
+![Convolution diagram#center](images/conv.jpg "Example of a (7,7) Conv node")
+<img src="images/html.png" alt="HTML example">
+{{< tab img_src="/learning-paths/category/example/images/hugo.webp">}}
+"""
+        analysis = orphan_images.analyze(
+            snapshot(
+                {
+                    "content/learning-paths/category/example/guide.md": guide,
+                    "content/learning-paths/category/example/frontmatter.png": b"frontmatter",
+                    "content/learning-paths/category/example/images/conv.jpg": b"markdown",
+                    "content/learning-paths/category/example/images/html.png": b"html",
+                    "content/learning-paths/category/example/images/hugo.webp": b"hugo",
+                }
+            )
+        )
+
+        self.assertEqual(analysis.orphan_images, [])
+        self.assertEqual(analysis.problems, [])
+        self.assertEqual(analysis.referenced_images, 4)
+
+    def test_malformed_reference_reserves_the_probable_image(self) -> None:
+        malformed = (
+            "![Device dialog#center](./create.webp \"Create dialog\""
+            "duplicated text#center](./create.webp \"Create dialog\")\n"
+        )
+        analysis = orphan_images.analyze(
+            snapshot(
+                {
+                    "content/learning-paths/category/example/guide.md": malformed,
+                    "content/learning-paths/category/example/create.webp": b"image",
+                }
+            )
+        )
+
+        self.assertEqual(analysis.orphan_images, [])
+        self.assertEqual([problem.kind for problem in analysis.problems], ["malformed_markdown"])
+
+    def test_reports_case_mismatch_without_orphaning_the_image(self) -> None:
+        analysis = orphan_images.analyze(
+            snapshot(
+                {
+                    "content/learning-paths/category/example/guide.md": (
+                        "![Architecture#center](images/Architecture.png)\n"
+                    ),
+                    "content/learning-paths/category/example/images/architecture.png": b"image",
+                }
+            )
+        )
+
+        self.assertEqual(analysis.orphan_images, [])
+        self.assertEqual([problem.kind for problem in analysis.problems], ["case_mismatch"])
+
+    def test_reports_missing_rendered_image_but_ignores_code_example(self) -> None:
+        guide = """![Missing#center](missing.png)
+
+`![Inline example](not-rendered.png)`
+
+```html
+<img src="generated-later.png">
+```
+"""
+        analysis = orphan_images.analyze(
+            snapshot({"content/learning-paths/category/example/guide.md": guide})
+        )
+
+        missing = [problem for problem in analysis.problems if problem.kind == "missing_image"]
+        self.assertEqual(len(missing), 1)
+        self.assertEqual(missing[0].target, "missing.png")
+
+    def test_unique_orphan_needs_review_without_generated_site(self) -> None:
+        image = "content/learning-paths/category/example/unused.png"
+        analysis = orphan_images.analyze(snapshot({image: b"unused"}))
+
+        self.assertEqual(analysis.orphan_images, [image])
+        self.assertEqual(analysis.safe_delete_images, [])
+        self.assertEqual(analysis.needs_review_images, [image])
+        report = orphan_images.analysis_text(analysis, [])
+        self.assertIn("Awaiting full rendered classification: 1", report)
+        self.assertNotIn(f"- {image}", report)
+
+    def test_exact_duplicate_orphan_is_safe_without_generated_site(self) -> None:
+        source = "content/learning-paths/category/example/guide.md"
+        used = "content/learning-paths/category/example/used.png"
+        duplicate = "content/learning-paths/category/example/duplicate.png"
+        analysis = orphan_images.analyze(
+            snapshot(
+                {
+                    source: "![Used](used.png)\n",
+                    used: b"same image",
+                    duplicate: b"same image",
+                }
+            )
+        )
+
+        self.assertEqual(analysis.orphan_images, [duplicate])
+        self.assertEqual(analysis.safe_delete_images, [duplicate])
+        self.assertEqual(analysis.duplicate_orphans, {duplicate: (used,)})
+        report = orphan_images.analysis_markdown(
+            analysis,
+            analysis.all_problems(),
+        )
+        self.assertIn("referenced byte-identical copies kept", report)
+        self.assertIn("delete only this unreferenced path", report)
+        self.assertEqual(
+            json.loads(
+                orphan_images.analysis_json(analysis, analysis.all_problems())
+            )["safe_deletions"],
+            [duplicate],
+        )
+
+    def test_rendered_site_evidence_marks_unique_orphan_safe(self) -> None:
+        image = "content/learning-paths/category/example/unused.png"
+        analysis = orphan_images.analyze(snapshot({image: b"unused"}), set())
+
+        self.assertTrue(analysis.generated_site_checked)
+        self.assertEqual(analysis.safe_delete_images, [image])
+        self.assertEqual(analysis.needs_review_images, [])
+
+    def test_unresolved_missing_reference_keeps_nearby_orphan_for_review(self) -> None:
+        source = "content/learning-paths/category/example/guide.md"
+        image = "content/learning-paths/category/example/other.png"
+        analysis = orphan_images.analyze(
+            snapshot({source: "![Missing](expected.png)\n", image: b"other"}),
+            set(),
+        )
+
+        self.assertEqual(analysis.safe_delete_images, [])
+        self.assertEqual(analysis.needs_review_images, [image])
+
+    def test_repairable_missing_candidate_is_protected_until_fixed(self) -> None:
+        source = "content/learning-paths/category/example/guide.md"
+        image = "content/learning-paths/category/example/screenshot.webp"
+        analysis = orphan_images.analyze(
+            snapshot({source: "![Screenshot](screenshot.png)\n", image: b"screen"}),
+            set(),
+        )
+
+        missing = [problem for problem in analysis.problems if problem.kind == "missing_image"]
+        self.assertEqual(missing[0].replacement, image)
+        self.assertEqual(analysis.safe_delete_images, [])
+        self.assertEqual(analysis.needs_review_images, [image])
+
+    def test_reports_current_review_images_when_problem_list_is_empty(self) -> None:
+        source = "content/learning-paths/category/example/guide.md"
+        image = "content/learning-paths/category/example/screenshot.webp"
+        analysis = orphan_images.analyze(
+            snapshot({source: "![Screenshot](screenshot.png)\n", image: b"screen"}),
+            set(),
+        )
+
+        report = orphan_images.analysis_text(analysis, [])
+        structured = json.loads(orphan_images.analysis_json(analysis, []))
+
+        self.assertIn("Current images needing review (1)", report)
+        self.assertIn(image, report)
+        self.assertIn(f"{source}:1 -> screenshot.png", report)
+        self.assertIn("No actionable image-integrity problems found.", report)
+        self.assertEqual(structured["needs_review"][0]["path"], image)
+        self.assertEqual(
+            structured["needs_review"][0]["related_references"][0]["source"],
+            source,
+        )
+
+    def test_json_report_lists_safe_deletion_paths(self) -> None:
+        image = "content/learning-paths/category/example/unused.png"
+        state = snapshot({image: b"unused"})
+        analysis = orphan_images.analyze(state, set())
+
+        structured = json.loads(
+            orphan_images.analysis_json(
+                analysis,
+                analysis.all_problems(),
+                file_oids=state.files,
+            )
+        )
+
+        self.assertEqual(structured["safe_deletions"], [image])
+        self.assertEqual(structured["safe_deletion_oids"], {image: state.files[image]})
+
+    def test_cleanup_manifest_accepts_unchanged_blob_ids(self) -> None:
+        image = "content/learning-paths/category/example/unused.png"
+        state = snapshot({image: b"unused"})
+        analysis = orphan_images.analyze(state, set())
+
+        with tempfile.TemporaryDirectory() as directory:
+            baseline = Path(directory) / "before.json"
+            baseline.write_text(
+                orphan_images.analysis_json(
+                    analysis,
+                    analysis.all_problems(),
+                    file_oids=state.files,
+                ),
+                encoding="utf-8",
+            )
+            paths = orphan_images.cleanup_manifest_paths(
+                baseline,
+                state.files,
+                orphan_images.DEFAULT_PATHS,
+            )
+
+        self.assertEqual(paths, [image])
+
+    def test_cleanup_manifest_rejects_changed_blob_ids(self) -> None:
+        image = "content/learning-paths/category/example/unused.png"
+        state = snapshot({image: b"unused"})
+        analysis = orphan_images.analyze(state, set())
+
+        with tempfile.TemporaryDirectory() as directory:
+            baseline = Path(directory) / "before.json"
+            baseline.write_text(
+                orphan_images.analysis_json(
+                    analysis,
+                    analysis.all_problems(),
+                    file_oids=state.files,
+                ),
+                encoding="utf-8",
+            )
+            changed = {image: "different-blob-id"}
+            with self.assertRaisesRegex(SystemExit, "changed after the audit"):
+                orphan_images.cleanup_manifest_paths(
+                    baseline,
+                    changed,
+                    orphan_images.DEFAULT_PATHS,
+                )
+
+    def test_cleanup_verification_accepts_exact_staged_deletions(self) -> None:
+        image = "content/learning-paths/category/example/unused.png"
+        before = orphan_images.analyze(snapshot({image: b"unused"}), set())
+        after = orphan_images.analyze(snapshot({}), set())
+
+        with tempfile.TemporaryDirectory() as directory:
+            baseline = Path(directory) / "before.json"
+            baseline.write_text(
+                orphan_images.analysis_json(before, before.all_problems()),
+                encoding="utf-8",
+            )
+            with mock.patch.object(
+                orphan_images,
+                "run_git",
+                return_value=(image + "\0").encode("utf-8"),
+            ):
+                errors = orphan_images.verify_cleanup(Path(directory), baseline, after)
+
+        self.assertEqual(errors, [])
+
+    def test_cleanup_verification_rejects_wrong_deletion_and_new_problem(self) -> None:
+        image = "content/learning-paths/category/example/unused.png"
+        source = "content/learning-paths/category/example/guide.md"
+        before = orphan_images.analyze(snapshot({image: b"unused"}), set())
+        after = orphan_images.analyze(
+            snapshot({source: "![Missing](missing.png)\n"}),
+            set(),
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            baseline = Path(directory) / "before.json"
+            baseline.write_text(
+                orphan_images.analysis_json(before, before.all_problems()),
+                encoding="utf-8",
+            )
+            with mock.patch.object(
+                orphan_images,
+                "run_git",
+                return_value=b"content/learning-paths/category/example/other.png\0",
+            ):
+                errors = orphan_images.verify_cleanup(Path(directory), baseline, after)
+
+        self.assertTrue(any("expected deletions are missing" in error for error in errors))
+        self.assertTrue(any("unexpected deletions are staged" in error for error in errors))
+        self.assertTrue(any("new non-orphan problem" in error for error in errors))
+
+    def test_markdown_report_links_review_image_and_source(self) -> None:
+        source = "content/learning-paths/category/example/guide.md"
+        image = "content/learning-paths/category/example/screenshot.webp"
+        analysis = orphan_images.analyze(
+            snapshot({source: "![Screenshot](screenshot.png)\n", image: b"screen"}),
+            set(),
+        )
+
+        report = orphan_images.analysis_markdown(
+            analysis,
+            [],
+            repository_url="https://github.com/owner/repository",
+            revision="abc123",
+        )
+
+        self.assertIn(
+            "https://github.com/owner/repository/blob/abc123/" + image,
+            report,
+        )
+        self.assertIn(
+            "https://github.com/owner/repository/blob/abc123/" + source + "#L1",
+            report,
+        )
+        self.assertIn("Current images needing review (1)", report)
+
+    def test_generated_site_reference_marks_asset_used(self) -> None:
+        image = "content/learning-paths/category/example/rendered.png"
+        absolute = "content/learning-paths/category/example/absolute.webp"
+        with tempfile.TemporaryDirectory() as directory:
+            site = Path(directory)
+            output = site / "learning-paths/category/example/index.html"
+            output.parent.mkdir(parents=True)
+            output.write_text(
+                '<img src="rendered.png">'
+                '<img src="https://learn.arm.com/learning-paths/category/example/absolute.webp">',
+                encoding="utf-8",
+            )
+
+            generated = orphan_images.generated_site_references(site, {image, absolute})
+
+        analysis = orphan_images.analyze(
+            snapshot({image: b"rendered", absolute: b"absolute"}), generated
+        )
+        self.assertEqual(generated, {image, absolute})
+        self.assertEqual(analysis.orphan_images, [])
+
+    def test_generated_site_scan_ignores_paths_embedded_in_binary_assets(self) -> None:
+        image = "content/learning-paths/category/example/unused.png"
+        with tempfile.TemporaryDirectory() as directory:
+            site = Path(directory)
+            (site / "index.html").write_text("<p>No image reference</p>", encoding="utf-8")
+            (site / "copied.png").write_text(
+                "/learning-paths/category/example/unused.png",
+                encoding="utf-8",
+            )
+
+            generated = orphan_images.generated_site_references(site, {image})
+
+        self.assertEqual(generated, set())
+
+    def test_empty_generated_site_cannot_upgrade_confidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(SystemExit):
+                orphan_images.generated_site_references(Path(directory), set())
+
+    def test_repository_text_reserves_an_exact_content_asset(self) -> None:
+        image = "content/learning-paths/category/example/future.png"
+        analysis = orphan_images.analyze(
+            snapshot({"docs/images.md": f"Reserved: {image}\n", image: b"future"})
+        )
+
+        self.assertEqual(analysis.orphan_images, [])
+        self.assertEqual(analysis.problems, [])
+
+    def test_repairs_duplicated_markdown_corruption(self) -> None:
+        malformed = (
+            '![Device dialog#center](./create.webp "Create dialog"'
+            'duplicated text#center](./create.webp "Create dialog")\n'
+        )
+
+        repaired = orphan_images.repair_duplicated_image_line(malformed)
+
+        self.assertEqual(
+            repaired,
+            '![Device dialog#center](./create.webp "Create dialog")\n',
+        )
+
+    def test_applies_unambiguous_case_and_missing_reference_fixes(self) -> None:
+        source = "content/learning-paths/category/example/guide.md"
+        guide = (
+            "![Architecture](images/Architecture.png)\n"
+            "![Title screen](/images/title-screen.jpg)\n"
+        )
+        files = {
+            source: guide,
+            "content/learning-paths/category/example/images/architecture.png": b"diagram",
+            "content/learning-paths/category/example/images/title-screen.jpg": b"screen",
+        }
+        analysis = orphan_images.analyze(snapshot(files))
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source_path = root / source
+            source_path.parent.mkdir(parents=True)
+            source_path.write_text(guide, encoding="utf-8")
+
+            changes = orphan_images.apply_safe_reference_fixes(root, analysis)
+
+            self.assertEqual(len(changes), 2)
+            self.assertEqual(
+                source_path.read_text(encoding="utf-8"),
+                "![Architecture](images/architecture.png)\n"
+                "![Title screen](./images/title-screen.jpg)\n",
+            )
+
+    def test_does_not_guess_between_ambiguous_missing_assets(self) -> None:
+        source = "content/learning-paths/category/example/guide.md"
+        analysis = orphan_images.analyze(
+            snapshot(
+                {
+                    source: "![Diagram](missing/diagram.png)\n",
+                    "content/learning-paths/category/example/one/diagram.png": b"one",
+                    "content/learning-paths/category/example/two/diagram.png": b"two",
+                }
+            )
+        )
+
+        missing = [problem for problem in analysis.problems if problem.kind == "missing_image"]
+        self.assertEqual(len(missing), 1)
+        self.assertEqual(missing[0].replacement, "")
+
+    def test_safe_deletion_preserves_case_colliding_worktree_file(self) -> None:
+        regular = "content/learning-paths/category/example/unused.png"
+        lower = "content/learning-paths/category/example/image.png"
+        upper = "content/learning-paths/category/example/Image.png"
+        with mock.patch.object(orphan_images.subprocess, "check_call") as check_call:
+            changes = orphan_images.delete_safe_images(
+                Path("/repo"),
+                [regular, lower],
+                [regular, lower, upper],
+            )
+
+        self.assertEqual(
+            check_call.call_args_list,
+            [
+                mock.call(["git", "-C", "/repo", "rm", "-q", "--", regular]),
+                mock.call(
+                    ["git", "-C", "/repo", "rm", "--cached", "-q", "--", lower]
+                ),
+            ],
+        )
+        self.assertEqual(
+            [(change.kind, change.path) for change in changes],
+            [
+                ("deleted_safe_orphan", regular),
+                ("removed_duplicate_index_entry", lower),
+            ],
+        )
+
+    def test_cli_writes_both_reports_then_applies_verified_manifest(self) -> None:
+        image = "content/learning-paths/category/example/unused.png"
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory)
+            repository = temporary / "repository"
+            repository.mkdir()
+            subprocess.run(
+                ["git", "init", "-q", str(repository)],
+                check=True,
+            )
+            image_path = repository / image
+            image_path.parent.mkdir(parents=True)
+            image_path.write_bytes(b"unused image")
+            subprocess.run(
+                ["git", "-C", str(repository), "add", image],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repository),
+                    "-c",
+                    "user.name=Image Integrity Test",
+                    "-c",
+                    "user.email=image-integrity@example.invalid",
+                    "commit",
+                    "-qm",
+                    "Add test image",
+                ],
+                check=True,
+            )
+
+            generated_site = temporary / "site"
+            generated_site.mkdir()
+            (generated_site / "index.html").write_text(
+                "<p>No image reference</p>",
+                encoding="utf-8",
+            )
+            markdown_report = temporary / "report.md"
+            json_report = temporary / "report.json"
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    str(SCRIPT_PATH),
+                    "--repo-root",
+                    str(repository),
+                    "--generated-site",
+                    str(generated_site),
+                    "--format",
+                    "markdown",
+                    "--output",
+                    str(markdown_report),
+                    "--json-output",
+                    str(json_report),
+                ],
+            ):
+                self.assertEqual(orphan_images.main(), 0)
+
+            structured = json.loads(json_report.read_text(encoding="utf-8"))
+            self.assertEqual(structured["safe_deletions"], [image])
+            self.assertIn("Safe automatic deletions | 1", markdown_report.read_text())
+
+            changes_report = temporary / "changes.md"
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    str(SCRIPT_PATH),
+                    "--repo-root",
+                    str(repository),
+                    "--apply-cleanup",
+                    str(json_report),
+                    "--format",
+                    "markdown",
+                    "--output",
+                    str(changes_report),
+                ],
+            ):
+                self.assertEqual(orphan_images.main(), 0)
+
+            self.assertFalse(image_path.exists())
+            deleted = subprocess.check_output(
+                [
+                    "git",
+                    "-C",
+                    str(repository),
+                    "diff",
+                    "--cached",
+                    "--name-only",
+                    "--diff-filter=D",
+                ],
+                text=True,
+            ).splitlines()
+            self.assertEqual(deleted, [image])
+            self.assertIn("Staged 1 verified image deletion", changes_report.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/skills/audit-images/tests/test_orphan_images.py
+++ b/.github/skills/audit-images/tests/test_orphan_images.py
@@ -31,13 +31,68 @@ def snapshot(files: dict[str, str | bytes]) -> orphan_images.Snapshot:
 
 
 class OrphanImagesTests(unittest.TestCase):
-    def test_recognizes_supported_reference_formats(self) -> None:
+    def test_cli_defaults_to_markdown_output(self) -> None:
+        with mock.patch.object(sys, "argv", [str(SCRIPT_PATH)]):
+            args = orphan_images.parse_args()
+
+        self.assertEqual(args.format, "markdown")
+
+    def test_snapshot_excludes_entire_draft_learning_path(self) -> None:
+        draft_root = "content/learning-paths/category/draft-example"
+        published_root = "content/learning-paths/category/published-example"
+        tracked = {
+            f"{draft_root}/_index.md": "draft-index",
+            f"{draft_root}/guide.md": "draft-guide",
+            f"{draft_root}/planned.png": "draft-image",
+            f"{published_root}/_index.md": "published-index",
+            f"{published_root}/guide.md": "published-guide",
+            f"{published_root}/used.png": "published-image",
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            repository = Path(directory)
+            text_files = {
+                f"{draft_root}/_index.md": "---\ndraft: true\ncascade:\n    draft: true\n---\n",
+                f"{draft_root}/guide.md": "![Incomplete](missing.png)\n",
+                f"{published_root}/_index.md": "---\ndraft: false\n---\n",
+                f"{published_root}/guide.md": "![Published](used.png)\n",
+            }
+            for path, content in text_files.items():
+                destination = repository / path
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_text(content, encoding="utf-8")
+
+            with mock.patch.object(
+                orphan_images,
+                "tracked_file_oids",
+                return_value=tracked,
+            ):
+                state = orphan_images.current_snapshot(
+                    repository,
+                    orphan_images.DEFAULT_PATHS,
+                )
+                install_guide_state = orphan_images.current_snapshot(
+                    repository,
+                    ("content/install-guides",),
+                )
+
+        self.assertEqual(state.excluded_draft_learning_paths, (draft_root,))
+        self.assertEqual(install_guide_state.excluded_draft_learning_paths, ())
+        self.assertNotIn(f"{draft_root}/planned.png", state.files)
+        self.assertNotIn(f"{draft_root}/guide.md", state.text)
+        analysis = orphan_images.analyze(state, set())
+        self.assertEqual(analysis.tracked_images, 1)
+        self.assertEqual(analysis.referenced_images, 1)
+        self.assertEqual(analysis.orphan_images, [])
+        self.assertEqual(analysis.problems, [])
+        self.assertEqual(analysis.excluded_draft_learning_paths, 1)
+
+    def test_recognizes_repository_reference_formats(self) -> None:
         guide = """---
 diagram: frontmatter.png
 ---
 
 ![Convolution diagram#center](images/conv.jpg "Example of a (7,7) Conv node")
-<img src="images/html.png" alt="HTML example">
 {{< tab img_src="/learning-paths/category/example/images/hugo.webp">}}
 """
         analysis = orphan_images.analyze(
@@ -46,7 +101,6 @@ diagram: frontmatter.png
                     "content/learning-paths/category/example/guide.md": guide,
                     "content/learning-paths/category/example/frontmatter.png": b"frontmatter",
                     "content/learning-paths/category/example/images/conv.jpg": b"markdown",
-                    "content/learning-paths/category/example/images/html.png": b"html",
                     "content/learning-paths/category/example/images/hugo.webp": b"hugo",
                 }
             )
@@ -54,7 +108,20 @@ diagram: frontmatter.png
 
         self.assertEqual(analysis.orphan_images, [])
         self.assertEqual(analysis.problems, [])
-        self.assertEqual(analysis.referenced_images, 4)
+        self.assertEqual(analysis.referenced_images, 3)
+
+    def test_does_not_parse_unused_reference_formats(self) -> None:
+        references, problems = orphan_images.extract_markdown_references(
+            "content/learning-paths/category/example/guide.md",
+            """![Reference style][diagram]
+[diagram]: reference.png
+![Angle destination](<angle.png>)
+<img data-src="lazy.png" alt="Lazy image">
+""",
+        )
+
+        self.assertEqual(references, [])
+        self.assertEqual([problem.kind for problem in problems], ["malformed_markdown"])
 
     def test_malformed_reference_reserves_the_probable_image(self) -> None:
         malformed = (
@@ -112,9 +179,9 @@ diagram: frontmatter.png
         self.assertEqual(analysis.orphan_images, [image])
         self.assertEqual(analysis.safe_delete_images, [])
         self.assertEqual(analysis.needs_review_images, [image])
-        report = orphan_images.analysis_text(analysis, [])
-        self.assertIn("Awaiting full rendered classification: 1", report)
-        self.assertNotIn(f"- {image}", report)
+        report = orphan_images.analysis_markdown(analysis, [])
+        self.assertIn("| Requires review |", report)
+        self.assertIn(image, report)
 
     def test_exact_duplicate_orphan_is_safe_without_generated_site(self) -> None:
         source = "content/learning-paths/category/example/guide.md"
@@ -137,8 +204,8 @@ diagram: frontmatter.png
             analysis,
             analysis.all_problems(),
         )
-        self.assertIn("referenced byte-identical copies kept", report)
-        self.assertIn("delete only this unreferenced path", report)
+        self.assertIn("| Safe-deletion candidate |", report)
+        self.assertIn(duplicate, report)
         self.assertEqual(
             json.loads(
                 orphan_images.analysis_json(analysis, analysis.all_problems())
@@ -186,16 +253,22 @@ diagram: frontmatter.png
             set(),
         )
 
-        report = orphan_images.analysis_text(analysis, [])
+        report = orphan_images.analysis_markdown(analysis, [])
         structured = json.loads(orphan_images.analysis_json(analysis, []))
 
-        self.assertIn("Current images needing review (1)", report)
+        self.assertIn("| Requires review |", report)
         self.assertIn(image, report)
-        self.assertIn(f"{source}:1 -> screenshot.png", report)
-        self.assertIn("No actionable image-integrity problems found.", report)
+        self.assertIn(f"{source}:1", report)
+        self.assertIn("No malformed, missing, or case-mismatched references found.", report)
         self.assertEqual(structured["needs_review"][0]["path"], image)
         self.assertEqual(
-            structured["needs_review"][0]["related_references"][0]["source"],
+            structured["needs_review"][0]["category"],
+            "requires_review",
+        )
+        self.assertNotIn("reason", structured["needs_review"][0])
+        self.assertNotIn("recommendation", structured["needs_review"][0])
+        self.assertEqual(
+            structured["needs_review"][0]["related_sources"][0]["source"],
             source,
         )
 
@@ -259,6 +332,30 @@ diagram: frontmatter.png
                     baseline,
                     changed,
                     orphan_images.DEFAULT_PATHS,
+                )
+
+    def test_cleanup_manifest_rejects_a_newly_drafted_path(self) -> None:
+        draft_root = "content/learning-paths/category/draft-example"
+        image = f"{draft_root}/unused.png"
+        state = snapshot({image: b"unused"})
+        analysis = orphan_images.analyze(state, set())
+
+        with tempfile.TemporaryDirectory() as directory:
+            baseline = Path(directory) / "before.json"
+            baseline.write_text(
+                orphan_images.analysis_json(
+                    analysis,
+                    analysis.all_problems(),
+                    file_oids=state.files,
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(SystemExit, "excluded draft Learning Path"):
+                orphan_images.cleanup_manifest_paths(
+                    baseline,
+                    state.files,
+                    orphan_images.DEFAULT_PATHS,
+                    (draft_root,),
                 )
 
     def test_cleanup_verification_accepts_exact_staged_deletions(self) -> None:
@@ -330,7 +427,7 @@ diagram: frontmatter.png
             "https://github.com/owner/repository/blob/abc123/" + source + "#L1",
             report,
         )
-        self.assertIn("Current images needing review (1)", report)
+        self.assertIn("| Requires review |", report)
 
     def test_github_file_link_preserves_branch_name_slashes(self) -> None:
         link = orphan_images.github_file_link(
@@ -544,7 +641,7 @@ diagram: frontmatter.png
 
             structured = json.loads(json_report.read_text(encoding="utf-8"))
             self.assertEqual(structured["safe_deletions"], [image])
-            self.assertIn("Safe automatic deletions | 1", markdown_report.read_text())
+            self.assertIn("Safe-deletion candidates | 1", markdown_report.read_text())
 
             changes_report = temporary / "changes.md"
             with mock.patch.object(

--- a/.github/workflows/image-integrity.yml
+++ b/.github/workflows/image-integrity.yml
@@ -127,7 +127,7 @@ jobs:
           {
             echo "## Automated image cleanup proposal"
             echo ""
-            echo "This PR deletes **$safe_count** images that have no tracked source reference, no rendered Hugo reference, and no unresolved nearby reference."
+            echo "This PR proposes deleting **$safe_count** safe-deletion candidates. Review every path before merging."
             echo ""
             echo "It leaves **$review_count** ambiguous images untouched for human review. It never writes directly to the default branch and is not configured for auto-merge."
             echo ""
@@ -148,7 +148,7 @@ jobs:
             echo "</details>"
             echo ""
             echo "<details>"
-            echo "<summary>Protected images needing review ($review_count)</summary>"
+            echo "<summary>Images requiring review ($review_count)</summary>"
             echo ""
             jq -r --arg base "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/$GITHUB_SHA/" \
               '.needs_review[].path | "- [`\(.)`](\($base)\(.))"' "$REPORT_JSON"
@@ -215,7 +215,7 @@ jobs:
           if [ "${{ steps.cleanup.outputs.enabled }}" = "true" ] && \
              [ "${{ steps.cleanup-changes.outputs.has_changes }}" != "true" ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "No safe deletion changes were available for a cleanup PR." >> "$GITHUB_STEP_SUMMARY"
+            echo "No safe-deletion candidates were available for a cleanup PR." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload image-integrity report

--- a/.github/workflows/image-integrity.yml
+++ b/.github/workflows/image-integrity.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/image-integrity.yml
+++ b/.github/workflows/image-integrity.yml
@@ -1,0 +1,231 @@
+name: Orphaned images cleanup
+
+on:
+  schedule:
+    - cron: "0 9 1 1,5,9 *"
+  workflow_dispatch:
+    inputs:
+      create_cleanup_pr:
+        description: "Create or update the safe-deletion PR after the full audit"
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: image-integrity-${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  HUGO_VERSION: 0.130.0
+  CLEANUP_BRANCH: automation/image-integrity-cleanup
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-image-integrity:
+    if: >-
+      github.event_name != 'schedule' ||
+      github.repository == 'ArmDeveloperEcosystem/arm-learning-paths'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run image-integrity unit tests
+        run: python3 -m unittest discover -s .github/skills/audit-images/tests -v
+
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+
+      - name: Render the site
+        run: hugo --destination "$RUNNER_TEMP/image-integrity-site"
+
+      - name: Run full rendered audit
+        run: |
+          set -o pipefail
+          python3 .github/skills/audit-images/scripts/orphan_images.py \
+            --generated-site "$RUNNER_TEMP/image-integrity-site" \
+            --format markdown \
+            --json-output "$RUNNER_TEMP/image-integrity-before-cleanup.json" \
+            --repository-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            --revision "$GITHUB_SHA" | \
+            tee image-integrity-report.md
+
+      - name: Decide whether to propose cleanup
+        id: cleanup
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_CREATE_PR: ${{ inputs.create_cleanup_pr }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          enabled=false
+          if [ "$EVENT_NAME" = "schedule" ] || [ "$MANUAL_CREATE_PR" = "true" ]; then
+            if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+              echo "::error::Cleanup PRs must be generated from the default branch."
+              exit 1
+            fi
+            enabled=true
+          fi
+          echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
+
+      - name: Apply the rendered-safe cleanup manifest
+        if: steps.cleanup.outputs.enabled == 'true'
+        id: cleanup-changes
+        run: |
+          set -o pipefail
+          git switch -c "$CLEANUP_BRANCH"
+          python3 .github/skills/audit-images/scripts/orphan_images.py \
+            --apply-cleanup "$RUNNER_TEMP/image-integrity-before-cleanup.json" \
+            --format markdown \
+            --repository-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            --revision "$GITHUB_SHA" | \
+            tee "$RUNNER_TEMP/image-cleanup-changes.md"
+          if git diff --cached --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rebuild the site after proposed deletions
+        if: steps.cleanup-changes.outputs.has_changes == 'true'
+        run: hugo --destination "$RUNNER_TEMP/image-integrity-cleaned-site"
+
+      - name: Verify the proposed deletion set
+        if: steps.cleanup-changes.outputs.has_changes == 'true'
+        run: |
+          set -o pipefail
+          python3 .github/skills/audit-images/scripts/orphan_images.py \
+            --generated-site "$RUNNER_TEMP/image-integrity-cleaned-site" \
+            --verify-cleanup "$RUNNER_TEMP/image-integrity-before-cleanup.json" \
+            --format markdown \
+            --repository-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            --revision "$CLEANUP_BRANCH" | \
+            tee "$RUNNER_TEMP/image-integrity-after-cleanup.md"
+
+      - name: Prepare the cleanup pull request
+        if: steps.cleanup-changes.outputs.has_changes == 'true'
+        env:
+          REPORT_JSON: ${{ runner.temp }}/image-integrity-before-cleanup.json
+          PR_BODY: ${{ runner.temp }}/image-cleanup-pr-body.md
+        run: |
+          safe_count=$(jq '.safe_deletions | length' "$REPORT_JSON")
+          review_count=$(jq '.needs_review | length' "$REPORT_JSON")
+          {
+            echo "## Automated image cleanup proposal"
+            echo ""
+            echo "This PR deletes **$safe_count** images that have no tracked source reference, no rendered Hugo reference, and no unresolved nearby reference."
+            echo ""
+            echo "It leaves **$review_count** ambiguous images untouched for human review. It never writes directly to the default branch and is not configured for auto-merge."
+            echo ""
+            echo "### Verification"
+            echo ""
+            echo "- Full Hugo site built before deletion"
+            echo "- Deleted paths exactly matched the rendered dry-run manifest"
+            echo "- Full Hugo site rebuilt after deletion"
+            echo "- No new non-orphan image-integrity problems were introduced"
+            echo "- Source workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo ""
+            echo "<details>"
+            echo "<summary>Proposed deletions ($safe_count)</summary>"
+            echo ""
+            jq -r --arg base "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/$GITHUB_SHA/" \
+              '.safe_deletions[] | "- [`\(.)`](\($base)\(.))"' "$REPORT_JSON"
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "<details>"
+            echo "<summary>Protected images needing review ($review_count)</summary>"
+            echo ""
+            jq -r --arg base "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/$GITHUB_SHA/" \
+              '.needs_review[].path | "- [`\(.)`](\($base)\(.))"' "$REPORT_JSON"
+            echo ""
+            echo "</details>"
+          } > "$PR_BODY"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Delete images unused by the rendered site"
+          git fetch --no-tags origin \
+            "refs/heads/$CLEANUP_BRANCH:refs/remotes/origin/$CLEANUP_BRANCH" || true
+          git push --force-with-lease origin "HEAD:refs/heads/$CLEANUP_BRANCH"
+
+      - name: Create or update the cleanup pull request
+        if: steps.cleanup-changes.outputs.has_changes == 'true'
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ runner.temp }}/image-cleanup-pr-body.md
+        run: |
+          title="Delete images unused by the rendered site"
+          pr_number=$(gh pr list \
+            --base "$DEFAULT_BRANCH" \
+            --head "$CLEANUP_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+          if [ -n "$pr_number" ]; then
+            jq -n \
+              --arg title "$title" \
+              --rawfile body "$PR_BODY" \
+              '{title: $title, body: $body}' > "$RUNNER_TEMP/pull-request.json"
+            gh api \
+              --method PATCH \
+              "repos/$GITHUB_REPOSITORY/pulls/$pr_number" \
+              --input "$RUNNER_TEMP/pull-request.json" > /dev/null
+          else
+            gh pr create \
+              --base "$DEFAULT_BRANCH" \
+              --head "$CLEANUP_BRANCH" \
+              --title "$title" \
+              --body-file "$PR_BODY"
+          fi
+          pr_url=$(gh pr view "$CLEANUP_BRANCH" --json url --jq '.url')
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Cleanup PR:** $pr_url" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish image-integrity summary
+        if: always()
+        run: |
+          echo "## Image integrity" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Mode:** Full rendered audit" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f image-integrity-report.md ]; then
+            sed -n '1,200p' image-integrity-report.md >> "$GITHUB_STEP_SUMMARY"
+            if [ "$(wc -l < image-integrity-report.md)" -gt 200 ]; then
+              echo "Report truncated to 200 lines. Download the artifact for the complete report." >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "No report was produced. Review the failed step above." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ "${{ steps.cleanup.outputs.enabled }}" = "true" ] && \
+             [ "${{ steps.cleanup-changes.outputs.has_changes }}" != "true" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No safe deletion changes were available for a cleanup PR." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload image-integrity report
+        if: always() && hashFiles('image-integrity-report.md') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-integrity-report
+          path: |
+            image-integrity-report.md
+            ${{ runner.temp }}/image-integrity-before-cleanup.json
+            ${{ runner.temp }}/image-cleanup-changes.md
+            ${{ runner.temp }}/image-integrity-after-cleanup.md
+          retention-days: 14

--- a/.github/workflows/image-integrity.yml
+++ b/.github/workflows/image-integrity.yml
@@ -2,7 +2,7 @@ name: Orphaned images cleanup
 
 on:
   schedule:
-    - cron: "0 9 1 1,5,9 *"
+    - cron: "0 9 1 3,9 *"
   workflow_dispatch:
     inputs:
       create_cleanup_pr:

--- a/content/learning-paths/cross-platform/distributed-ros2-zenoh-lp2/2-connect-the-control-container.md
+++ b/content/learning-paths/cross-platform/distributed-ros2-zenoh-lp2/2-connect-the-control-container.md
@@ -81,11 +81,7 @@ ros2 topic hz /camera/image_raw
 
 Collect several samples and press **Ctrl+C**. The rate should be close to the rate measured in the robot container, since the Docker Network is not a bottleneck.
 
-<!-- ![Control Terminal #center](./ros2-topic-rates.png) -->
-<div style="text-align:center;">
-  <img src="/learning-paths/cross-platform/distributed-ros2-zenoh-lp2/ros2-topic-rates.png" alt="" style="max-width:600px; width:100%;" />
-  <div style="font-style:italic;">Contol terminal showing data transfer rate in Hz</div>
-</div>
+![Control terminal showing data transfer rates in Hz#center](./ros2-topic-rates.png "Control terminal showing data transfer rates in Hz")
 
 {{% notice Note %}}
 This example uses an NVIDIA DGX Spark as the host. Topic rates may vary on other systems, such as AWS Graviton instances.
@@ -101,11 +97,6 @@ just rviz_nav2
 
 RViz now subscribes to the map, transforms, laser scans, costmaps, and robot state across the client connection. The simulation and Navigation2 remain in the robot container.
 
-<!-- IMAGE PLACEHOLDER: Add a screenshot of RViz running in the control container and displaying the simulated ROX robot, map, and laser scan. Suggested filename: control-container-rviz.png -->
-<div style="text-align:center;">
-  <img src="/learning-paths/cross-platform/distributed-ros2-zenoh-lp2/control-container-rviz1.png" alt="" style="max-width:800px; width:100%;" />
-  <div style="font-style:italic;">RViz window opened from the control terminal</div>
-</div>
+![RViz window opened from the control terminal showing the simulated robot, map, and laser scan#center](./control-container-rviz1.png "RViz window opened from the control terminal")
 
 This demonstrates the first distributed boundary: the visualisation process and the simulated robot are in separate container network namespaces, while ROS 2 communication continues through `rmw_zenoh`.
-

--- a/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-alif/1-overview.md
+++ b/content/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-alif/1-overview.md
@@ -13,10 +13,7 @@ layout: learningpathall
 
 The Alif Ensemble E8 DevKit features two dual-core Arm processors (Cortex-A32 and Cortex-M55) and three neural processing units (NPUs): two Ethos-U55s and one Ethos-U85.
 
-<div style="text-align:center;">
-  <img src="/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-alif/alif-ensemble-e8-board-soc-highlighted.jpg" alt="Alif Ensemble E8 DevKit with a red box highlighting the application processor SoC. The overlay identifies two Cortex-A32 cores, two Cortex-M55 cores, one Ethos-U85 NPU, and two Ethos-U55 NPUs." title="Alif Ensemble E8 application processor SoC and integrated Arm cores and NPUs" style="max-width:800px; width:100%;" />
-  <div style="font-style:italic;">Alif Ensemble E8 application processor SoC and integrated Arm cores and NPUs</div>
-</div>
+![Alif Ensemble E8 DevKit with a red box highlighting the application processor SoC. The overlay identifies two Cortex-A32 cores, two Cortex-M55 cores, one Ethos-U85 NPU, and two Ethos-U55 NPUs.#center](./alif-ensemble-e8-board-soc-highlighted.jpg "Alif Ensemble E8 application processor SoC and integrated Arm cores and NPUs")
 
 You'll run an MNIST digit-classification model on the Arm Ethos-U85 NPU. You can either use the provided `.pte` model or follow optional steps to train and export your own MNIST model. 
 


### PR DESCRIPTION
## Summary

This PR adds an orphaned-image audit and GitHub Actions workflow.

It:

- Detects unreferenced images, broken paths, case mismatches, and malformed Markdown.
- Checks both tracked source files and the rendered Hugo site.
- Separates safe deletion candidates from images requiring review.
- Creates a separate cleanup PR instead of deleting directly from `main`.

## Safety

Cleanup uses a blob-verified audit manifest, rebuilds Hugo after proposed deletions, and verifies that no new reference problems were introduced. Ambiguous images remain untouched, and cleanup PRs are never auto-merged.

The workflow supports manual audits and runs automatically at 09:00 UTC on January 1, May 1, and September 1 in the official Arm repository only. We can change and adjust if we have to.

## Validation

- 25 unit tests passed.
- Final report-only workflow passed:  
  https://github.com/sairamvarmabudharaju/arm-learning-paths/actions/runs/32491817078
- Latest audit found 94 safe candidates and 4 images requiring review.
- This PR does not delete any images.

## Repository checklist

Create a Learning Path review: Not applicable — this PR adds repository tooling.

- [x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of the Creative Commons Attribution 4.0 International License.
