### PR TITLE
Add a Learning Path for integrating a KleidiAI SME2 kernel into XNNPACK

### DIFF
--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/0001-prepare-qd8-f16-qc4w-sme2-kernel.patch
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/0001-prepare-qd8-f16-qc4w-sme2-kernel.patch
@@ -1,0 +1,78 @@
+From 32db2b56876ceac0bd4da299b6775e2dddfa5ee3 Mon Sep 17 00:00:00 2001
+From: Qxiang Xu <Qixiang.Xu@arm.com>
+Date: Tue, 25 Aug 2026 10:04:03 +0800
+Subject: [PATCH 1/4] Prepare QD8 F16 QC4W SME2 kernel
+
+---
+ cmake/gen/neonsme2_microkernels.cmake          |  3 ++-
+ gen/neonsme2_microkernels.bzl                  |  1 +
+ ...qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c | 18 ++++++++++++++++++
+ src/xnnpack/gemm.h                             |  3 +++
+ 4 files changed, 24 insertions(+), 1 deletion(-)
+ create mode 100644 src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c
+
+diff --git a/cmake/gen/neonsme2_microkernels.cmake b/cmake/gen/neonsme2_microkernels.cmake
+index c349181e17..45d7de4c3c 100644
+--- a/cmake/gen/neonsme2_microkernels.cmake
++++ b/cmake/gen/neonsme2_microkernels.cmake
+@@ -30,6 +30,7 @@ SET(PROD_NEONSME2_MICROKERNEL_SRCS
+   src/x32-pack-lh/x32-packlh-igemm-neonsme2.c
+   src/x32-pack-lh/x32-packlh-neonsme2.c)
+ 
+-SET(NON_PROD_NEONSME2_MICROKERNEL_SRCS)
++SET(NON_PROD_NEONSME2_MICROKERNEL_SRCS
++  src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c)
+ 
+ SET(ALL_NEONSME2_MICROKERNEL_SRCS ${PROD_NEONSME2_MICROKERNEL_SRCS} ${NON_PROD_NEONSME2_MICROKERNEL_SRCS})
+diff --git a/gen/neonsme2_microkernels.bzl b/gen/neonsme2_microkernels.bzl
+index cf22def575..3024cc5b07 100644
+--- a/gen/neonsme2_microkernels.bzl
++++ b/gen/neonsme2_microkernels.bzl
+@@ -28,6 +28,7 @@ PROD_NEONSME2_MICROKERNEL_SRCS = [
+ ]
+ 
+ NON_PROD_NEONSME2_MICROKERNEL_SRCS = [
++    "src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c",
+ ]
+ 
+ ALL_NEONSME2_MICROKERNEL_SRCS = PROD_NEONSME2_MICROKERNEL_SRCS + NON_PROD_NEONSME2_MICROKERNEL_SRCS
+diff --git a/src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c b/src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c
+new file mode 100644
+index 0000000000..9999026148
+--- /dev/null
++++ b/src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c
+@@ -0,0 +1,18 @@
++// Copyright 2026 Google LLC
++//
++// This source code is licensed under the BSD-style license found in the
++// LICENSE file in the root directory of this source tree.
++
++#include <stddef.h>
++
++#if XNN_ENABLE_KLEIDIAI
++#include "kai/ukernels/matmul/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa.h"
++
++size_t xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_mr(void) {
++  return kai_get_mr_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa();
++}
++
++size_t xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_nr(void) {
++  return kai_get_nr_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa();
++}
++#endif  // XNN_ENABLE_KLEIDIAI
+diff --git a/src/xnnpack/gemm.h b/src/xnnpack/gemm.h
+index 146c9970db..9fc4cfa5a8 100644
+--- a/src/xnnpack/gemm.h
++++ b/src/xnnpack/gemm.h
+@@ -4042,6 +4042,9 @@ size_t xnn_qp8_f32_qc4w_gemm_minmax_ukernel_1x64c4__neonsme2_get_nr();
+ size_t xnn_qp8_f32_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_mr();
+ size_t xnn_qp8_f32_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_nr();
+ 
++size_t xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_mr(void);
++size_t xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_nr(void);
++
+ size_t xnn_qp8_f32_qc4w_gemm_minmax_ukernel_1x64c4__neonsme_get_mr();
+ size_t xnn_qp8_f32_qc4w_gemm_minmax_ukernel_1x64c4__neonsme_get_nr();
+ size_t xnn_qp8_f32_qc4w_gemm_minmax_ukernel_16x64c4__neonsme_get_mr();
+-- 
+2.43.0

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/0002-support-transposed-kai-qc4w-weights.patch
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/0002-support-transposed-kai-qc4w-weights.patch
@@ -1,0 +1,50 @@
+From 6eb253c4263e54c1697d77aa0ff00b7c5b95d67d Mon Sep 17 00:00:00 2001
+From: Qxiang Xu <Qixiang.Xu@arm.com>
+Date: Tue, 25 Aug 2026 10:04:48 +0800
+Subject: [PATCH 2/4] Support transposed KAI QC4W weights
+
+---
+ src/reference/packing.cc | 19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/src/reference/packing.cc b/src/reference/packing.cc
+index 97553815fb..3b4a0dbc2b 100644
+--- a/src/reference/packing.cc
++++ b/src/reference/packing.cc
+@@ -11,6 +11,7 @@
+ #include <cstddef>
+ #include <cstdint>
+ #include <cstring>
++#include <vector>
+ 
+ #include "include/xnnpack.h"
+ #include "src/xnnpack/common.h"
+@@ -2552,9 +2553,25 @@ void xnn_pack_kai_qs4_weights_and_biases_sme(
+     extra_data0 = calloc(output_channels, sizeof(float));
+     free_accumulator_init = true;
+   }
++  const uint8_t* rhs = reinterpret_cast<const uint8_t*>(weights);
++  std::vector<uint8_t> transposed_rhs;
++  if (flags & XNN_FLAG_TRANSPOSE_WEIGHTS) {
++    const size_t source_stride = round_up(output_channels, 2) / 2;
++    const size_t destination_stride = round_up(input_channels, 2) / 2;
++    transposed_rhs.resize(output_channels * destination_stride);
++    for (size_t n = 0; n < output_channels; n++) {
++      for (size_t k = 0; k < input_channels; k++) {
++        const uint8_t source = rhs[k * source_stride + n / 2];
++        const uint8_t value = (source >> ((n & 1) * 4)) & 0x0F;
++        transposed_rhs[n * destination_stride + k / 2] |= value << ((k & 1) * 4);
++      }
++    }
++    rhs = transposed_rhs.data();
++  }
++
+   kai_run_rhs_pack_nxk_qsi4cxps1s0_qsu4cxs1s0_neon(
+       groups, output_channels, input_channels, nr, kr, sr,
+-      /*rhs=*/reinterpret_cast<const uint8_t*>(weights),
++      rhs,
+       /*bias=*/reinterpret_cast<const float*>(extra_data0),
+       /*scale=*/reinterpret_cast<const float*>(extra_data1),
+       /*rhs_packed=*/packed_weights_ptr,
+-- 
+2.43.0

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/0003-pack-qd8-lhs-for-kai-sme2.patch
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/0003-pack-qd8-lhs-for-kai-sme2.patch
@@ -1,0 +1,71 @@
+From 4bd031ce80a01e353b28b76fc9c7bf1f8c9aa690 Mon Sep 17 00:00:00 2001
+From: Qxiang Xu <Qixiang.Xu@arm.com>
+Date: Tue, 25 Aug 2026 10:05:08 +0800
+Subject: [PATCH 3/4] Pack QD8 LHS for KAI SME2
+
+---
+ ...d8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c | 45 +++++++++++++++++++
+ 1 file changed, 45 insertions(+)
+
+diff --git a/src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c b/src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c
+index 9999026148..951ff1c994 100644
+--- a/src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c
++++ b/src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c
+@@ -4,6 +4,10 @@
+ // LICENSE file in the root directory of this source tree.
+ 
+ #include <stddef.h>
++#include <stdint.h>
++
++#include "src/xnnpack/math.h"
++#include "src/xnnpack/microparams.h"
+ 
+ #if XNN_ENABLE_KLEIDIAI
+ #include "kai/ukernels/matmul/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa.h"
+@@ -16,3 +20,44 @@ size_t xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_nr(void) {
+   return kai_get_nr_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa();
+ }
+ #endif  // XNN_ENABLE_KLEIDIAI
++
++static size_t lhs_packed_size(
++    size_t m, size_t k, size_t mr) {
++  const size_t k_padded = round_up(k, 32);
++  return round_up(m, mr) *
++      (k_padded * sizeof(int8_t) + sizeof(int32_t) + sizeof(float));
++}
++
++static void pack_lhs(
++    size_t m, size_t k, size_t mr, size_t kr, const int8_t* input, size_t input_stride,
++    const struct xnn_qd8_quantization_params* quantization_params,
++    void* packed_lhs) {
++  const size_t k_padded = round_up(k, 32);
++  const size_t packed_row_size =
++      k_padded * sizeof(int8_t) + sizeof(int32_t) + sizeof(float);
++  int8_t* packed = packed_lhs;
++
++  for (size_t m_start = 0; m_start < m; m_start += mr) {
++    const size_t rows = min(mr, m - m_start);
++    int8_t* values = packed;
++    int32_t* offsets = (int32_t*) (values + mr * k_padded);
++    float* scales = (float*) (offsets + mr);
++
++    for (size_t row = 0; row < mr; row++) {
++      const size_t source_row = m_start + min(row, rows - 1);
++      const int8_t* source = input + source_row * input_stride;
++      const struct xnn_qd8_quantization_params qparams =
++          quantization_params[source_row];
++      for (size_t k_start = 0; k_start < k_padded; k_start += kr) {
++        for (size_t k_offset = 0; k_offset < kr; k_offset++) {
++          values[(k_start / kr) * mr * kr + row * kr + k_offset] =
++              k_start + k_offset < k ? source[k_start + k_offset]
++                                   : (int8_t) qparams.zero_point;
++        }
++      }
++      offsets[row] = -qparams.zero_point;
++      scales[row] = qparams.inv_scale;
++    }
++    packed += mr * packed_row_size;
++  }
++}
+-- 
+2.43.0

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/0004-dispatch-qd8-f16-qc4w-through-kai-sme2.patch
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/0004-dispatch-qd8-f16-qc4w-through-kai-sme2.patch
@@ -1,0 +1,161 @@
+From 5474e582cade0aa80e3bb8045ae9430faa51d2f0 Mon Sep 17 00:00:00 2001
+From: Qxiang Xu <Qixiang.Xu@arm.com>
+Date: Tue, 25 Aug 2026 10:05:42 +0800
+Subject: [PATCH 4/4] Dispatch QD8 F16 QC4W through KAI SME2
+
+---
+ cmake/gen/neonsme2_microkernels.cmake         |  4 +-
+ gen/neonsme2_microkernels.bzl                 |  2 +-
+ src/configs/gemm-config.c                     | 25 +++++++++++
+ ...d8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c | 41 +++++++++++++++++++
+ src/xnnpack/gemm.h                            |  2 +
+ 5 files changed, 71 insertions(+), 3 deletions(-)
+
+diff --git a/cmake/gen/neonsme2_microkernels.cmake b/cmake/gen/neonsme2_microkernels.cmake
+index 45d7de4c3c..66a08721df 100644
+--- a/cmake/gen/neonsme2_microkernels.cmake
++++ b/cmake/gen/neonsme2_microkernels.cmake
+@@ -19,6 +19,7 @@ SET(PROD_NEONSME2_MICROKERNEL_SRCS
+   src/pqs8-f32-qc8w-igemm/pqs8-f32-qc8w-igemm-32x32c4-minmax-neonsme2.c
+   src/pqs8-qc8w-gemm/pqs8-qc8w-gemm-1x32c4-minmax-neonsme2.c
+   src/pqs8-qc8w-gemm/pqs8-qc8w-gemm-32x32c4-minmax-neonsme2.c
++  src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c
+   src/qp8-f32-qc4w-gemm/qp8-f32-qc4w-gemm-minmax-1x64c4-neonsme2.c
+   src/qp8-f32-qc4w-gemm/qp8-f32-qc4w-gemm-minmax-16x64c4-neonsme2.c
+   src/qp8-f32-qc8w-gemm/qp8-f32-qc8w-gemm-minmax-1x64c4-neonsme2.c
+@@ -30,7 +31,6 @@ SET(PROD_NEONSME2_MICROKERNEL_SRCS
+   src/x32-pack-lh/x32-packlh-igemm-neonsme2.c
+   src/x32-pack-lh/x32-packlh-neonsme2.c)
+ 
+-SET(NON_PROD_NEONSME2_MICROKERNEL_SRCS
+-  src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c)
++SET(NON_PROD_NEONSME2_MICROKERNEL_SRCS)
+ 
+ SET(ALL_NEONSME2_MICROKERNEL_SRCS ${PROD_NEONSME2_MICROKERNEL_SRCS} ${NON_PROD_NEONSME2_MICROKERNEL_SRCS})
+diff --git a/gen/neonsme2_microkernels.bzl b/gen/neonsme2_microkernels.bzl
+index 3024cc5b07..cecf32795c 100644
+--- a/gen/neonsme2_microkernels.bzl
++++ b/gen/neonsme2_microkernels.bzl
+@@ -15,6 +15,7 @@ PROD_NEONSME2_MICROKERNEL_SRCS = [
+     "src/pqs8-f32-qc8w-igemm/pqs8-f32-qc8w-igemm-32x32c4-minmax-neonsme2.c",
+     "src/pqs8-qc8w-gemm/pqs8-qc8w-gemm-1x32c4-minmax-neonsme2.c",
+     "src/pqs8-qc8w-gemm/pqs8-qc8w-gemm-32x32c4-minmax-neonsme2.c",
++    "src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c",
+     "src/qp8-f32-qc4w-gemm/qp8-f32-qc4w-gemm-minmax-1x64c4-neonsme2.c",
+     "src/qp8-f32-qc4w-gemm/qp8-f32-qc4w-gemm-minmax-16x64c4-neonsme2.c",
+     "src/qp8-f32-qc8w-gemm/qp8-f32-qc8w-gemm-minmax-1x64c4-neonsme2.c",
+@@ -28,7 +29,6 @@ PROD_NEONSME2_MICROKERNEL_SRCS = [
+ ]
+ 
+ NON_PROD_NEONSME2_MICROKERNEL_SRCS = [
+-    "src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c",
+ ]
+ 
+ ALL_NEONSME2_MICROKERNEL_SRCS = PROD_NEONSME2_MICROKERNEL_SRCS + NON_PROD_NEONSME2_MICROKERNEL_SRCS
+diff --git a/src/configs/gemm-config.c b/src/configs/gemm-config.c
+index 8c1f146a98..b7c9cd2fdf 100644
+--- a/src/configs/gemm-config.c
++++ b/src/configs/gemm-config.c
+@@ -2298,6 +2298,31 @@ static void init_qd8_f16_qc4w_gemm_config(void) {
+     const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
+     assert(hardware_config != NULL);
+     (void) hardware_config;  // May be unused.
++    #if XNN_ENABLE_KLEIDIAI && XNN_ENABLE_ARM_SME2
++    if (hardware_config->arch_flags & xnn_arch_arm_sme2) {
++      const size_t mr =
++          xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_mr();
++      const size_t nr =
++          xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_nr();
++      qd8_f16_qc4w_gemm_config.minmax.dqgemm[XNN_MR_TO_INDEX(1)] =
++          XNN_INIT_HMP_DQGEMM_UKERNEL(
++              xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2);
++      qd8_f16_qc4w_gemm_config.minmax.dqgemm[XNN_MR_TO_INDEX(mr)] =
++          XNN_INIT_HMP_DQGEMM_UKERNEL(
++              xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2);
++      qd8_f16_qc4w_gemm_config.init.f16_qc4w =
++          xnn_init_f16_qc4w_minmax_scalar_params;
++      qd8_f16_qc4w_gemm_config.pack_weights_and_biases =
++          xnn_pack_kai_qs4_weights_and_biases_sme;
++      qd8_f16_qc4w_gemm_config.packed_stride_weights_and_biases =
++          xnn_packed_stride_kai_qs4_weights_and_biases_sme;
++      qd8_f16_qc4w_gemm_config.mr = mr;
++      qd8_f16_qc4w_gemm_config.nr = nr;
++      qd8_f16_qc4w_gemm_config.log2_kr = 2;
++      qd8_f16_qc4w_gemm_config.log2_sr = 0;
++      qd8_f16_qc4w_gemm_config.planes = 2;
++    } else
++    #endif  // XNN_ENABLE_KLEIDIAI && XNN_ENABLE_ARM_SME2
+     if (XNN_ENABLE_ARM_I8MM && (hardware_config->arch_flags & xnn_arch_arm_neon_i8mm)) {
+       #if XNN_ENABLE_ARM_I8MM
+         qd8_f16_qc4w_gemm_config.minmax.dqgemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_DQGEMM_UKERNEL(xnn_qd8_f16_qc4w_gemm_minmax_ukernel_1x16c8__neoni8mm);
+diff --git a/src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c b/src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c
+index 951ff1c994..7625d5491e 100644
+--- a/src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c
++++ b/src/qd8-f16-qc4w-gemm/qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c
+@@ -5,6 +5,7 @@
+ 
+ #include <stddef.h>
+ #include <stdint.h>
++#include <stdlib.h>
+ 
+ #include "src/xnnpack/math.h"
+ #include "src/xnnpack/microparams.h"
+@@ -61,3 +62,43 @@ static void pack_lhs(
+     packed += mr * packed_row_size;
+   }
+ }
++
++void xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2(
++    size_t mr, size_t nr, size_t k, const int8_t* a, size_t a_stride,
++    const void* w, xnn_float16* c, size_t cm_stride, size_t cn_stride,
++    const struct xnn_f16_qc4w_minmax_params* params,
++    const struct xnn_qd8_quantization_params* quantization_params) {
++#if XNN_ENABLE_KLEIDIAI
++  const size_t packed_mr =
++      kai_get_mr_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa();
++  const size_t kr =
++      kai_get_kr_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa();
++  const size_t sr =
++      kai_get_sr_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa();
++  assert(sr == 1);
++  assert(round_up(k, 32) % kr == 0);
++  const size_t packed_lhs_size =
++      lhs_packed_size(mr, k, packed_mr);
++  void* packed_lhs = malloc(packed_lhs_size);
++  assert(packed_lhs != NULL);
++  pack_lhs(mr, k, packed_mr, kr, a, a_stride, quantization_params, packed_lhs);
++  kai_run_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa(
++      mr, nr, k, packed_lhs, w, c, cm_stride, cn_stride,
++      xnn_float16_to_float(params->scalar.min),
++      xnn_float16_to_float(params->scalar.max));
++  free(packed_lhs);
++#else
++  (void) mr;
++  (void) nr;
++  (void) k;
++  (void) a;
++  (void) a_stride;
++  (void) w;
++  (void) c;
++  (void) cm_stride;
++  (void) cn_stride;
++  (void) params;
++  (void) quantization_params;
++  assert(!"KleidiAI support is required for this microkernel");
++#endif  // XNN_ENABLE_KLEIDIAI
++}
+diff --git a/src/xnnpack/gemm.h b/src/xnnpack/gemm.h
+index 9fc4cfa5a8..1f5eddb5f4 100644
+--- a/src/xnnpack/gemm.h
++++ b/src/xnnpack/gemm.h
+@@ -4044,6 +4044,8 @@ size_t xnn_qp8_f32_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_nr();
+ 
+ size_t xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_mr(void);
+ size_t xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_nr(void);
++DECLARE_QD8_F16_QC4W_GEMM_MINMAX_UKERNEL_FUNCTION(
++    xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2)
+ 
+ size_t xnn_qp8_f32_qc4w_gemm_minmax_ukernel_1x64c4__neonsme_get_mr();
+ size_t xnn_qp8_f32_qc4w_gemm_minmax_ukernel_1x64c4__neonsme_get_nr();
+-- 
+2.43.0

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/_index.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/_index.md
@@ -1,0 +1,68 @@
+---
+title: Integrate a KleidiAI SME2 kernel into XNNPACK
+
+minutes_to_complete: 45
+
+draft: true
+cascade:
+    draft: true
+
+who_is_this_for: This is an advanced topic for software developers and performance engineers who want to integrate a KleidiAI SME2 microkernel into an existing AI inference framework.
+
+learning_objectives:
+    - Understand the XNNPACK `qd8_f16_qc4w` fully connected operator and its quantized matrix formats
+    - Select a KleidiAI microkernel by matching quantization contracts, not only data types
+    - Pack XNNPACK qd8 activations and QC4W weights into the layouts required by a KleidiAI SME2 kernel
+    - Add runtime SME2 dispatch with a safe fallback path
+    - Build and validate the integration on an Android Arm device
+
+prerequisites:
+    - Familiarity with C or C++ and basic matrix multiplication
+    - Android Debug Bridge (`adb`) and an Android Arm device with SME2 support for the validation steps
+    - Android NDK r29, or a compatible Android NDK
+
+author: Arm
+
+generate_summary_faq: true
+rerun_summary: false
+rerun_faqs: false
+
+### Tags
+skilllevels: Advanced
+subjects: ML
+armips:
+    - Armv9-A
+tools_software_languages:
+    - C++
+    - Android NDK
+    - KleidiAI
+    - SME2
+    - XNNPACK
+operatingsystems:
+    - Android
+    - Linux
+
+further_reading:
+    - resource:
+        title: KleidiAI repository
+        link: https://github.com/ARM-software/kleidiai
+        type: website
+    - resource:
+        title: XNNPACK repository
+        link: https://github.com/google/XNNPACK
+        type: website
+    - resource:
+        title: Arm SME2 introduction, part 4
+        link: https://developer.arm.com/community/arm-community-blogs/b/architectures-and-processors-blog/posts/part4-arm-sme2-introduction
+        type: blog
+    - resource:
+        title: Understand KleidiAI SME2 matmul microkernels
+        link: /learning-paths/mobile-graphics-and-gaming/kai_sme2_matmul_ukernel_explained/
+        type: learning-path
+
+### FIXED, DO NOT MODIFY
+# ==============================================================================
+weight: 1
+layout: "learningpathall"
+learning_path_main_page: "yes"
+---

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/_next-steps.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/_next-steps.md
@@ -1,0 +1,32 @@
+---
+title: Next steps
+weight: 9
+
+### FIXED, DO NOT MODIFY
+layout: learningpathall
+---
+
+## Continue learning
+
+You have integrated a KleidiAI SME2 microkernel into an XNNPACK quantized fully connected operator.
+
+Use these Learning Paths to go further:
+
+- [Understand KleidiAI SME2 matmul microkernels](/learning-paths/mobile-graphics-and-gaming/kai_sme2_matmul_ukernel_explained/) explains SME2 MOPA packing and kernel execution in more detail.
+- [KleidiAI on Android with MediaPipe and XNNPACK](/learning-paths/mobile-graphics-and-gaming/kleidiai-on-android-with-mediapipe-and-xnnpack/) shows an end-to-end Android inference workflow.
+
+## Improve the integration
+
+The correctness-first adapter packs a qd8 LHS tile immediately before the KAI call. For workloads that split a single activation matrix across many N tiles, consider a workspace-based LHS pre-pack stage:
+
+```text
+Pack LHS once per run
+  -> reuse packed LHS across all RHS N tiles
+```
+
+Keep the same rules when optimizing:
+
+- Preserve the qd8 per-row zero point and scale.
+- Pad K with the quantized zero point.
+- Query KAI tile dimensions instead of hard-coding vector-length-dependent values.
+- Keep the non-SME2 XNNPACK fallback.

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/build-and-validate.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/build-and-validate.md
@@ -1,0 +1,86 @@
+---
+title: Build and validate the integration
+weight: 8
+
+### FIXED, DO NOT MODIFY
+layout: learningpathall
+---
+
+## Check the patch series
+
+Confirm that the patches were applied to the baseline XNNPACK revision in the expected order:
+
+```bash
+git log --oneline -4
+```
+
+The commit subjects should be:
+
+```output
+Dispatch QD8 F16 QC4W through KAI SME2
+Pack QD8 LHS for KAI SME2
+Support transposed KAI QC4W weights
+Prepare QD8 F16 QC4W SME2 kernel
+```
+
+Regenerate the microkernel source lists. This command must complete without duplicate-microkernel messages:
+
+```bash
+python3 tools/update-microkernels.py
+git diff --check
+```
+
+## Build for Android
+
+This example uses Android NDK r29. Set the NDK path for your environment:
+
+```bash
+export ANDROID_NDK=/tools/android-ndk-r29
+
+scripts/build-android-arm64.sh \
+  -DXNNPACK_ENABLE_KLEIDIAI=ON \
+  -DXNNPACK_BUILD_BENCHMARKS=OFF \
+  -DXNNPACK_BUILD_TESTS=ON
+```
+
+Build the fully connected operator test:
+
+```bash
+cmake --build build/android/arm64-v8a \
+  --target fully-connected-nc-test -- -j"$(nproc)"
+```
+
+## Run the correctness tests on an SME2 device
+
+Copy the test binary to an Android device that reports SME2 support:
+
+```bash
+adb push build/android/arm64-v8a/test/operators/fully-connected-nc-test \
+  /data/local/tmp/xnnpack-fc-test
+
+adb shell "chmod 755 /data/local/tmp/xnnpack-fc-test"
+
+adb shell "/data/local/tmp/xnnpack-fc-test \
+  --gtest_filter='FULLY_CONNECTED_NC_QD8_F16_QC4W.*'"
+```
+
+Expected result:
+
+```output
+[==========] Running 15 tests from 1 test suite.
+[  PASSED  ] 15 tests.
+```
+
+The suite covers normal and small batches, min/max clamp ranges, input and output stride, optional bias, transposed weights, and weights-cache reuse.
+
+## Check the fallback build
+
+The KAI path must not break builds where KleidiAI is disabled. On a development host, run:
+
+```bash
+bazel build //:packing --define=xnn_enable_kleidiai=false
+```
+
+This validates that the `XNN_ENABLE_KLEIDIAI` guards preserve the non-KleidiAI configuration.
+
+

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/hook-micro-kernel.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/hook-micro-kernel.md
@@ -1,0 +1,131 @@
+---
+title: Configure and dispatch the SME2 kernel
+weight: 7
+
+### FIXED, DO NOT MODIFY
+layout: learningpathall
+---
+
+## Select the KAI SME2 backend
+
+Keep the existing XNNPACK microkernels as the fallback. Select the KAI path only when XNNPACK detects SME2:
+
+```c
+if (hardware_config->arch_flags & xnn_arch_arm_sme2) {
+  // Configure KAI RHS packing, LHS packing, and the DQGEMM adapter.
+} else {
+  // Continue with the existing native XNNPACK configuration.
+}
+```
+
+The selected backend has two different packing lifetimes:
+
+```text
+RHS: pack static weights once during operator creation
+LHS: pack dynamic qd8 activation tiles at runtime
+```
+
+Both sides must use the layouts expected by the same KAI SME2 matmul microkernel.
+
+## Configure the KAI RHS packer
+
+XNNPACK already has an adapter around the KAI `qsi4cxp` RHS packer:
+
+```c
+xnn_pack_kai_qs4_weights_and_biases_sme
+xnn_packed_stride_kai_qs4_weights_and_biases_sme
+```
+
+When SME2 is selected, set these functions in the GEMM configuration:
+
+```c
+qd8_f16_qc4w_gemm_config.pack_weights_and_biases =
+    xnn_pack_kai_qs4_weights_and_biases_sme;
+qd8_f16_qc4w_gemm_config.packed_stride_weights_and_biases =
+    xnn_packed_stride_kai_qs4_weights_and_biases_sme;
+```
+
+XNNPACK uses this configuration during operator creation. It passes the original QC4W weights, scales, and bias to the KAI RHS packer. The resulting packed RHS, including `weight_sum[n]`, is stored in operator memory or the XNNPACK weights cache.
+
+
+## Configure the KAI LHS packer
+
+There is no persistent LHS buffer at operator creation because qd8 activations and their quantization parameters change for every invocation.
+
+Instead, the XNNPACK DQGEMM adapter packs each activation tile immediately before calling KAI:
+
+```text
+raw qd8 int8 values + qd8 parameters
+  -> KAI qai8dxp packed LHS
+  -> KAI SME2 MOPA matmul
+```
+
+The adapter uses the private `pack_lhs` helper in the SME2 wrapper file. It performs the following mapping for each activation row:
+
+```text
+KAI int8 values       = XNNPACK qd8 values
+KAI negative zero pt  = -XNNPACK zero_point
+KAI scale             = XNNPACK inv_scale
+```
+
+It also queries KAI `kr` and `sr`, checks that `sr == 1`, interleaves the values in `kr`-sized blocks, and pads the K tail with the row zero point. See [Pack the QD8 activation without requantizing](../pack-lhs/) for the packed-LHS layout.
+
+## Register the DQGEMM adapter
+
+Query the KAI tile sizes and register the adapter for both the single-row and full-MR cases:
+
+```c
+const size_t mr =
+    xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_mr();
+const size_t nr =
+    xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2_get_nr();
+
+qd8_f16_qc4w_gemm_config.minmax.dqgemm[XNN_MR_TO_INDEX(1)] =
+    XNN_INIT_HMP_DQGEMM_UKERNEL(
+        xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2);
+qd8_f16_qc4w_gemm_config.minmax.dqgemm[XNN_MR_TO_INDEX(mr)] =
+    XNN_INIT_HMP_DQGEMM_UKERNEL(
+        xnn_qd8_f16_qc4w_gemm_minmax_ukernel_16x64c4__neonsme2);
+```
+
+Set the KAI packing parameters:
+
+```text
+kr = 4
+sr = 1
+```
+
+The adapter calls:
+
+```text
+kai_run_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa
+```
+
+Pass the output row stride, an FP16 column stride of two bytes, and XNNPACK's FP16 clamp range.
+
+This step corresponds to [patch 4: Dispatch QD8 F16 QC4W through KAI SME2](../0004-dispatch-qd8-f16-qc4w-through-kai-sme2.patch).
+
+The patch also changes the generated SME2 source lists. Run the generator after adding or renaming a file that ends in `-neonsme2.c`:
+
+```bash
+python3 tools/update-microkernels.py
+```
+
+Before this dispatch is registered, the new wrapper is listed as a non-production SME2 source. After `gemm-config.c` registers the wrapper, the generator finds it in the configuration and moves it to the production SME2 source list. Do not edit the generated list files by hand.
+
+## Understand the adapter
+
+The adapter has the standard XNNPACK DQGEMM ABI. XNNPACK calls it with an int8 activation tile, a pointer to packed weights, the FP16 output tile, clamp parameters, and the qd8 parameters for the activation rows.
+
+The adapter performs three operations:
+
+```text
+raw QD8 tile + per-row parameters
+  -> pack_lhs() into KAI qai8dxp layout
+  -> kai_run_matmul_clamp_f16_qai8dxp...sme2_mopa()
+  -> FP16 output tile
+```
+
+The wrapper filename uses the XNNPACK-style label `16x64c4__neonsme2`. It is not a fixed runtime tile size. The actual M and N tile sizes are queried from KleidiAI because they depend on the SME streaming vector length.
+
+The adapter currently allocates a temporary packed-LHS buffer for each DQGEMM call. This keeps the first integration simple and correct. The next optimization is to allocate and reuse a workspace buffer so the same LHS is not repacked for every N tile.

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/introduction.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/introduction.md
@@ -1,0 +1,94 @@
+---
+title: Overview and prerequisites
+weight: 2
+
+### FIXED, DO NOT MODIFY
+layout: learningpathall
+---
+
+## What you will build
+
+In this Learning Path, you integrate a KleidiAI matrix multiplication microkernel into the existing XNNPACK `qd8_f16_qc4w` fully connected operator.
+
+The completed path uses the following KleidiAI SME2 MOPA microkernel:
+
+```text
+kai_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa
+```
+
+The name is long, but its important properties are straightforward:
+
+- `f16`: the output is FP16.
+- `qai8dxp`: the left-hand side is asymmetric int8 quantized per row.
+- `qsi4cxp`: the right-hand side is signed int4 quantized per output channel.
+- `sme2_mopa`: it uses SME2 matrix outer product accumulate instructions.
+
+This is a framework-integration example. The aim is not to write a new assembly microkernel. Instead, you learn how to select an existing kernel, adapt framework-owned tensors to its packed layouts, dispatch it safely, and verify correctness.
+
+## Start from the tested XNNPACK revision
+
+The patch series in this Learning Path was created and tested from XNNPACK commit:
+
+```text
+119bb329762be10e63688256bb989a0007445b49
+```
+
+Use this exact revision when following the steps. Other XNNPACK revisions can have different microkernel lists, packing helpers, or operator code.
+
+```bash
+git clone https://github.com/google/XNNPACK.git
+cd XNNPACK
+git checkout 119bb329762be10e63688256bb989a0007445b49
+```
+
+## Download the patch series
+
+The implementation is split into four small patches. Apply them in numeric order after checking out the baseline revision:
+
+```bash
+git am 0001-prepare-qd8-f16-qc4w-sme2-kernel.patch
+git am 0002-support-transposed-kai-qc4w-weights.patch
+git am 0003-pack-qd8-lhs-for-kai-sme2.patch
+git am 0004-dispatch-qd8-f16-qc4w-through-kai-sme2.patch
+```
+
+Download links:
+
+1. [Prepare the SME2 wrapper](../0001-prepare-qd8-f16-qc4w-sme2-kernel.patch)
+2. [Support transposed QC4W weights](../0002-support-transposed-kai-qc4w-weights.patch)
+3. [Pack the QD8 LHS](../0003-pack-qd8-lhs-for-kai-sme2.patch)
+4. [Dispatch through KAI SME2](../0004-dispatch-qd8-f16-qc4w-through-kai-sme2.patch)
+
+
+## The completed data flow
+
+XNNPACK owns the operator lifecycle. KleidiAI supplies optimized packing and matrix multiplication components.
+
+```text
+Create operator
+  Raw QC4W weights and FP32 bias
+      -> pack RHS once for KleidiAI
+      -> optionally store packed RHS in the XNNPACK weights cache
+
+Run operator
+  QD8 activation values and per-row quantization parameters
+      -> pack LHS for KleidiAI without requantizing
+      -> run the SME2 MOPA microkernel
+      -> write FP16 output
+```
+
+On a CPU without SME2 support, XNNPACK continues to use its existing native microkernels. This fallback is essential for portability and correctness.
+
+## What you will do
+
+You will complete these steps:
+
+1. Inspect the matrix and quantization formats used by `qd8_f16_qc4w`.
+2. Select a compatible KleidiAI microkernel.
+3. Pack the static QC4W right-hand side during operator creation.
+4. Pack the dynamic QD8 left-hand side at execution time without changing its quantization.
+5. Add SME2 runtime dispatch and call the KleidiAI kernel.
+6. Build for Android and validate the completed integration on an SME2 device.
+
+
+Next, examine the operator inputs before selecting a kernel.

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/operator-formats.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/operator-formats.md
@@ -1,0 +1,103 @@
+---
+title: Understand the XNNPACK operator qd8_f16_qc4w formats
+weight: 3
+
+### FIXED, DO NOT MODIFY
+layout: learningpathall
+---
+
+## Start with the math
+
+The fully connected operator computes:
+
+```text
+C[M,N] = A[M,K] x B[N,K]^T + bias[N]
+```
+
+Where:
+
+- `M` is the number of input rows/tokens.
+- `K` is the number of input feature dimension/reduction dimension.
+- `N` is the number of output feature dimension.
+- `A` is the activation matrix.
+- `B` is the weight matrix.
+- `C` is the FP16 output matrix.
+
+Although the logical RHS matrix is written as `B[N,K]`, the multiplication uses its transpose. Each output has one row of weights with `K` values.
+
+## Left-hand side: QD8 activation data
+
+XNNPACK stores the activation matrix as signed 8-bit values. Each row has separate dynamic quantization parameters:
+
+```c
+struct xnn_qd8_quantization_params {
+  int32_t zero_point;
+  float inv_scale;
+};
+```
+
+The real value represented by one element is:
+
+```text
+A_real[m,k] = (A_q[m,k] - zero_point[m]) * inv_scale[m]
+```
+
+This is **asymmetric, per-row quantization**:
+
+- The int8 values are stored row-major with the input stride.
+- Each row can have a different zero point.
+- Each row can have a different scale.
+
+The important point is that this qd8 representation already contains the quantized activation values. A framework integration should preserve these values whenever possible.
+
+## Right-hand side: QC4W weights
+
+The XNNPACK QC4W input consists of:
+
+- Packed 4-bit weights.
+- One FP32 scale for each output channel.
+- A kernel zero point of `0` or `8`.
+- Optional FP32 bias values.
+
+Two 4-bit weights occupy one byte:
+
+```text
+bits [3:0] = K element 0
+bits [7:4] = K element 1
+```
+
+For the normal weight layout, the raw tensor is `N x K`: each output channel has a contiguous packed row.
+
+XNNPACK also supports `XNN_FLAG_TRANSPOSE_WEIGHTS`. In that case, the source tensor is `K x N`, so the integration must convert it to the `N x K` form expected by the selected KleidiAI RHS packer.
+
+## Padding K safely
+
+The selected KleidiAI SME2 microkernel rounds its internal K dimension up to a multiple of 32. The original model does not need to have a K dimension that is divisible by 32.
+
+The integration creates a padded representation:
+
+```text
+K_padded = round_up(K, 32)
+```
+
+Padding must represent real value zero:
+
+- For the QD8 LHS, pad each row with its own `zero_point`.
+- For signed int4 weights, pad with zero.
+- For unsigned int4 weights with zero point 8, the RHS packer converts padding to signed zero.
+
+Padding with any other value changes the dot product and produces incorrect output.
+
+## Where this data enters XNNPACK
+
+The public operator entry points are:
+
+```c
+xnn_create_fully_connected_nc_qd8_f16_qc4w(...)
+xnn_reshape_fully_connected_nc_qd8_f16_qc4w(...)
+xnn_setup_fully_connected_nc_qd8_f16_qc4w(...)
+```
+
+The create step receives the static weights, scales, and bias, and packs the persistent RHS representation. The reshape step receives the runtime batch size and plans the GEMM tiles, parallel work, and any required workspace. The setup step receives the qd8 activation values, the FP16 output buffer, and the per-row `xnn_qd8_quantization_params` array.
+
+Next, use these facts to choose a compatible KleidiAI microkernel.

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/pack-lhs.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/pack-lhs.md
@@ -1,0 +1,151 @@
+---
+title: Pack the QD8 activation without requantizing
+weight: 6
+
+### FIXED, DO NOT MODIFY
+layout: learningpathall
+---
+
+## Preserve the QD8 quantization
+
+The selected KAI LHS format is `qai8dxp`: asymmetric int8 with dynamic per-row parameters. This matches the XNNPACK qd8 input.
+
+This step corresponds to [patch 3: Pack QD8 LHS for KAI SME2](../0003-pack-qd8-lhs-for-kai-sme2.patch).
+
+## Convert the XNNPACK LHS to the KAI LHS
+
+Before packing, XNNPACK provides two related inputs:
+
+```text
+input[M, K]                    signed int8 activation values
+quantization_params[M]         one { zero_point, inv_scale } pair per row
+```
+
+`input` is row-major. Row `m` starts at `input + m * input_stride`. Its quantization parameters are stored separately at `quantization_params[m]`.
+
+The KAI SME2 microkernel cannot consume these two arrays directly. It expects one packed `qai8dxp` LHS buffer. For each group of `mr` rows, that buffer contains:
+
+```text
+| KAI-interleaved int8 values for mr rows |
+| int32 negative zero point for each row  |
+| float scale for each row                |
+```
+
+The conversion changes the memory layout, but not the quantization meaning:
+
+```text
+XNNPACK input[M, K] + quantization_params[M]
+  -> KAI qai8dxp packed LHS
+```
+
+The int8 values are copied and interleaved for the KAI inner loop. The separate XNNPACK metadata is appended after the values as KAI metadata. The following sections show the exact mapping.
+
+For each XNNPACK row:
+
+```text
+real_value = (q - zero_point) * inv_scale
+```
+
+The KAI packed row stores:
+
+```text
+interleaved int8 values
+int32 negative_zero_point
+float scale
+```
+
+The correct mapping is therefore:
+
+```text
+KAI int8 values       = XNNPACK qd8 values
+KAI negative zero pt  = -XNNPACK zero_point
+KAI scale             = XNNPACK inv_scale
+```
+
+No floating-point dequantization is required. No new int8 quantization is required.
+
+## Interleave values for the microkernel
+
+The selected KAI microkernel uses:
+
+```text
+kr = 4
+sr = 1
+```
+
+For a packed group of `mr` rows, values are interleaved in groups of four K values:
+
+```text
+K[0..3] for row 0
+K[0..3] for row 1
+...
+K[0..3] for row mr-1
+K[4..7] for row 0
+...
+```
+
+The `mr` value is vector-length dependent, so obtain it from the KAI kernel query function. For a tail M tile, duplicate the last valid row in the packed buffer. The microkernel writes only the requested M rows.
+
+## Pad K with the quantized zero
+
+KAI rounds K up to a multiple of 32. For a qd8 row, the quantized representation of real zero is its row's zero point:
+
+```text
+q_zero = zero_point
+```
+
+Use it for padding:
+
+```c
+packed_value = k_index < k ? input[k_index] : quantization.zero_point;
+```
+
+This guarantees that padded elements contribute zero to the dot product:
+
+```text
+(q_zero - zero_point) * inv_scale = 0
+```
+
+
+## How the packing loop works
+
+The packing helper processes the activation matrix in groups of `mr` rows. Each group has three adjacent regions in the destination buffer:
+
+```text
+| interleaved int8 values | int32 negative zero points | float scales |
+```
+
+For every group, the helper performs the following work:
+
+1. Select up to `mr` source rows starting at `m_start`.
+2. If the final group has fewer than `mr` rows, reuse the last valid source row for the unused packed slots.
+3. Copy values in K blocks of `kr`, interleaving the same K block from every row.
+4. Pad any K values beyond the original K dimension with that row's quantized zero.
+5. Store `-zero_point` and `inv_scale` for every packed row.
+
+The implementation obtains `kr` from the selected KAI microkernel instead of relying on a hard-coded value. The current SME2 kernel reports `kr = 4`, but querying it keeps the pack layout coupled to the actual kernel contract:
+
+```c
+const size_t kr = kai_get_kr_matmul_clamp_f16_qai8dxp...();
+const size_t sr = kai_get_sr_matmul_clamp_f16_qai8dxp...();
+assert(sr == 1);
+```
+
+For example, if `mr = 4`, the values are stored in this order:
+
+```text
+K[0..kr-1] for row 0, row 1, row 2, row 3
+K[kr..2*kr-1] for row 0, row 1, row 2, row 3
+...
+```
+
+For an M tail, suppose the final group contains only two valid rows. The packer uses the following source rows:
+
+```text
+packed slots:  0  1  2  3
+source rows:   8  9  9  9
+```
+
+The matmul call still receives `m = 2`, so it writes results only for rows 8 and 9. Duplicating row 9 only gives the kernel safe data for the complete packed group.
+
+Next, wire the adapter into XNNPACK runtime dispatch.

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/pack-rhs.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/pack-rhs.md
@@ -1,0 +1,251 @@
+---
+title: Pack QC4W weights for the KAI SME2 kernel
+weight: 5
+
+### FIXED, DO NOT MODIFY
+layout: learningpathall
+---
+
+## Why pack the RHS once
+
+The right-hand side (RHS) is the fully connected weight matrix. Its int4 values, per-channel scales, and bias values are static after the operator is created. Pack this data once during `xnn_create_fully_connected_nc_qd8_f16_qc4w`, rather than during every inference run.
+
+```text
+Original QC4W model weights
+  -> XNNPACK create
+  -> KAI packed RHS
+  -> XNNPACK operator memory or weights cache
+  -> repeated inference runs
+```
+
+This is different from the qd8 left-hand side (LHS), which changes for every inference run and must be packed at runtime.
+
+This step corresponds to [patch 2: Support transposed KAI QC4W weights](../0002-support-transposed-kai-qc4w-weights.patch).
+
+## Raw XNNPACK QC4W source layout
+
+The logical RHS matrix is:
+
+```text
+B[N, K]
+```
+
+Each row represents one output channel. The source data contains:
+
+```text
+packed int4 weights[N, K]
+float kernel_scale[N]
+float bias[N]
+uint8 kernel_zero_point
+```
+
+Two consecutive K values occupy one byte:
+
+```text
+bits [3:0] = weight[n][k]
+bits [7:4] = weight[n][k + 1]
+```
+
+For example, eight int4 values for one output channel are stored as four bytes:
+
+```text
+logical values:
+K0 K1 K2 K3 K4 K5 K6 K7
+
+packed bytes:
+[K1|K0] [K3|K2] [K5|K4] [K7|K6]
+```
+
+The scale and bias are separate arrays. They are not embedded in the raw packed-int4 bytes.
+
+## Signedness and kernel zero point
+
+XNNPACK accepts two QC4W encodings:
+
+```text
+kernel_zero_point = 0
+  each nibble is a signed int4 value in [-8, 7]
+
+kernel_zero_point = 8
+  each nibble is an unsigned value in [0, 15]
+  its signed weight value is nibble - 8
+```
+
+The selected KAI microkernel uses signed int4 weight semantics. The KAI RHS packer handles the required zero-point conversion and also pads the K dimension with signed zero.
+
+## Why raw QC4W cannot feed the KAI kernel directly
+
+Raw XNNPACK QC4W data is organized as one K-contiguous row per output channel, with scales and bias stored separately. This is convenient for a model format, but it is not the layout consumed by the SME2 MOPA inner loop.
+
+The KAI microkernel computes several output channels together. It needs K blocks from an N tile arranged for sequential vector and matrix loads, followed by metadata at KAI-defined offsets.
+
+```text
+Raw XNNPACK QC4W
+  channel-major int4 rows
+  separate scale and bias arrays
+
+KAI packed qsi4cxp RHS
+  K blocks interleaved for an N tile
+  weight sums, scales, and bias embedded with the tile
+```
+
+The formats represent the same mathematical weights, but their byte layouts are different.
+
+## KAI qsi4cxp packed RHS layout
+
+Use the KAI packer:
+
+```text
+kai_run_rhs_pack_nxk_qsi4cxps1s0_qsu4cxs1s0_neon
+```
+
+It produces the `qsi4cxp` packed RHS format used by:
+
+```text
+kai_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa
+```
+
+The packer receives the logical `N x K` source, bias, scale, `nr`, `kr`, and `sr`. For the selected SME2 microkernel:
+
+```text
+kr = 4
+sr = 1
+K_padded = round_up(K, 32)
+nr = queried from the KAI microkernel at runtime
+```
+
+Conceptually, one packed N tile contains:
+
+```text
+| packed int4 data for K block 0 across nr channels |
+| packed int4 data for K block 1 across nr channels |
+| ...                                                |
+| int32 weight sums[nr]                              |
+| float scales[nr]                                   |
+| float bias[nr]                                     |
+```
+
+The exact byte interleave is owned by the KAI packer. Framework code should call the packer rather than reproduce this microkernel-specific layout by hand.
+
+The weight sums are used to compensate for the asymmetric qd8 LHS zero point during matrix multiplication.
+
+## Why the packed RHS stores weight sums
+
+The qd8 activation is asymmetric. For one activation row, its real values are:
+
+```text
+a_real[k] = (a_q[k] - a_zero_point) * a_scale
+```
+
+For one output channel, let `w_q[n,k]` be the signed int4 weight values. Ignoring the final scale and bias for a moment, the integer part of the dot product is:
+
+```text
+sum_k ((a_q[k] - a_zero_point) * w_q[n,k])
+```
+
+Expanding this expression gives:
+
+```text
+sum_k (a_q[k] * w_q[n,k])
+  - a_zero_point * sum_k(w_q[n,k])
+```
+
+The first term is the normal integer dot product. The second term is the asymmetric activation correction. The RHS packer calculates and stores this per-output-channel value:
+
+```text
+weight_sum[n] = sum_k(w_q[n,k])
+```
+
+At runtime, the KAI packed LHS stores:
+
+```text
+negative_zero_point = -a_zero_point
+```
+
+The KAI microkernel can then compute:
+
+```text
+dot(a_q, w_q) + negative_zero_point * weight_sum[n]
+```
+
+This is equivalent to subtracting `a_zero_point * weight_sum[n]`, which restores the original asymmetric qd8 equation.
+
+`weight_sum[n]` depends only on static weights and K padding, so the RHS packer calculates it once. The dynamic qd8 zero point can change for every activation row and inference run, but it is supplied through the packed LHS metadata. It does not require the RHS to be packed again.
+
+## Worked packing example
+
+Assume one N tile contains four output channels, `K = 8`, and `kr = 4`.
+
+The raw `N x K` source is conceptually:
+
+```text
+channel 0: K0 K1 K2 K3 | K4 K5 K6 K7
+channel 1: K0 K1 K2 K3 | K4 K5 K6 K7
+channel 2: K0 K1 K2 K3 | K4 K5 K6 K7
+channel 3: K0 K1 K2 K3 | K4 K5 K6 K7
+```
+
+The KAI packed tile is conceptually ordered as:
+
+```text
+K0..K3 for channels 0..3
+K4..K7 for channels 0..3
+weight_sum[0..3]
+scale[0..3]
+bias[0..3]
+```
+
+This diagram explains the data grouping, not every byte position. The KAI packer defines the exact byte layout required by the SME2 microkernel.
+
+## Handle XNN_FLAG_TRANSPOSE_WEIGHTS
+
+Normally, XNNPACK receives packed nibbles in `N x K` order. With `XNN_FLAG_TRANSPOSE_WEIGHTS`, the source is instead `K x N`.
+
+The KAI RHS packer accepts only `N x K`, so the XNNPACK adapter first creates a temporary `N x K` packed-nibble buffer:
+
+```text
+XNNPACK source:   K x N packed int4
+temporary source:  N x K packed int4
+KAI RHS packer:   N x K -> qsi4cxp packed RHS
+```
+
+The conversion must move individual nibbles, rather than whole bytes, because the source and destination pack along different matrix dimensions:
+
+```cpp
+const uint8_t source = rhs[k * source_stride + n / 2];
+const uint8_t value = (source >> ((n & 1) * 4)) & 0x0F;
+transposed_rhs[n * destination_stride + k / 2] |= value << ((k & 1) * 4);
+```
+
+`n / 2` and `k / 2` select the packed byte. The low or high nibble is selected with `& 1`. The temporary buffer starts as zeroed bytes, so the `|=` operation safely writes one nibble at a time.
+
+Use the original model QC4W tensor as the input to the packer selected for the active backend:
+
+```text
+Original QC4W model weights
+  -> XNNPACK native packer -> XNNPACK native microkernel
+
+Original QC4W model weights
+  -> KAI RHS packer -> KleidiAI SME2 microkernel
+```
+
+The following path is incorrect:
+
+```text
+Original QC4W model weights
+  -> XNNPACK native packer
+  -> KleidiAI SME2 microkernel
+```
+
+The KAI microkernel would interpret the XNNPACK-native packed bytes using the wrong interleave and metadata offsets. Keep each packed representation private to the microkernel family that created it.
+
+## Summary
+
+When packing the RHS:
+
+1. Start from the original QC4W model weights, scales, and bias.
+2. Convert a transposed `K x N` source to `N x K` when required.
+3. Let the KAI packer create the `qsi4cxp` layout.
+4. Pack once during operator creation and reuse the result through the weights cache.
+
+Next, adapt the dynamic qd8 LHS without requantizing it.

--- a/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/select-kernel.md
+++ b/content/learning-paths/mobile-graphics-and-gaming/integrate-kleidiai-kernel-xnnpack-qd8-f16-qc4w/select-kernel.md
@@ -1,0 +1,81 @@
+---
+title: Select a compatible KleidiAI microkernel
+weight: 4
+
+### FIXED, DO NOT MODIFY
+layout: learningpathall
+---
+
+## Match quantization contracts first
+
+Do not select a microkernel only because it produces FP16 output and uses int8 and int4 inputs. Its quantization contract must also match the framework operator.
+
+An initially tempting KleidiAI kernel is:
+
+```text
+matmul_clamp_f16_qsi8d32p_qai4c32p
+```
+
+It is not a correct match for XNNPACK `qd8_f16_qc4w`:
+
+- `qsi8d32p` requires symmetric int8 quantization for each block of 32 K values.
+- XNNPACK QD8 uses asymmetric int8 quantization for each row.
+
+Using that kernel requires dequantizing and then requantizing the LHS per 32-value block. This adds quantization error and can violate the numerical contract of the existing XNNPACK operator.
+
+## Select `qai8dxp/qsi4cxp`
+
+Use this KleidiAI SME2 MOPA microkernel instead:
+
+```text
+kai_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa
+```
+
+Its formats match the operator:
+
+| Operand | XNNPACK format | KAI format | Result |
+|---|---|---|---|
+| LHS | QD8, asymmetric per row | `qai8dxp`, asymmetric per row | Direct metadata adaptation |
+| RHS | QC4W, int4 per output channel | `qsi4cxp`, signed int4 per channel | Pack once during create |
+| Output | FP16 with min/max clamp | FP16 with min/max clamp | Direct match |
+
+`qai8dxp` means quantized asymmetric int8 with dynamic, per-row parameters. It is the key reason this kernel is suitable: the original qd8 activation values do not need to be requantized.
+
+## Why SME2 MOPA
+
+The `sme2_mopa` suffix means the microkernel uses SME2 matrix outer product accumulate instructions. SME2 provides a matrix accumulator, called ZA, that is designed for matrix workloads.
+
+The kernel tile dimensions are expressed in vector lengths:
+
+```text
+1VL x 4VL
+```
+
+The actual `mr` and `nr` values depend on the device's streaming vector length. Do not hard-code them. Query the kernel:
+
+```c
+size_t mr = kai_get_mr_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa();
+size_t nr = kai_get_nr_matmul_clamp_f16_qai8dxp1vlx8_qsi4cxp4vlx8_1vlx4vl_sme2_mopa();
+```
+
+The same kernel reports `kr = 4` and `sr = 1`. These values define the K interleave used by the packed LHS and RHS buffers.
+
+## Prepare the XNNPACK SME2 wrapper
+
+The first implementation step is [patch 1: Prepare QD8 F16 QC4W SME2 kernel](../0001-prepare-qd8-f16-qc4w-sme2-kernel.patch).
+
+It adds an XNNPACK wrapper at:
+
+```text
+src/qd8-f16-qc4w-gemm/
+  qd8-f16-qc4w-gemm-minmax-16x64c4-neonsme2.c
+```
+
+The `16x64c4` part follows the existing XNNPACK SME2 wrapper naming convention. It is a name used by XNNPACK tooling, not a claim that the KAI kernel always uses a fixed 16 by 64 tile. The actual tile dimensions come from the KAI `get_mr` and `get_nr` functions at runtime.
+
+
+{{% notice Tip %}}
+The most reusable lesson is simple: select a kernel from its complete operand contract. Compare quantization granularity, signedness, zero-point behavior, output type, clamp behavior, and packing requirements before implementing any adapter.
+{{% /notice %}}
+
+Next, pack the static RHS weights.


### PR DESCRIPTION
## Summary

This PR adds an advanced Learning Path that demonstrates how to integrate a KleidiAI SME2 matrix multiplication microkernel into XNNPACK's `qd8_f16_qc4w` fully connected operator.

## What is included

- An overview of the XNNPACK operator lifecycle and its QD8, QC4W, and FP16 data formats
- Guidance for selecting a KleidiAI microkernel based on its complete quantization contract
- Instructions for packing static QC4W weights into the KleidiAI RHS layout
- Instructions for packing dynamic QD8 activations without requantization
- SME2 runtime dispatch with the existing XNNPACK microkernels retained as a fallback
- Support for normal and transposed QC4W weight layouts
- Android NDK build and on-device correctness validation steps
- A four-part patch series that readers can apply to the documented XNNPACK baseline revision

## Key learning outcomes

After completing this Learning Path, readers will understand how to:

- Match framework tensor formats to a compatible KleidiAI microkernel
- Preserve per-row QD8 quantization parameters
- Handle K-dimension padding correctly
- Integrate KleidiAI packing and execution into XNNPACK
- Select the SME2 path at runtime without breaking non-SME2 configurations
- Build and test the integration on an SME2-capable Android device

## Validation

The Learning Path documents validation using:

- XNNPACK's `FULLY_CONNECTED_NC_QD8_F16_QC4W` correctness tests on an SME2-capable Android device
- A fallback build with KleidiAI disabled

## Submission checklist

Before submitting a pull request for a new Learning Path, please review [Create a Learning Path](https://learn.arm.com/learning-paths/cross-platform/_example-learning-path/).

- [ x] I have reviewed Create a Learning Path

Please do not include any confidential information in your contribution. This includes confidential microarchitecture details and unannounced product information.

- [ x] I have checked my contribution for confidential information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).